### PR TITLE
log to stderr when using stdio.

### DIFF
--- a/cmd/mcp-digitalocean/main.go
+++ b/cmd/mcp-digitalocean/main.go
@@ -38,7 +38,7 @@ func main() {
 		level = slog.LevelInfo
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 	token := *tokenFlag
 	if token == "" {
 		token = os.Getenv("DIGITALOCEAN_API_TOKEN")


### PR DESCRIPTION
# Description

Log messages to stdout are interpreted as valid JSONRPC messages. This creates a bunch of JSON parse errors when logging out debug messages. Instead, we must log to stderr.