### PR TITLE
APPS: add app health to get-deployment-status. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module mcp-digitalocean
 go 1.24.1
 
 require (
-	github.com/digitalocean/godo v1.155.0
+	github.com/digitalocean/godo v1.156.0
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.155.0 h1:+Y09Nz1TTXFSq5fdgSpqvCKfEpN35FU9WIOMuEuCwgg=
 github.com/digitalocean/godo v1.155.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
+github.com/digitalocean/godo v1.156.0 h1:nGod3u9cicC8wcc79e3HiTEix7KHqKjzgqE9cWQTPwk=
+github.com/digitalocean/godo v1.156.0/go.mod h1:tYeiWY5ZXVpU48YaFv0M5irUFHXGorZpDNm7zzdWMzM=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -99,6 +99,12 @@ func (a *AppPlatformTool) DeleteApp(ctx context.Context, req mcp.CallToolRequest
 	return mcp.NewToolResultText("App deleted successfully"), nil
 }
 
+// DeploymentStatus represents the status of a deployment, including health and deployment details.
+type DeploymentStatus struct {
+	Health     *godo.AppHealth  `json:"health"`
+	Deployment *godo.Deployment `json:"deployment"`
+}
+
 // GetDeploymentStatus retrieves the deployment status of an app by its ID.
 func (a *AppPlatformTool) GetDeploymentStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, ok := req.GetArguments()["AppID"].(string)
@@ -117,19 +123,25 @@ func (a *AppPlatformTool) GetDeploymentStatus(ctx context.Context, req mcp.CallT
 		return mcp.NewToolResultText(fmt.Sprintf("there are no deployments found for AppID %s", appID)), nil
 	}
 
+	// Get the health status of the deployment
+	health, _, err := a.client.Apps.GetAppHealth(ctx, appID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get health status for app %s: %w", appID, err)
+	}
+
+	// Combine these two into a single response.
+	deploymentStatus := DeploymentStatus{
+		Health:     health,
+		Deployment: deployments[0],
+	}
+
 	// Convert the deployment information to JSON format
-	activeDeploymentJSON, err := json.MarshalIndent(deployments[0], "", "  ")
+	activeDeploymentJSON, err := json.MarshalIndent(deploymentStatus, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal deployment for app %s: %w", appID, err)
 	}
 
 	return mcp.NewToolResultText(string(activeDeploymentJSON)), nil
-}
-
-// GetAppUsage retrieves the usage information for an app by its ID.
-// We're going to need to expose this through the godo api
-func (a *AppPlatformTool) GetAppUsage(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return nil, nil // Not implemented yet
 }
 
 // GetAppInfo retrieves an app by its ID
@@ -217,7 +229,7 @@ func (a *AppPlatformTool) Tools() []server.ServerTool {
 		{
 			Handler: a.GetDeploymentStatus,
 			Tool: mcp.NewTool("digitalocean-apps-get-deployment-status",
-				mcp.WithDescription("Retrieves the active deployment for an application on DigitalOcean App Platform. This is useful for getting the current state of an app's latest deployment."),
+				mcp.WithDescription("Retrieves the active deployment for an application on DigitalOcean App Platform. This is useful for getting the current state of an app's latest deployment and it's health status."),
 				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app to retrieve active deployment for"))),
 		},
 		{
@@ -240,13 +252,6 @@ func (a *AppPlatformTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool("digitalocean-apps-get-info",
 				mcp.WithDescription("Get information about an application on DigitalOcean App Platform"),
 				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app to retrieve information for")),
-			),
-		},
-		{
-			Handler: a.GetAppUsage,
-			Tool: mcp.NewTool("digitalocean-apps-usage",
-				mcp.WithDescription("Get usage information for an application on DigitalOcean App Platform"),
-				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app to retrieve usage information for")),
 			),
 		},
 	}

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -374,6 +374,19 @@ func TestGetDeploymentStatus(t *testing.T) {
 			mock: func(app *MockAppsService, deployments []*godo.Deployment) {
 				app.EXPECT().ListDeployments(gomock.Any(), testAppId, gomock.Any()).
 					Return(deployments, nil, nil).Times(1)
+				app.EXPECT().GetAppHealth(gomock.Any(), testAppId).
+					Return(&godo.AppHealth{
+						Components: []*godo.ComponentHealth{
+							{
+								Name:               "web",
+								CPUUsagePercent:    90,
+								MemoryUsagePercent: 50,
+								ReplicasDesired:    1,
+								ReplicasReady:      1,
+								State:              "HEALTHY",
+							},
+						},
+					}, nil, nil).Times(1)
 			},
 			toolRequest: mcp.CallToolRequest{
 				Params: mcp.CallToolParams{Arguments: map[string]any{"AppID": testAppId}},
@@ -382,8 +395,22 @@ func TestGetDeploymentStatus(t *testing.T) {
 				Content: []mcp.Content{
 					mcp.TextContent{
 						Type: "text",
-						Text: toJSONString(&godo.Deployment{
-							ID: "deployment-1", Cause: "manual", Phase: godo.DeploymentPhase_Deploying,
+						Text: toJSONString(&DeploymentStatus{
+							Health: &godo.AppHealth{
+								Components: []*godo.ComponentHealth{
+									{
+										Name:               "web",
+										CPUUsagePercent:    90,
+										MemoryUsagePercent: 50,
+										ReplicasDesired:    1,
+										ReplicasReady:      1,
+										State:              "HEALTHY",
+									},
+								},
+							},
+							Deployment: &godo.Deployment{
+								ID: "deployment-1", Cause: "manual", Phase: godo.DeploymentPhase_Deploying,
+							},
 						}),
 					},
 				},

--- a/internal/apps/mocks.go
+++ b/internal/apps/mocks.go
@@ -141,6 +141,22 @@ func (mr *MockAppsServiceMockRecorder) GetAppDatabaseConnectionDetails(ctx, appI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppDatabaseConnectionDetails", reflect.TypeOf((*MockAppsService)(nil).GetAppDatabaseConnectionDetails), ctx, appID)
 }
 
+// GetAppHealth mocks base method.
+func (m *MockAppsService) GetAppHealth(ctx context.Context, appID string) (*godo.AppHealth, *godo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAppHealth", ctx, appID)
+	ret0, _ := ret[0].(*godo.AppHealth)
+	ret1, _ := ret[1].(*godo.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAppHealth indicates an expected call of GetAppHealth.
+func (mr *MockAppsServiceMockRecorder) GetAppHealth(ctx, appID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppHealth", reflect.TypeOf((*MockAppsService)(nil).GetAppHealth), ctx, appID)
+}
+
 // GetAppInstances mocks base method.
 func (m *MockAppsService) GetAppInstances(ctx context.Context, appID string, opts *godo.GetAppInstancesOpts) ([]*godo.AppInstance, *godo.Response, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Combines both apphealth and deployment into a single tool call. 