### PR TITLE
tools: refactor to report error from handler to llm

### DIFF
--- a/internal/account/keys_tools.go
+++ b/internal/account/keys_tools.go
@@ -31,12 +31,12 @@ func (k *KeysTool) createKey(ctx context.Context, req mcp.CallToolRequest) (*mcp
 		PublicKey: publicKey,
 	})
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonKey, err := json.MarshalIndent(key, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonKey)), nil
@@ -47,7 +47,7 @@ func (k *KeysTool) deleteKey(ctx context.Context, req mcp.CallToolRequest) (*mcp
 
 	_, err := k.client.Keys.DeleteByID(ctx, keyID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("SSH key deleted successfully"), nil

--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -26,38 +26,36 @@ func NewAppPlatformTool(client *godo.Client) (*AppPlatformTool, error) {
 	return &AppPlatformTool{client: client}, nil
 }
 
-func (a *AppPlatformTool) CreateAppFromAppSpec(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (a *AppPlatformTool) createAppFromAppSpec(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	jsonBytes, err := json.Marshal(req.GetArguments())
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	var create godo.AppCreateRequest
 	if err := json.Unmarshal(jsonBytes, &create); err != nil {
-		return nil, fmt.Errorf("failed to parse app spec: %w", err)
+		return mcp.NewToolResultErrorFromErr("parse app spec", err), nil
 	}
 
 	if create.Spec == nil {
 		return mcp.NewToolResultError("App spec is required"), nil
 	}
 
-	// Create the app using the DigitalOcean API
 	app, _, err := a.client.Apps.Create(ctx, &create)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create app: %w", err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
-	// now marshall the app spec to JSON
 	appJSON, err := json.MarshalIndent(app, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal app spec: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(appJSON)), nil
 }
 
-// ListApps lists all apps on the DigitalOcean App Platform
-func (a *AppPlatformTool) ListApps(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// listApps lists all apps on the DigitalOcean App Platform
+func (a *AppPlatformTool) listApps(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	page, ok := req.GetArguments()["Page"].(int)
 	if !ok {
 		page = defaultPage
@@ -70,57 +68,51 @@ func (a *AppPlatformTool) ListApps(ctx context.Context, req mcp.CallToolRequest)
 
 	apps, _, err := a.client.Apps.List(ctx, &godo.ListOptions{Page: page, PerPage: perPage})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list apps: %w", err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
-	// Convert the app information to JSON format
 	appsJSON, err := json.MarshalIndent(apps, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal apps: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(appsJSON)), nil
 }
 
-// DeleteApp deletes an existing app by its ID
-func (a *AppPlatformTool) DeleteApp(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Extract the app ID from the request
+// deleteApp deletes an existing app by its ID
+func (a *AppPlatformTool) deleteApp(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, ok := req.GetArguments()["AppID"].(string)
 	if !ok {
 		return mcp.NewToolResultError("App ID is required"), nil
 	}
 
-	// Delete the app using the DigitalOcean API
 	_, err := a.client.Apps.Delete(ctx, appID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete app %s: %w", appID, err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("App deleted successfully"), nil
 }
 
-// GetDeploymentStatus retrieves the deployment status of an app by its ID.
-func (a *AppPlatformTool) GetDeploymentStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// getDeploymentStatus retrieves the deployment status of an app by its ID.
+func (a *AppPlatformTool) getDeploymentStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, ok := req.GetArguments()["AppID"].(string)
 	if !ok {
 		return mcp.NewToolResultError("App ID is required"), nil
 	}
 
-	// list deployment for app
 	deployments, _, err := a.client.Apps.ListDeployments(ctx, appID, &godo.ListOptions{Page: 1, PerPage: defaultPageSize})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list deployments for app %s: %w", appID, err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
-	// we only want the last active deployment
 	if len(deployments) == 0 {
 		return mcp.NewToolResultText(fmt.Sprintf("there are no deployments found for AppID %s", appID)), nil
 	}
 
-	// Convert the deployment information to JSON format
 	activeDeploymentJSON, err := json.MarshalIndent(deployments[0], "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal deployment for app %s: %w", appID, err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(activeDeploymentJSON)), nil
@@ -132,24 +124,21 @@ func (a *AppPlatformTool) GetAppUsage(ctx context.Context, req mcp.CallToolReque
 	return nil, nil // Not implemented yet
 }
 
-// GetAppInfo retrieves an app by its ID
-func (a *AppPlatformTool) GetAppInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// Extract the app ID from the request
+// getAppInfo retrieves an app by its ID
+func (a *AppPlatformTool) getAppInfo(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, ok := req.GetArguments()["AppID"].(string)
 	if !ok {
 		return mcp.NewToolResultError("App ID is required"), nil
 	}
 
-	// Get the app using the DigitalOcean API
 	app, _, err := a.client.Apps.Get(ctx, appID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get app %s: %w", appID, err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
-	// Convert the app information to JSON format
 	appJSON, err := json.MarshalIndent(app.Spec, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal app spec: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(appJSON)), nil
@@ -167,46 +156,42 @@ type AppUpdateRequest struct {
 	AppID string `json:"app_id"`
 }
 
-// UpdateApp updates an existing app by its ID. If the spec is not provided, this simply forces a re-deploy of the app.
-func (a *AppPlatformTool) UpdateApp(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// updateApp updates an existing app by its ID. If the spec is not provided, this simply forces a re-deploy of the app.
+func (a *AppPlatformTool) updateApp(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	jsonBytes, err := json.Marshal(req.GetArguments())
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	var update AppUpdate
 	if err := json.Unmarshal(jsonBytes, &update); err != nil {
-		return nil, fmt.Errorf("failed to parse app spec: %w", err)
+		return mcp.NewToolResultErrorFromErr("parse app spec", err), nil
 	}
 
-	// force a build if the request spec is nil
 	if update.Update.Request == nil {
 		deployment, _, err := a.client.Apps.CreateDeployment(ctx, update.Update.AppID, &godo.DeploymentCreateRequest{
 			ForceBuild: true,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create deployment for app %s: %w", update.Update.AppID, err)
+			return mcp.NewToolResultErrorFromErr("api error", err), nil
 		}
 
-		// Convert the deployment information to JSON format
 		deploymentJSON, err := json.MarshalIndent(deployment, "", "  ")
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal deployment for app %s: %w", update.Update.AppID, err)
+			return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 		}
 
 		return mcp.NewToolResultText(string(deploymentJSON)), nil
 	}
 
-	// Update the app with an updated spec which triggers a re-deploy
 	app, _, err := a.client.Apps.Update(ctx, update.Update.AppID, update.Update.Request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update app %s: %w", update.Update.AppID, err)
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
-	// Convert the updated app information to JSON format
 	appJSON, err := json.MarshalIndent(app, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal updated app spec: %w", err)
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(appJSON)), nil
@@ -215,13 +200,13 @@ func (a *AppPlatformTool) UpdateApp(ctx context.Context, req mcp.CallToolRequest
 func (a *AppPlatformTool) Tools() []server.ServerTool {
 	tools := []server.ServerTool{
 		{
-			Handler: a.GetDeploymentStatus,
+			Handler: a.getDeploymentStatus,
 			Tool: mcp.NewTool("digitalocean-apps-get-deployment-status",
 				mcp.WithDescription("Retrieves the active deployment for an application on DigitalOcean App Platform. This is useful for getting the current state of an app's latest deployment."),
 				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app to retrieve active deployment for"))),
 		},
 		{
-			Handler: a.ListApps,
+			Handler: a.listApps,
 			Tool: mcp.NewTool("digitalocean-apps-list",
 				mcp.WithDescription("List all applications on DigitalOcean App Platform"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultPage), mcp.Description("The page number to retrieve (default is 1)")),
@@ -229,14 +214,14 @@ func (a *AppPlatformTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: a.DeleteApp,
+			Handler: a.deleteApp,
 			Tool: mcp.NewTool("digitalocean-apps-delete",
 				mcp.WithDescription("Delete an existing app on DigitalOcean App Platform"),
 				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app we want to delete.")),
 			),
 		},
 		{
-			Handler: a.GetAppInfo,
+			Handler: a.getAppInfo,
 			Tool: mcp.NewTool("digitalocean-apps-get-info",
 				mcp.WithDescription("Get information about an application on DigitalOcean App Platform"),
 				mcp.WithString("AppID", mcp.Required(), mcp.Description("The application ID of the app to retrieve information for")),
@@ -257,7 +242,7 @@ func (a *AppPlatformTool) Tools() []server.ServerTool {
 	}
 
 	appCreateTool := server.ServerTool{
-		Handler: a.CreateAppFromAppSpec,
+		Handler: a.createAppFromAppSpec,
 		Tool: mcp.NewToolWithRawSchema(
 			"digitalocean-apps-create-app-from-spec",
 			"Creates an application from a given app spec. Within the app spec, a source has to be provided. The source can be a Git repository, a Dockerfile, or a container image.",
@@ -271,7 +256,7 @@ func (a *AppPlatformTool) Tools() []server.ServerTool {
 	}
 
 	appUpdateTool := server.ServerTool{
-		Handler: a.UpdateApp,
+		Handler: a.updateApp,
 		Tool: mcp.NewToolWithRawSchema(
 			"digitalocean-apps-update",
 			"Updates an existing application on DigitalOcean App Platform. The app ID and the AppSpec must be provided in the request.",

--- a/internal/apps/apps_test.go
+++ b/internal/apps/apps_test.go
@@ -126,10 +126,10 @@ func TestUpdateApp(t *testing.T) {
 				tc.mock(appService)
 			}
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.UpdateApp(context.Background(), req)
+			resp, err := tool.updateApp(context.Background(), req)
 			if tc.expectError {
-				require.Error(t, err)
-				require.Nil(t, resp)
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
 				return
 			}
 
@@ -185,10 +185,10 @@ func TestListApps(t *testing.T) {
 				tc.mock(appService, tc.expectedApps)
 			}
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.ListApps(context.Background(), req)
+			resp, err := tool.listApps(context.Background(), req)
 			if tc.expectError {
-				require.Error(t, err)
-				require.Nil(t, resp)
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
 				return
 			}
 			require.NoError(t, err)
@@ -283,10 +283,10 @@ func TestCreateAppFromAppSpec(t *testing.T) {
 			}
 
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{"spec": tc.spec}}}
-			resp, err := tool.CreateAppFromAppSpec(context.Background(), req)
+			resp, err := tool.createAppFromAppSpec(context.Background(), req)
 			if tc.expectError {
-				require.Error(t, err)
-				require.Nil(t, resp)
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
 				return
 			}
 
@@ -338,9 +338,10 @@ func TestDeleteApp(t *testing.T) {
 				tc.mock(appService)
 			}
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.DeleteApp(context.Background(), req)
+			resp, err := tool.deleteApp(context.Background(), req)
 			if tc.expectError {
-				require.Error(t, err)
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
 				return
 			}
 			if tc.expectMcp != "" {
@@ -443,11 +444,12 @@ func TestGetDeploymentStatus(t *testing.T) {
 				tc.mock(appService, tc.expectedDeployments)
 			}
 
-			resp, err := tool.GetDeploymentStatus(context.Background(), tc.toolRequest)
+			resp, err := tool.getDeploymentStatus(context.Background(), tc.toolRequest)
 
 			// unexpected error from the http client should return an error
 			if tc.expectErr {
-				require.Error(t, err)
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
 				return
 			}
 

--- a/internal/droplet/droplet_tools.go
+++ b/internal/droplet/droplet_tools.go
@@ -22,7 +22,7 @@ func NewDropletTool(client *godo.Client) *DropletTool {
 }
 
 // CreateDroplet creates a new droplet
-func (d *DropletTool) CreateDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	dropletName := args["Name"].(string)
 	size := args["Size"].(string)
@@ -50,265 +50,265 @@ func (d *DropletTool) CreateDroplet(ctx context.Context, req mcp.CallToolRequest
 	return mcp.NewToolResultText(string(jsonDroplet)), nil
 }
 
-// DeleteDroplet deletes a droplet
-func (d *DropletTool) DeleteDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// deleteDroplet deletes a droplet
+func (d *DropletTool) deleteDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	_, err := d.client.Droplets.Delete(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 	return mcp.NewToolResultText("Droplet deleted successfully"), nil
 }
 
-// PowerCycleDroplet power cycles a droplet
-func (d *DropletTool) PowerCycleDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerCycleDroplet power cycles a droplet
+func (d *DropletTool) powerCycleDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.PowerCycle(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// PowerOnDroplet powers on a droplet
-func (d *DropletTool) PowerOnDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerOnDroplet powers on a droplet
+func (d *DropletTool) powerOnDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.PowerOn(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// PowerOffDroplet powers off a droplet
-func (d *DropletTool) PowerOffDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerOffDroplet powers off a droplet
+func (d *DropletTool) powerOffDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.PowerOff(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// ShutdownDroplet shuts down a droplet
-func (d *DropletTool) ShutdownDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// shutdownDroplet shuts down a droplet
+func (d *DropletTool) shutdownDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.Shutdown(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// RestoreDroplet restores a droplet to a backup image
-func (d *DropletTool) RestoreDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// restoreDroplet restores a droplet to a backup image
+func (d *DropletTool) restoreDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	imageID := req.GetArguments()["ImageID"].(float64)
 	action, _, err := d.client.DropletActions.Restore(ctx, int(dropletID), int(imageID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// ResizeDroplet resizes a droplet
-func (d *DropletTool) ResizeDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// resizeDroplet resizes a droplet
+func (d *DropletTool) resizeDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	size := req.GetArguments()["Size"].(string)
 	resizeDisk, _ := req.GetArguments()["ResizeDisk"].(bool) // Defaults to false
 	action, _, err := d.client.DropletActions.Resize(ctx, int(dropletID), size, resizeDisk)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// RebuildDroplet rebuilds a droplet using a provided image
-func (d *DropletTool) RebuildDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// rebuildDroplet rebuilds a droplet using a provided image
+func (d *DropletTool) rebuildDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	imageID := req.GetArguments()["ImageID"].(float64)
 	action, _, err := d.client.DropletActions.RebuildByImageID(ctx, int(dropletID), int(imageID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// RenameDroplet renames a droplet
-func (d *DropletTool) RenameDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// renameDroplet renames a droplet
+func (d *DropletTool) renameDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	name := req.GetArguments()["Name"].(string)
 	action, _, err := d.client.DropletActions.Rename(ctx, int(dropletID), name)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// ChangeKernel changes a droplet's kernel
-func (d *DropletTool) ChangeKernel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// changeKernel changes a droplet's kernel
+func (d *DropletTool) changeKernel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	kernelID := req.GetArguments()["KernelID"].(float64)
 	action, _, err := d.client.DropletActions.ChangeKernel(ctx, int(dropletID), int(kernelID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// EnableIPv6 enables IPv6 on a droplet
-func (d *DropletTool) EnableIPv6(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enableIPv6 enables IPv6 on a droplet
+func (d *DropletTool) enableIPv6(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.EnableIPv6(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// EnableBackups enables backups on a droplet
-func (d *DropletTool) EnableBackups(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enableBackups enables backups on a droplet
+func (d *DropletTool) enableBackups(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.EnableBackups(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// DisableBackups disables backups on a droplet
-func (d *DropletTool) DisableBackups(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// disableBackups disables backups on a droplet
+func (d *DropletTool) disableBackups(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.DisableBackups(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// SnapshotDroplet creates a snapshot of a droplet
-func (d *DropletTool) SnapshotDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// snapshotDroplet creates a snapshot of a droplet
+func (d *DropletTool) snapshotDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	name := req.GetArguments()["Name"].(string)
 	action, _, err := d.client.DropletActions.Snapshot(ctx, int(dropletID), name)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// GetDropletNeighbors gets a droplet's neighbors
-func (d *DropletTool) GetDropletNeighbors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// getDropletNeighbors gets a droplet's neighbors
+func (d *DropletTool) getDropletNeighbors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	neighbors, _, err := d.client.Droplets.Neighbors(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonNeighbors, err := json.MarshalIndent(neighbors, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonNeighbors)), nil
 }
 
-// EnablePrivateNetworking enables private networking on a droplet
-func (d *DropletTool) EnablePrivateNetworking(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enablePrivateNetworking enables private networking on a droplet
+func (d *DropletTool) enablePrivateNetworking(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.EnablePrivateNetworking(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// GetDropletKernels gets available kernels for a droplet
-func (d *DropletTool) GetDropletKernels(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// getDropletKernels gets available kernels for a droplet
+func (d *DropletTool) getDropletKernels(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 
 	// Use list options to get all kernels
@@ -319,206 +319,206 @@ func (d *DropletTool) GetDropletKernels(ctx context.Context, req mcp.CallToolReq
 
 	kernels, _, err := d.client.Droplets.Kernels(ctx, int(dropletID), opt)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonKernels, err := json.MarshalIndent(kernels, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonKernels)), nil
 }
 
-// RebootDroplet reboots a droplet
-func (d *DropletTool) RebootDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// rebootDroplet reboots a droplet
+func (d *DropletTool) rebootDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.Reboot(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// PasswordResetDroplet resets the password for a droplet
-func (d *DropletTool) PasswordResetDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// passwordResetDroplet resets the password for a droplet
+func (d *DropletTool) passwordResetDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	action, _, err := d.client.DropletActions.PasswordReset(ctx, int(dropletID))
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
 // RebuildByImageSlugDroplet rebuilds a droplet using an image slug
-func (d *DropletTool) RebuildByImageSlugDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DropletTool) rebuildByImageSlugDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
 	imageSlug := req.GetArguments()["ImageSlug"].(string)
 	action, _, err := d.client.DropletActions.RebuildByImageSlug(ctx, int(dropletID), imageSlug)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAction, err := json.MarshalIndent(action, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAction)), nil
 }
 
-// PowerCycleByTag power cycles droplets by tag
-func (d *DropletTool) PowerCycleByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerCycleByTag power cycles droplets by tag
+func (d *DropletTool) powerCycleByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.PowerCycleByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// PowerOnByTag powers on droplets by tag
-func (d *DropletTool) PowerOnByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerOnByTag powers on droplets by tag
+func (d *DropletTool) powerOnByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.PowerOnByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// PowerOffByTag powers off droplets by tag
-func (d *DropletTool) PowerOffByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// powerOffByTag powers off droplets by tag
+func (d *DropletTool) powerOffByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.PowerOffByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// ShutdownByTag shuts down droplets by tag
-func (d *DropletTool) ShutdownByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// shutdownByTag shuts down droplets by tag
+func (d *DropletTool) shutdownByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.ShutdownByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// EnableBackupsByTag enables backups on droplets by tag
-func (d *DropletTool) EnableBackupsByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enableBackupsByTag enables backups on droplets by tag
+func (d *DropletTool) enableBackupsByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.EnableBackupsByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// DisableBackupsByTag disables backups on droplets by tag
-func (d *DropletTool) DisableBackupsByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// disableBackupsByTag disables backups on droplets by tag
+func (d *DropletTool) disableBackupsByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.DisableBackupsByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// SnapshotByTag takes a snapshot of droplets by tag
-func (d *DropletTool) SnapshotByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// snapshotByTag takes a snapshot of droplets by tag
+func (d *DropletTool) snapshotByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	name := req.GetArguments()["Name"].(string)
 	actions, _, err := d.client.DropletActions.SnapshotByTag(ctx, tag, name)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// EnableIPv6ByTag enables IPv6 on droplets by tag
-func (d *DropletTool) EnableIPv6ByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enableIPv6ByTag enables IPv6 on droplets by tag
+func (d *DropletTool) enableIPv6ByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.EnableIPv6ByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
 }
 
-// EnablePrivateNetworkingByTag enables private networking on droplets by tag
-func (d *DropletTool) EnablePrivateNetworkingByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// enablePrivateNetworkingByTag enables private networking on droplets by tag
+func (d *DropletTool) enablePrivateNetworkingByTag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tag := req.GetArguments()["Tag"].(string)
 	actions, _, err := d.client.DropletActions.EnablePrivateNetworkingByTag(ctx, tag)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonActions, err := json.MarshalIndent(actions, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonActions)), nil
@@ -528,7 +528,7 @@ func (d *DropletTool) EnablePrivateNetworkingByTag(ctx context.Context, req mcp.
 func (d *DropletTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: d.CreateDroplet,
+			Handler: d.createDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-create",
 				mcp.WithDescription("Create a new droplet"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
@@ -540,42 +540,42 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.DeleteDroplet,
+			Handler: d.deleteDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-delete",
 				mcp.WithDescription("Delete a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to delete")),
 			),
 		},
 		{
-			Handler: d.PowerCycleDroplet,
+			Handler: d.powerCycleDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-power-cycle",
 				mcp.WithDescription("Power cycle a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power cycle")),
 			),
 		},
 		{
-			Handler: d.PowerOnDroplet,
+			Handler: d.powerOnDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-power-on",
 				mcp.WithDescription("Power on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power on")),
 			),
 		},
 		{
-			Handler: d.PowerOffDroplet,
+			Handler: d.powerOffDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-power-off",
 				mcp.WithDescription("Power off a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power off")),
 			),
 		},
 		{
-			Handler: d.ShutdownDroplet,
+			Handler: d.shutdownDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-shutdown",
 				mcp.WithDescription("Shutdown a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to shutdown")),
 			),
 		},
 		{
-			Handler: d.RestoreDroplet,
+			Handler: d.restoreDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-restore",
 				mcp.WithDescription("Restore a droplet from a backup/snapshot"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to restore")),
@@ -583,7 +583,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.ResizeDroplet,
+			Handler: d.resizeDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-resize",
 				mcp.WithDescription("Resize a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to resize")),
@@ -592,7 +592,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.RebuildDroplet,
+			Handler: d.rebuildDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-rebuild",
 				mcp.WithDescription("Rebuild a droplet from an image"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
@@ -600,7 +600,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.RenameDroplet,
+			Handler: d.renameDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-rename",
 				mcp.WithDescription("Rename a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rename")),
@@ -608,7 +608,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.ChangeKernel,
+			Handler: d.changeKernel,
 			Tool: mcp.NewTool("digitalocean-droplet-change-kernel",
 				mcp.WithDescription("Change a droplet's kernel"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
@@ -616,28 +616,28 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.EnableIPv6,
+			Handler: d.enableIPv6,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-ipv6",
 				mcp.WithDescription("Enable IPv6 on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.EnableBackups,
+			Handler: d.enableBackups,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-backups",
 				mcp.WithDescription("Enable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.DisableBackups,
+			Handler: d.disableBackups,
 			Tool: mcp.NewTool("digitalocean-droplet-disable-backups",
 				mcp.WithDescription("Disable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.SnapshotDroplet,
+			Handler: d.snapshotDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-snapshot",
 				mcp.WithDescription("Take a snapshot of a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
@@ -645,42 +645,42 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.GetDropletNeighbors,
+			Handler: d.getDropletNeighbors,
 			Tool: mcp.NewTool("digitalocean-droplet-get-neighbors",
 				mcp.WithDescription("Get neighbors of a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.EnablePrivateNetworking,
+			Handler: d.enablePrivateNetworking,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-private-net",
 				mcp.WithDescription("Enable private networking on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.GetDropletKernels,
+			Handler: d.getDropletKernels,
 			Tool: mcp.NewTool("digitalocean-droplet-get-kernels",
 				mcp.WithDescription("Get available kernels for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.RebootDroplet,
+			Handler: d.rebootDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-reboot",
 				mcp.WithDescription("Reboot a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to reboot")),
 			),
 		},
 		{
-			Handler: d.PasswordResetDroplet,
+			Handler: d.passwordResetDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-password-reset",
 				mcp.WithDescription("Reset password for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
 		{
-			Handler: d.RebuildByImageSlugDroplet,
+			Handler: d.rebuildByImageSlugDroplet,
 			Tool: mcp.NewTool("digitalocean-droplet-rebuild-by-slug",
 				mcp.WithDescription("Rebuild a droplet using an image slug"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
@@ -688,49 +688,49 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.PowerCycleByTag,
+			Handler: d.powerCycleByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-power-cycle-by-tag",
 				mcp.WithDescription("Power cycle droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power cycle")),
 			),
 		},
 		{
-			Handler: d.PowerOnByTag,
+			Handler: d.powerOnByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-power-on-by-tag",
 				mcp.WithDescription("Power on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power on")),
 			),
 		},
 		{
-			Handler: d.PowerOffByTag,
+			Handler: d.powerOffByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-power-off-by-tag",
 				mcp.WithDescription("Power off droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power off")),
 			),
 		},
 		{
-			Handler: d.ShutdownByTag,
+			Handler: d.shutdownByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-shutdown-by-tag",
 				mcp.WithDescription("Shutdown droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to shutdown")),
 			),
 		},
 		{
-			Handler: d.EnableBackupsByTag,
+			Handler: d.enableBackupsByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-backups-by-tag",
 				mcp.WithDescription("Enable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
 		},
 		{
-			Handler: d.DisableBackupsByTag,
+			Handler: d.disableBackupsByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-disable-backups-by-tag",
 				mcp.WithDescription("Disable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
 		},
 		{
-			Handler: d.SnapshotByTag,
+			Handler: d.snapshotByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-snapshot-by-tag",
 				mcp.WithDescription("Take a snapshot of droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
@@ -738,14 +738,14 @@ func (d *DropletTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.EnableIPv6ByTag,
+			Handler: d.enableIPv6ByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-ipv6-by-tag",
 				mcp.WithDescription("Enable IPv6 on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
 		},
 		{
-			Handler: d.EnablePrivateNetworkingByTag,
+			Handler: d.enablePrivateNetworkingByTag,
 			Tool: mcp.NewTool("digitalocean-droplet-enable-private-net-by-tag",
 				mcp.WithDescription("Enable private networking on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),

--- a/internal/networking/certificate_tools.go
+++ b/internal/networking/certificate_tools.go
@@ -21,8 +21,8 @@ func NewCertificateTool(client *godo.Client) *CertificateTool {
 	}
 }
 
-// CreateCertificate creates a new certificate
-func (c *CertificateTool) CreateCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// createCertificate creates a new certificate
+func (c *CertificateTool) createCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	privateKey := req.GetArguments()["PrivateKey"].(string)
 	leafCertificate := req.GetArguments()["LeafCertificate"].(string)
@@ -38,39 +38,39 @@ func (c *CertificateTool) CreateCertificate(ctx context.Context, req mcp.CallToo
 
 	certificate, _, err := c.client.Certificates.Create(ctx, certRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonCert, err := json.MarshalIndent(certificate, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonCert)), nil
 }
 
-// DeleteCertificate deletes a certificate
-func (c *CertificateTool) DeleteCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// deleteCertificate deletes a certificate
+func (c *CertificateTool) deleteCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	certID := req.GetArguments()["ID"].(string)
 	_, err := c.client.Certificates.Delete(ctx, certID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("Certificate deleted successfully"), nil
 }
 
-// GetCertificate retrieves a certificate by ID
-func (c *CertificateTool) GetCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// getCertificate retrieves a certificate by ID
+func (c *CertificateTool) getCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	certID := req.GetArguments()["ID"].(string)
 	certificate, _, err := c.client.Certificates.Get(ctx, certID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonCert, err := json.MarshalIndent(certificate, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonCert)), nil
@@ -80,7 +80,7 @@ func (c *CertificateTool) GetCertificate(ctx context.Context, req mcp.CallToolRe
 func (c *CertificateTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: c.CreateCertificate,
+			Handler: c.createCertificate,
 			Tool: mcp.NewTool("digitalocean-certificate-create",
 				mcp.WithDescription("Create a new certificate"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
@@ -90,14 +90,14 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: c.DeleteCertificate,
+			Handler: c.deleteCertificate,
 			Tool: mcp.NewTool("digitalocean-certificate-delete",
 				mcp.WithDescription("Delete a certificate"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the certificate to delete")),
 			),
 		},
 		{
-			Handler: c.GetCertificate,
+			Handler: c.getCertificate,
 			Tool: mcp.NewTool("digitalocean-certificate-get",
 				mcp.WithDescription("Get details of a certificate"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the certificate to retrieve")),

--- a/internal/networking/domains_tools.go
+++ b/internal/networking/domains_tools.go
@@ -19,7 +19,7 @@ func NewDomainsTool(client *godo.Client) *DomainsTool {
 	}
 }
 
-func (d *DomainsTool) CreateDomain(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DomainsTool) createDomain(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	ipAddress := req.GetArguments()["IPAddress"].(string)
 
@@ -30,29 +30,29 @@ func (d *DomainsTool) CreateDomain(ctx context.Context, req mcp.CallToolRequest)
 
 	domain, _, err := d.client.Domains.Create(ctx, createRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonDomain, err := json.MarshalIndent(domain, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonDomain)), nil
 }
 
-func (d *DomainsTool) DeleteDomain(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DomainsTool) deleteDomain(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 
 	_, err := d.client.Domains.Delete(ctx, name)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("Domain deleted successfully"), nil
 }
 
-func (d *DomainsTool) CreateRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DomainsTool) createRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain := req.GetArguments()["Domain"].(string)
 	recordType := req.GetArguments()["Type"].(string)
 	name := req.GetArguments()["Name"].(string)
@@ -66,30 +66,30 @@ func (d *DomainsTool) CreateRecord(ctx context.Context, req mcp.CallToolRequest)
 
 	record, _, err := d.client.Domains.CreateRecord(ctx, domain, createRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonRecord, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonRecord)), nil
 }
 
-func (d *DomainsTool) DeleteRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DomainsTool) deleteRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain := req.GetArguments()["Domain"].(string)
 	recordID := int(req.GetArguments()["RecordID"].(float64))
 
 	_, err := d.client.Domains.DeleteRecord(ctx, domain, recordID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("Record deleted successfully"), nil
 }
 
-func (d *DomainsTool) EditRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (d *DomainsTool) editRecord(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain := req.GetArguments()["Domain"].(string)
 	recordID := int(req.GetArguments()["RecordID"].(float64))
 	recordType := req.GetArguments()["Type"].(string)
@@ -104,12 +104,12 @@ func (d *DomainsTool) EditRecord(ctx context.Context, req mcp.CallToolRequest) (
 
 	record, _, err := d.client.Domains.EditRecord(ctx, domain, recordID, editRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonRecord, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonRecord)), nil
@@ -118,7 +118,7 @@ func (d *DomainsTool) EditRecord(ctx context.Context, req mcp.CallToolRequest) (
 func (d *DomainsTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: d.CreateDomain,
+			Handler: d.createDomain,
 			Tool: mcp.NewTool("digitalocean-domain-create",
 				mcp.WithDescription("Create a new domain"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the domain")),
@@ -126,14 +126,14 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.DeleteDomain,
+			Handler: d.deleteDomain,
 			Tool: mcp.NewTool("digitalocean-domain-delete",
 				mcp.WithDescription("Delete a domain"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the domain to delete")),
 			),
 		},
 		{
-			Handler: d.CreateRecord,
+			Handler: d.createRecord,
 			Tool: mcp.NewTool("digitalocean-domain-record-create",
 				mcp.WithDescription("Create a new domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
@@ -143,7 +143,7 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.DeleteRecord,
+			Handler: d.deleteRecord,
 			Tool: mcp.NewTool("digitalocean-domain-record-delete",
 				mcp.WithDescription("Delete a domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
@@ -151,7 +151,7 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: d.EditRecord,
+			Handler: d.editRecord,
 			Tool: mcp.NewTool("digitalocean-domain-record-edit",
 				mcp.WithDescription("Edit a domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),

--- a/internal/networking/firewall_tools.go
+++ b/internal/networking/firewall_tools.go
@@ -21,8 +21,8 @@ func NewFirewallTool(client *godo.Client) *FirewallTool {
 	}
 }
 
-// CreateFirewall creates a new firewall
-func (f *FirewallTool) CreateFirewall(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// createFirewall creates a new firewall
+func (f *FirewallTool) createFirewall(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	inboundProtocol := req.GetArguments()["InboundProtocol"].(string)
 	inboundPortRange := req.GetArguments()["InboundPortRange"].(string)
@@ -60,23 +60,23 @@ func (f *FirewallTool) CreateFirewall(ctx context.Context, req mcp.CallToolReque
 
 	firewall, _, err := f.client.Firewalls.Create(ctx, firewallRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonFirewall, err := json.MarshalIndent(firewall, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonFirewall)), nil
 }
 
-// DeleteFirewall deletes a firewall
-func (f *FirewallTool) DeleteFirewall(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// deleteFirewall deletes a firewall
+func (f *FirewallTool) deleteFirewall(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	firewallID := req.GetArguments()["ID"].(string)
 	_, err := f.client.Firewalls.Delete(ctx, firewallID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 	return mcp.NewToolResultText("Firewall deleted successfully"), nil
 }
@@ -85,7 +85,7 @@ func (f *FirewallTool) DeleteFirewall(ctx context.Context, req mcp.CallToolReque
 func (f *FirewallTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: f.CreateFirewall,
+			Handler: f.createFirewall,
 			Tool: mcp.NewTool("digitalocean-firewall-create",
 				mcp.WithDescription("Create a new firewall"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the firewall")),
@@ -106,7 +106,7 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: f.DeleteFirewall,
+			Handler: f.deleteFirewall,
 			Tool: mcp.NewTool("digitalocean-firewall-delete",
 				mcp.WithDescription("Delete a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to delete")),

--- a/internal/networking/partner_attachment_tools.go
+++ b/internal/networking/partner_attachment_tools.go
@@ -19,7 +19,7 @@ func NewPartnerAttachmentTool(client *godo.Client) *PartnerAttachmentTool {
 	}
 }
 
-func (p *PartnerAttachmentTool) CreatePartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (p *PartnerAttachmentTool) createPartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	region := req.GetArguments()["Region"].(string)
 	bandwidth := int(req.GetArguments()["Bandwidth"].(float64))
@@ -32,57 +32,57 @@ func (p *PartnerAttachmentTool) CreatePartnerAttachment(ctx context.Context, req
 
 	attachment, _, err := p.client.PartnerAttachment.Create(ctx, createRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAttachment, err := json.MarshalIndent(attachment, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAttachment)), nil
 }
 
-func (p *PartnerAttachmentTool) DeletePartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (p *PartnerAttachmentTool) deletePartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id := req.GetArguments()["ID"].(string)
 	_, err := p.client.PartnerAttachment.Delete(ctx, id)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 	return mcp.NewToolResultText("Partner attachment deleted successfully"), nil
 }
 
-func (p *PartnerAttachmentTool) GetServiceKey(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (p *PartnerAttachmentTool) getServiceKey(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id := req.GetArguments()["ID"].(string)
 	serviceKey, _, err := p.client.PartnerAttachment.GetServiceKey(ctx, id)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonServiceKey, err := json.MarshalIndent(serviceKey, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonServiceKey)), nil
 }
 
-func (p *PartnerAttachmentTool) GetBGPConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (p *PartnerAttachmentTool) getBGPConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id := req.GetArguments()["ID"].(string)
 	bgpAuthKey, _, err := p.client.PartnerAttachment.GetBGPAuthKey(ctx, id)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonBGPAuthKey, err := json.MarshalIndent(bgpAuthKey, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonBGPAuthKey)), nil
 }
 
-func (p *PartnerAttachmentTool) UpdatePartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (p *PartnerAttachmentTool) updatePartnerAttachment(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	id := req.GetArguments()["ID"].(string)
 	name := req.GetArguments()["Name"].(string)
 	vpcIDs := req.GetArguments()["VPCIDs"].([]string)
@@ -94,12 +94,12 @@ func (p *PartnerAttachmentTool) UpdatePartnerAttachment(ctx context.Context, req
 
 	attachment, _, err := p.client.PartnerAttachment.Update(ctx, id, updateRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonAttachment, err := json.MarshalIndent(attachment, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonAttachment)), nil
@@ -108,7 +108,7 @@ func (p *PartnerAttachmentTool) UpdatePartnerAttachment(ctx context.Context, req
 func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: p.CreatePartnerAttachment,
+			Handler: p.createPartnerAttachment,
 			Tool: mcp.NewTool("digitalocean-partner-attachment-create",
 				mcp.WithDescription("Create a new partner attachment"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the partner attachment")),
@@ -117,28 +117,28 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: p.DeletePartnerAttachment,
+			Handler: p.deletePartnerAttachment,
 			Tool: mcp.NewTool("digitalocean-partner-attachment-delete",
 				mcp.WithDescription("Delete a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment to delete")),
 			),
 		},
 		{
-			Handler: p.GetServiceKey,
+			Handler: p.getServiceKey,
 			Tool: mcp.NewTool("digitalocean-partner-attachment-get-service-key",
 				mcp.WithDescription("Get the service key of a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment")),
 			),
 		},
 		{
-			Handler: p.GetBGPConfig,
+			Handler: p.getBGPConfig,
 			Tool: mcp.NewTool("digitalocean-partner-attachment-get-bgp-config",
 				mcp.WithDescription("Get the BGP configuration of a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment")),
 			),
 		},
 		{
-			Handler: p.UpdatePartnerAttachment,
+			Handler: p.updatePartnerAttachment,
 			Tool: mcp.NewTool("digitalocean-partner-attachment-update",
 				mcp.WithDescription("Update a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment to update")),

--- a/internal/networking/vpc_tools.go
+++ b/internal/networking/vpc_tools.go
@@ -21,8 +21,8 @@ func NewVPCTool(client *godo.Client) *VPCTool {
 	}
 }
 
-// CreateVPC creates a new VPC
-func (v *VPCTool) CreateVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// createVPC creates a new VPC
+func (v *VPCTool) createVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	region := req.GetArguments()["Region"].(string)
 
@@ -33,41 +33,41 @@ func (v *VPCTool) CreateVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 
 	vpc, _, err := v.client.VPCs.Create(ctx, createRequest)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonVPC, err := json.MarshalIndent(vpc, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonVPC)), nil
 }
 
-// ListVPCMembers lists members of a VPC
-func (v *VPCTool) ListVPCMembers(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// listVPCMembers lists members of a VPC
+func (v *VPCTool) listVPCMembers(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	vpcID := req.GetArguments()["ID"].(string)
 
 	members, _, err := v.client.VPCs.ListMembers(ctx, vpcID, nil, nil)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	jsonMembers, err := json.MarshalIndent(members, "", "  ")
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("marshal error", err), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonMembers)), nil
 }
 
-// DeleteVPC deletes a VPC
-func (v *VPCTool) DeleteVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// deleteVPC deletes a VPC
+func (v *VPCTool) deleteVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	vpcID := req.GetArguments()["ID"].(string)
 
 	_, err := v.client.VPCs.Delete(ctx, vpcID)
 	if err != nil {
-		return nil, err
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
 	}
 
 	return mcp.NewToolResultText("VPC deleted successfully"), nil
@@ -77,7 +77,7 @@ func (v *VPCTool) DeleteVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 func (v *VPCTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Handler: v.CreateVPC,
+			Handler: v.createVPC,
 			Tool: mcp.NewTool("digitalocean-vpc-create",
 				mcp.WithDescription("Create a new VPC"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the VPC")),
@@ -85,14 +85,14 @@ func (v *VPCTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: v.ListVPCMembers,
+			Handler: v.listVPCMembers,
 			Tool: mcp.NewTool("digitalocean-vpc-list-members",
 				mcp.WithDescription("List members of a VPC"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC")),
 			),
 		},
 		{
-			Handler: v.DeleteVPC,
+			Handler: v.deleteVPC,
 			Tool: mcp.NewTool("digitalocean-vpc-delete",
 				mcp.WithDescription("Delete a VPC"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC to delete")),


### PR DESCRIPTION
Making the tools handlers:
- un-exported
- error from handler to be propagated to LLM. 

[From docs](https://github.com/mark3labs/mcp-go/blob/56f25011a0a97b4bb60e7742f017ce0ce098ae66/mcp/tools.go#L26)
```
// CallToolResult is the server's response to a tool call.
//
// Any errors that originate from the tool SHOULD be reported inside the result
// object, with `isError` set to true, _not_ as an MCP protocol-level error
// response. Otherwise, the LLM would not be able to see that an error occurred
// and self-correct.
//
// However, any errors in _finding_ the tool, an error indicating that the
// server does not support tool calls, or any other exceptional conditions,
// should be reported as an MCP error response.
```