### PR TITLE
Add optional subnet parameter to VPC creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ scripts/npm/node_modules/
 
 # Build output
 scripts/npm/dist/
+
+docode/*

--- a/internal/networking/vpc_tools.go
+++ b/internal/networking/vpc_tools.go
@@ -70,6 +70,11 @@ func (v *VPCTool) createVPC(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		RegionSlug: region,
 	}
 
+	// Add optional subnet parameter
+	if subnet, ok := req.GetArguments()["Subnet"].(string); ok && subnet != "" {
+		createRequest.IPRange = subnet
+	}
+
 	vpc, _, err := v.client.VPCs.Create(ctx, createRequest)
 	if err != nil {
 		return mcp.NewToolResultErrorFromErr("api error", err), nil
@@ -136,6 +141,7 @@ func (v *VPCTool) Tools() []server.ServerTool {
 				mcp.WithDescription("Create a new VPC"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the VPC")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region slug (e.g., nyc3)")),
+				mcp.WithString("Subnet", mcp.Description("Optional subnet CIDR block (e.g., 10.10.0.0/20)")),
 			),
 		},
 		{

--- a/internal/networking/vpc_tools_test.go
+++ b/internal/networking/vpc_tools_test.go
@@ -205,6 +205,41 @@ func TestVPCTool_createVPC(t *testing.T) {
 			},
 		},
 		{
+			name: "Successful create with subnet",
+			args: map[string]any{
+				"Name":   "private-net",
+				"Region": "nyc3",
+				"Subnet": "10.10.0.0/20",
+			},
+			mockSetup: func(m *MockVPCsService) {
+				m.EXPECT().
+					Create(gomock.Any(), &godo.VPCCreateRequest{
+						Name:       "private-net",
+						RegionSlug: "nyc3",
+						IPRange:    "10.10.0.0/20",
+					}).
+					Return(testVPC, nil, nil).
+					Times(1)
+			},
+		},
+		{
+			name: "Successful create with empty subnet",
+			args: map[string]any{
+				"Name":   "private-net",
+				"Region": "nyc3",
+				"Subnet": "",
+			},
+			mockSetup: func(m *MockVPCsService) {
+				m.EXPECT().
+					Create(gomock.Any(), &godo.VPCCreateRequest{
+						Name:       "private-net",
+						RegionSlug: "nyc3",
+					}).
+					Return(testVPC, nil, nil).
+					Times(1)
+			},
+		},
+		{
 			name: "API error",
 			args: map[string]any{
 				"Name":   "fail-vpc",


### PR DESCRIPTION
The VPC creation tool now supports an optional 'Subnet' argument, allowing users to specify a custom CIDR block for the VPC. Tests have been added to verify behavior with and without the subnet parameter.