### PR TITLE
Add support for adding/removing firewall rules

### DIFF
--- a/internal/networking/README.md
+++ b/internal/networking/README.md
@@ -73,6 +73,30 @@ This directory contains tools and resources for managing DigitalOcean networking
   - `ID` (string, required): ID of the firewall to remove droplets from
   - `DropletIDs` (array of numbers, required): Droplet IDs to remove from the firewall
 
+- **`digitalocean-firewall-add-rules`**
+  Add one or more rules to a firewall.
+  - `ID` (string, required): ID of the firewall to add rules to
+  - `InboundRules` (array of objects, optional): Inbound rules to add
+    - `Protocol` (string, required): Protocol (tcp, udp, icmp)
+    - `PortRange` (string, required): Port range (e.g., '80', '443', '8000-8080')
+    - `Sources` (array of strings, required): Source IP addresses or CIDR blocks
+  - `OutboundRules` (array of objects, optional): Outbound rules to add
+    - `Protocol` (string, required): Protocol (tcp, udp, icmp)
+    - `PortRange` (string, required): Port range (e.g., '80', '443', '8000-8080')
+    - `Destinations` (array of strings, required): Destination IP addresses or CIDR blocks
+
+- **`digitalocean-firewall-remove-rules`**
+  Remove one or more rules from a firewall.
+  - `ID` (string, required): ID of the firewall to remove rules from
+  - `InboundRules` (array of objects, optional): Inbound rules to remove
+    - `Protocol` (string, required): Protocol (tcp, udp, icmp)
+    - `PortRange` (string, required): Port range (e.g., '80', '443', '8000-8080')
+    - `Sources` (array of strings, required): Source IP addresses or CIDR blocks
+  - `OutboundRules` (array of objects, optional): Outbound rules to remove
+    - `Protocol` (string, required): Protocol (tcp, udp, icmp)
+    - `PortRange` (string, required): Port range (e.g., '80', '443', '8000-8080')
+    - `Destinations` (array of strings, required): Destination IP addresses or CIDR blocks
+
 ---
 
 ### Firewalls
@@ -335,6 +359,8 @@ The following tools are now available for direct querying and listing of all net
 - Delete the TXT record with ID 12345 from "example.com".
 - Create a new SSL certificate for "myapp.com".
 - Delete a firewall with ID "abcd-1234".
+- Add HTTP and HTTPS inbound rules to firewall "fw-123".
+- Remove SSH access rule from firewall "fw-456".
 - Reserve a new IPv4 in region "nyc3".
 - Assign reserved IP "198.51.100.5" to droplet 987654.
 - Create a new VPC named "private-net" in region "sfo2".

--- a/internal/networking/firewall_tools.go
+++ b/internal/networking/firewall_tools.go
@@ -171,6 +171,150 @@ func (f *FirewallTool) removeTags(ctx context.Context, req mcp.CallToolRequest) 
 	return mcp.NewToolResultText("Tag(s) removed from firewall successfully"), nil
 }
 
+// addRules adds one or more rules to a firewall
+func (f *FirewallTool) addRules(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	firewallID := req.GetArguments()["ID"].(string)
+
+	var inboundRules []godo.InboundRule
+	var outboundRules []godo.OutboundRule
+
+	// Process inbound rules if provided
+	if inboundData, ok := req.GetArguments()["InboundRules"]; ok && inboundData != nil {
+		inboundRulesList := inboundData.([]interface{})
+		for _, ruleData := range inboundRulesList {
+			rule := ruleData.(map[string]interface{})
+
+			protocol := rule["Protocol"].(string)
+			portRange := rule["PortRange"].(string)
+			sources := rule["Sources"].([]interface{})
+
+			sourceAddresses := make([]string, len(sources))
+			for i, source := range sources {
+				sourceAddresses[i] = source.(string)
+			}
+
+			inboundRule := godo.InboundRule{
+				Protocol:  protocol,
+				PortRange: portRange,
+				Sources:   &godo.Sources{Addresses: sourceAddresses},
+			}
+			inboundRules = append(inboundRules, inboundRule)
+		}
+	}
+
+	// Process outbound rules if provided
+	if outboundData, ok := req.GetArguments()["OutboundRules"]; ok && outboundData != nil {
+		outboundRulesList := outboundData.([]interface{})
+		for _, ruleData := range outboundRulesList {
+			rule := ruleData.(map[string]interface{})
+
+			protocol := rule["Protocol"].(string)
+			portRange := rule["PortRange"].(string)
+			destinations := rule["Destinations"].([]interface{})
+
+			destAddresses := make([]string, len(destinations))
+			for i, dest := range destinations {
+				destAddresses[i] = dest.(string)
+			}
+
+			outboundRule := godo.OutboundRule{
+				Protocol:     protocol,
+				PortRange:    portRange,
+				Destinations: &godo.Destinations{Addresses: destAddresses},
+			}
+			outboundRules = append(outboundRules, outboundRule)
+		}
+	}
+
+	if len(inboundRules) == 0 && len(outboundRules) == 0 {
+		return mcp.NewToolResultError("At least one inbound or outbound rule must be provided"), nil
+	}
+
+	rulesRequest := &godo.FirewallRulesRequest{
+		InboundRules:  inboundRules,
+		OutboundRules: outboundRules,
+	}
+
+	_, err := f.client.Firewalls.AddRules(ctx, firewallID, rulesRequest)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
+	}
+
+	return mcp.NewToolResultText("Rule(s) added to firewall successfully"), nil
+}
+
+// removeRules removes one or more rules from a firewall
+func (f *FirewallTool) removeRules(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	firewallID := req.GetArguments()["ID"].(string)
+
+	var inboundRules []godo.InboundRule
+	var outboundRules []godo.OutboundRule
+
+	// Process inbound rules if provided
+	if inboundData, ok := req.GetArguments()["InboundRules"]; ok && inboundData != nil {
+		inboundRulesList := inboundData.([]interface{})
+		for _, ruleData := range inboundRulesList {
+			rule := ruleData.(map[string]interface{})
+
+			protocol := rule["Protocol"].(string)
+			portRange := rule["PortRange"].(string)
+			sources := rule["Sources"].([]interface{})
+
+			sourceAddresses := make([]string, len(sources))
+			for i, source := range sources {
+				sourceAddresses[i] = source.(string)
+			}
+
+			inboundRule := godo.InboundRule{
+				Protocol:  protocol,
+				PortRange: portRange,
+				Sources:   &godo.Sources{Addresses: sourceAddresses},
+			}
+			inboundRules = append(inboundRules, inboundRule)
+		}
+	}
+
+	// Process outbound rules if provided
+	if outboundData, ok := req.GetArguments()["OutboundRules"]; ok && outboundData != nil {
+		outboundRulesList := outboundData.([]interface{})
+		for _, ruleData := range outboundRulesList {
+			rule := ruleData.(map[string]interface{})
+
+			protocol := rule["Protocol"].(string)
+			portRange := rule["PortRange"].(string)
+			destinations := rule["Destinations"].([]interface{})
+
+			destAddresses := make([]string, len(destinations))
+			for i, dest := range destinations {
+				destAddresses[i] = dest.(string)
+			}
+
+			outboundRule := godo.OutboundRule{
+				Protocol:     protocol,
+				PortRange:    portRange,
+				Destinations: &godo.Destinations{Addresses: destAddresses},
+			}
+			outboundRules = append(outboundRules, outboundRule)
+		}
+	}
+
+	if len(inboundRules) == 0 && len(outboundRules) == 0 {
+		return mcp.NewToolResultError("At least one inbound or outbound rule must be provided"), nil
+	}
+
+	rulesRequest := &godo.FirewallRulesRequest{
+		InboundRules:  inboundRules,
+		OutboundRules: outboundRules,
+	}
+
+	_, err := f.client.Firewalls.RemoveRules(ctx, firewallID, rulesRequest)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
+	}
+
+	return mcp.NewToolResultText("Rule(s) removed from firewall successfully"), nil
+}
+
 // Tools returns a list of tool functions
 func (f *FirewallTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
@@ -259,6 +403,112 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 				mcp.WithArray("Tags", mcp.Required(), mcp.Description("Tags to remove from the firewall"), mcp.Items(map[string]any{
 					"type":        "string",
 					"description": "Tag to remove",
+				})),
+			),
+		},
+		{
+			Handler: f.addRules,
+			Tool: mcp.NewTool("digitalocean-firewall-add-rules",
+				mcp.WithDescription("Add one or more rules to a firewall"),
+				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to add rules to")),
+				mcp.WithArray("InboundRules", mcp.Description("Inbound rules to add"), mcp.Items(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"Protocol": map[string]any{
+							"type":        "string",
+							"description": "Protocol (tcp, udp, icmp)",
+						},
+						"PortRange": map[string]any{
+							"type":        "string",
+							"description": "Port range (e.g., '80', '443', '8000-8080')",
+						},
+						"Sources": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":        "string",
+								"description": "Source IP address or CIDR block",
+							},
+							"description": "List of source addresses",
+						},
+					},
+					"required":    []string{"Protocol", "PortRange", "Sources"},
+					"description": "Inbound firewall rule",
+				})),
+				mcp.WithArray("OutboundRules", mcp.Description("Outbound rules to add"), mcp.Items(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"Protocol": map[string]any{
+							"type":        "string",
+							"description": "Protocol (tcp, udp, icmp)",
+						},
+						"PortRange": map[string]any{
+							"type":        "string",
+							"description": "Port range (e.g., '80', '443', '8000-8080')",
+						},
+						"Destinations": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":        "string",
+								"description": "Destination IP address or CIDR block",
+							},
+							"description": "List of destination addresses",
+						},
+					},
+					"required":    []string{"Protocol", "PortRange", "Destinations"},
+					"description": "Outbound firewall rule",
+				})),
+			),
+		},
+		{
+			Handler: f.removeRules,
+			Tool: mcp.NewTool("digitalocean-firewall-remove-rules",
+				mcp.WithDescription("Remove one or more rules from a firewall"),
+				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to remove rules from")),
+				mcp.WithArray("InboundRules", mcp.Description("Inbound rules to remove"), mcp.Items(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"Protocol": map[string]any{
+							"type":        "string",
+							"description": "Protocol (tcp, udp, icmp)",
+						},
+						"PortRange": map[string]any{
+							"type":        "string",
+							"description": "Port range (e.g., '80', '443', '8000-8080')",
+						},
+						"Sources": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":        "string",
+								"description": "Source IP address or CIDR block",
+							},
+							"description": "List of source addresses",
+						},
+					},
+					"required":    []string{"Protocol", "PortRange", "Sources"},
+					"description": "Inbound firewall rule",
+				})),
+				mcp.WithArray("OutboundRules", mcp.Description("Outbound rules to remove"), mcp.Items(map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"Protocol": map[string]any{
+							"type":        "string",
+							"description": "Protocol (tcp, udp, icmp)",
+						},
+						"PortRange": map[string]any{
+							"type":        "string",
+							"description": "Port range (e.g., '80', '443', '8000-8080')",
+						},
+						"Destinations": map[string]any{
+							"type": "array",
+							"items": map[string]any{
+								"type":        "string",
+								"description": "Destination IP address or CIDR block",
+							},
+							"description": "List of destination addresses",
+						},
+					},
+					"required":    []string{"Protocol", "PortRange", "Destinations"},
+					"description": "Outbound firewall rule",
 				})),
 			),
 		},

--- a/internal/networking/firewall_tools_test.go
+++ b/internal/networking/firewall_tools_test.go
@@ -541,6 +541,231 @@ func TestFirewallTool_removeDroplets(t *testing.T) {
 	}
 }
 
+func TestFirewallTool_addRules(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		mockSetup   func(*MockFirewallsService)
+		expectError bool
+		expectText  string
+	}{
+		{
+			name: "Successful add inbound and outbound rules",
+			args: map[string]any{
+				"ID": "fw-123",
+				"InboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "80",
+						"Sources":   []interface{}{"0.0.0.0/0", "10.0.0.0/8"},
+					},
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "443",
+						"Sources":   []interface{}{"0.0.0.0/0"},
+					},
+				},
+				"OutboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":     "udp",
+						"PortRange":    "53",
+						"Destinations": []interface{}{"8.8.8.8/32", "1.1.1.1/32"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					AddRules(gomock.Any(), "fw-123", gomock.Any()).
+					Return(&godo.Response{}, nil).
+					Times(1)
+			},
+			expectText: "Rule(s) added to firewall successfully",
+		},
+		{
+			name: "Successful add inbound rules only",
+			args: map[string]any{
+				"ID": "fw-456",
+				"InboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "22",
+						"Sources":   []interface{}{"192.168.1.0/24"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					AddRules(gomock.Any(), "fw-456", gomock.Any()).
+					Return(&godo.Response{}, nil).
+					Times(1)
+			},
+			expectText: "Rule(s) added to firewall successfully",
+		},
+		{
+			name: "No rules provided",
+			args: map[string]any{
+				"ID": "fw-789",
+			},
+			mockSetup:   nil,
+			expectError: true,
+		},
+		{
+			name: "API error",
+			args: map[string]any{
+				"ID": "fw-error",
+				"InboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "80",
+						"Sources":   []interface{}{"0.0.0.0/0"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					AddRules(gomock.Any(), "fw-error", gomock.Any()).
+					Return(nil, errors.New("api error")).
+					Times(1)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockFirewalls := NewMockFirewallsService(ctrl)
+			if tc.mockSetup != nil {
+				tc.mockSetup(mockFirewalls)
+			}
+			tool := setupFirewallToolWithMock(mockFirewalls)
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.addRules(context.Background(), req)
+			if tc.expectError {
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.False(t, resp.IsError)
+			require.Contains(t, resp.Content[0].(mcp.TextContent).Text, tc.expectText)
+		})
+	}
+}
+
+func TestFirewallTool_removeRules(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		mockSetup   func(*MockFirewallsService)
+		expectError bool
+		expectText  string
+	}{
+		{
+			name: "Successful remove inbound and outbound rules",
+			args: map[string]any{
+				"ID": "fw-123",
+				"InboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "80",
+						"Sources":   []interface{}{"0.0.0.0/0"},
+					},
+				},
+				"OutboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":     "udp",
+						"PortRange":    "53",
+						"Destinations": []interface{}{"8.8.8.8/32"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					RemoveRules(gomock.Any(), "fw-123", gomock.Any()).
+					Return(&godo.Response{}, nil).
+					Times(1)
+			},
+			expectText: "Rule(s) removed from firewall successfully",
+		},
+		{
+			name: "Successful remove outbound rules only",
+			args: map[string]any{
+				"ID": "fw-456",
+				"OutboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":     "tcp",
+						"PortRange":    "443",
+						"Destinations": []interface{}{"192.168.1.0/24", "10.0.0.0/8"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					RemoveRules(gomock.Any(), "fw-456", gomock.Any()).
+					Return(&godo.Response{}, nil).
+					Times(1)
+			},
+			expectText: "Rule(s) removed from firewall successfully",
+		},
+		{
+			name: "No rules provided",
+			args: map[string]any{
+				"ID": "fw-789",
+			},
+			mockSetup:   nil,
+			expectError: true,
+		},
+		{
+			name: "API error",
+			args: map[string]any{
+				"ID": "fw-error",
+				"InboundRules": []interface{}{
+					map[string]interface{}{
+						"Protocol":  "tcp",
+						"PortRange": "22",
+						"Sources":   []interface{}{"192.168.1.0/24"},
+					},
+				},
+			},
+			mockSetup: func(m *MockFirewallsService) {
+				m.EXPECT().
+					RemoveRules(gomock.Any(), "fw-error", gomock.Any()).
+					Return(nil, errors.New("api error")).
+					Times(1)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockFirewalls := NewMockFirewallsService(ctrl)
+			if tc.mockSetup != nil {
+				tc.mockSetup(mockFirewalls)
+			}
+			tool := setupFirewallToolWithMock(mockFirewalls)
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.removeRules(context.Background(), req)
+			if tc.expectError {
+				require.NotNil(t, resp)
+				require.True(t, resp.IsError)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.False(t, resp.IsError)
+			require.Contains(t, resp.Content[0].(mcp.TextContent).Text, tc.expectText)
+		})
+	}
+}
+
 func TestFirewallTool_deleteFirewall(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/networking/firewall_tools_test.go
+++ b/internal/networking/firewall_tools_test.go
@@ -556,23 +556,23 @@ func TestFirewallTool_addRules(t *testing.T) {
 			name: "Successful add inbound and outbound rules",
 			args: map[string]any{
 				"ID": "fw-123",
-				"InboundRules": []interface{}{
-					map[string]interface{}{
+				"InboundRules": []any{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "80",
-						"Sources":   []interface{}{"0.0.0.0/0", "10.0.0.0/8"},
+						"Sources":   []any{"0.0.0.0/0", "10.0.0.0/8"},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "443",
-						"Sources":   []interface{}{"0.0.0.0/0"},
+						"Sources":   []any{"0.0.0.0/0"},
 					},
 				},
-				"OutboundRules": []interface{}{
-					map[string]interface{}{
+				"OutboundRules": []any{
+					map[string]any{
 						"Protocol":     "udp",
 						"PortRange":    "53",
-						"Destinations": []interface{}{"8.8.8.8/32", "1.1.1.1/32"},
+						"Destinations": []any{"8.8.8.8/32", "1.1.1.1/32"},
 					},
 				},
 			},
@@ -588,11 +588,11 @@ func TestFirewallTool_addRules(t *testing.T) {
 			name: "Successful add inbound rules only",
 			args: map[string]any{
 				"ID": "fw-456",
-				"InboundRules": []interface{}{
-					map[string]interface{}{
+				"InboundRules": []any{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "22",
-						"Sources":   []interface{}{"192.168.1.0/24"},
+						"Sources":   []any{"192.168.1.0/24"},
 					},
 				},
 			},
@@ -616,11 +616,11 @@ func TestFirewallTool_addRules(t *testing.T) {
 			name: "API error",
 			args: map[string]any{
 				"ID": "fw-error",
-				"InboundRules": []interface{}{
-					map[string]interface{}{
+				"InboundRules": []any{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "80",
-						"Sources":   []interface{}{"0.0.0.0/0"},
+						"Sources":   []any{"0.0.0.0/0"},
 					},
 				},
 			},
@@ -671,18 +671,18 @@ func TestFirewallTool_removeRules(t *testing.T) {
 			name: "Successful remove inbound and outbound rules",
 			args: map[string]any{
 				"ID": "fw-123",
-				"InboundRules": []interface{}{
-					map[string]interface{}{
+				"InboundRules": []any{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "80",
-						"Sources":   []interface{}{"0.0.0.0/0"},
+						"Sources":   []any{"0.0.0.0/0"},
 					},
 				},
-				"OutboundRules": []interface{}{
-					map[string]interface{}{
+				"OutboundRules": []any{
+					map[string]any{
 						"Protocol":     "udp",
 						"PortRange":    "53",
-						"Destinations": []interface{}{"8.8.8.8/32"},
+						"Destinations": []any{"8.8.8.8/32"},
 					},
 				},
 			},
@@ -698,11 +698,11 @@ func TestFirewallTool_removeRules(t *testing.T) {
 			name: "Successful remove outbound rules only",
 			args: map[string]any{
 				"ID": "fw-456",
-				"OutboundRules": []interface{}{
-					map[string]interface{}{
+				"OutboundRules": []any{
+					map[string]any{
 						"Protocol":     "tcp",
 						"PortRange":    "443",
-						"Destinations": []interface{}{"192.168.1.0/24", "10.0.0.0/8"},
+						"Destinations": []any{"192.168.1.0/24", "10.0.0.0/8"},
 					},
 				},
 			},
@@ -726,11 +726,11 @@ func TestFirewallTool_removeRules(t *testing.T) {
 			name: "API error",
 			args: map[string]any{
 				"ID": "fw-error",
-				"InboundRules": []interface{}{
-					map[string]interface{}{
+				"InboundRules": []any{
+					map[string]any{
 						"Protocol":  "tcp",
 						"PortRange": "22",
-						"Sources":   []interface{}{"192.168.1.0/24"},
+						"Sources":   []any{"192.168.1.0/24"},
 					},
 				},
 			},


### PR DESCRIPTION
Introduces 'digitalocean-firewall-add-rules' and 'digitalocean-firewall-remove-rules' tools for managing inbound and outbound rules on firewalls. Updates documentation and adds comprehensive tests for these new functionalities.