### PR TITLE
Add Let's Encrypt certificate creation support

### DIFF
--- a/internal/networking/README.md
+++ b/internal/networking/README.md
@@ -42,12 +42,17 @@ This directory contains tools and resources for managing DigitalOcean networking
 
 ### Certificates
 
-- **`digitalocean-certificate-create`**
-  Create a new certificate.
+- **`digitalocean-custom-certificate-create`**
+  Create a new custom certificate.
   - `Name` (string, required): Name of the certificate
-  - `PrivateKey` (string, required): Private key
+  - `PrivateKey` (string, required): Private key for the certificate
   - `LeafCertificate` (string, required): Leaf certificate
   - `CertificateChain` (string, required): Certificate chain
+
+- **`digitalocean-lets-encrypt-certificate-create`**
+  Create a new Let's Encrypt certificate.
+  - `Name` (string, required): Name of the certificate
+  - `DnsNames` (array of strings, required): DNS names of the certificate, including wildcard domains
 
 - **`digitalocean-certificate-delete`**
   Delete a certificate.
@@ -357,7 +362,9 @@ The following tools are now available for direct querying and listing of all net
 - Create a new domain "example.com" pointing to IP "203.0.113.10".
 - Add an A record to "example.com" for "www" pointing to "203.0.113.20".
 - Delete the TXT record with ID 12345 from "example.com".
-- Create a new SSL certificate for "myapp.com".
+- Create a new custom SSL certificate for "myapp.com".
+- Create a new Let's Encrypt certificate for "example.com" and "www.example.com".
+- Create a wildcard Let's Encrypt certificate for "*.example.com" and "example.com".
 - Delete a firewall with ID "abcd-1234".
 - Add HTTP and HTTPS inbound rules to firewall "fw-123".
 - Remove SSH access rule from firewall "fw-456".

--- a/internal/networking/certificate_tools.go
+++ b/internal/networking/certificate_tools.go
@@ -53,11 +53,15 @@ func (c *CertificateTool) createCustomCertificate(ctx context.Context, req mcp.C
 // createLetsEncryptCertificate creates a new LetsEncrypt certificate
 func (c *CertificateTool) createLetsEncryptCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
-	dnsNames := req.GetArguments()["DnsNames"].([]string)
+	dnsNames := req.GetArguments()["DnsNames"].([]any)
+	dnsNamesStr := make([]string, len(dnsNames))
+	for i, dnsName := range dnsNames {
+		dnsNamesStr[i] = dnsName.(string)
+	}
 
 	certRequest := &godo.CertificateRequest{
 		Name:     name,
-		DNSNames: dnsNames,
+		DNSNames: dnsNamesStr,
 		Type:     "lets_encrypt",
 	}
 
@@ -159,7 +163,10 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool("digitalocean-lets-encrypt-certificate-create",
 				mcp.WithDescription("Create a new let's encrypt certificate"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
-				mcp.WithArray("DnsNames", mcp.Required(), mcp.Description("DNS names of the certificate")),
+				mcp.WithArray("DnsNames", mcp.Required(), mcp.Description("DNS names of the certificate"), mcp.Items(map[string]any{
+					"type":        "string",
+					"description": "DNS name for the certificate, including wildcard domains",
+				})),
 			),
 		},
 		{

--- a/internal/networking/certificate_tools.go
+++ b/internal/networking/certificate_tools.go
@@ -22,8 +22,8 @@ func NewCertificateTool(client *godo.Client) *CertificateTool {
 	}
 }
 
-// createCertificate creates a new certificate
-func (c *CertificateTool) createCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// createCustomCertificate creates a new certificate
+func (c *CertificateTool) createCustomCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name := req.GetArguments()["Name"].(string)
 	privateKey := req.GetArguments()["PrivateKey"].(string)
 	leafCertificate := req.GetArguments()["LeafCertificate"].(string)
@@ -35,6 +35,30 @@ func (c *CertificateTool) createCertificate(ctx context.Context, req mcp.CallToo
 		LeafCertificate:  leafCertificate,
 		CertificateChain: certificateChain,
 		Type:             "custom",
+	}
+
+	certificate, _, err := c.client.Certificates.Create(ctx, certRequest)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("api error", err), nil
+	}
+
+	jsonCert, err := json.MarshalIndent(certificate, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonCert)), nil
+}
+
+// createLetsEncryptCertificate creates a new LetsEncrypt certificate
+func (c *CertificateTool) createLetsEncryptCertificate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	name := req.GetArguments()["Name"].(string)
+	dnsNames := req.GetArguments()["DnsNames"].([]string)
+
+	certRequest := &godo.CertificateRequest{
+		Name:     name,
+		DNSNames: dnsNames,
+		Type:     "lets_encrypt",
 	}
 
 	certificate, _, err := c.client.Certificates.Create(ctx, certRequest)
@@ -121,13 +145,21 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 			),
 		},
 		{
-			Handler: c.createCertificate,
-			Tool: mcp.NewTool("digitalocean-certificate-create",
-				mcp.WithDescription("Create a new certificate"),
+			Handler: c.createCustomCertificate,
+			Tool: mcp.NewTool("digitalocean-custom-certificate-create",
+				mcp.WithDescription("Create a new custom certificate"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
 				mcp.WithString("PrivateKey", mcp.Required(), mcp.Description("Private key for the certificate")),
 				mcp.WithString("LeafCertificate", mcp.Required(), mcp.Description("Leaf certificate")),
 				mcp.WithString("CertificateChain", mcp.Required(), mcp.Description("Certificate chain")),
+			),
+		},
+		{
+			Handler: c.createLetsEncryptCertificate,
+			Tool: mcp.NewTool("digitalocean-lets-encrypt-certificate-create",
+				mcp.WithDescription("Create a new let's encrypt certificate"),
+				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
+				mcp.WithArray("DnsNames", mcp.Required(), mcp.Description("DNS names of the certificate")),
 			),
 		},
 		{


### PR DESCRIPTION
Introduces createLetsEncryptCertificate to handle creation of Let's Encrypt certificates via DigitalOcean API. Refactors custom certificate creation handler and updates tool registration to distinguish between custom and Let's Encrypt certificate creation.