### PR TITLE
networking: merge reserved ip tools for ipv4 and ipv6, disable PNC tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The MCP DigitalOcean Integration supports the following services, allowing users
 | **apps**        | Manage DigitalOcean App Platform applications, including deployments and configurations.                           |
 | **droplets**    | Create, manage, resize, snapshot, and monitor droplets (virtual machines) on DigitalOcean.                         |
 | **account**     | Get information about your DigitalOcean account, billing, balance, invoices, and SSH keys.                         |
-| **networking**  | Manage domains, DNS records, certificates, firewalls, reserved IPs, VPCs, CDNs, and Partner Network attachments.   |
+| **networking**  | Manage domains, DNS records, certificates, firewalls, reserved IPs, VPCs, and CDNs.                                |
 | **insights**    | Monitors your resources, endpoints and alert you when they're slow, unavailable, or SSL certificates are expiring. |
 | **spaces**      | DigitalOcean Spaces object storage and Spaces access keys for S3-compatible storage.                               |
 | **databases**   | Provision, manage, and monitor managed database clusters (Postgres, MySQL, Redis, etc.).                           |

--- a/internal/networking/README.md
+++ b/internal/networking/README.md
@@ -1,6 +1,6 @@
 # Networking MCP Tools
 
-This directory contains tools and resources for managing DigitalOcean networking features via the MCP Server. These tools enable you to create, modify, and query networking resources such as domains, certificates, firewalls, reserved IPs, VPCs, CDNs, and partner attachments.
+This directory contains tools and resources for managing DigitalOcean networking features via the MCP Server. These tools enable you to create, modify, and query networking resources such as domains, certificates, firewalls, reserved IPs, VPCs, and CDNs.
 
 ---
 
@@ -186,34 +186,16 @@ This directory contains tools and resources for managing DigitalOcean networking
   - `IP` (string, required): The reserved IP to unassign
   - `Type` (string, required): Type of IP (`ipv4` or `ipv6`)
 
-- **reserved-ipv4-list**
+- **reserved-ip-list**
   List reserved IPv4 addresses with pagination.
+  - `Type` (string, required): Type of IP (`ipv4` or `ipv6`)
   - `Page` (number, optional, default: 1): Page number
   - `PerPage` (number, optional, default: 20): Items per page
 
-- **reserved-ipv6-list**
-  List reserved IPv6 addresses with pagination.
-  - `Page` (number, optional, default: 1): Page number
-  - `PerPage` (number, optional, default: 20): Items per page
-
-- **reserved-ipv4-list**  
-  List reserved IPv4 addresses with pagination.  
-  - `Page` (number, optional, default: 1): Page number  
-  - `PerPage` (number, optional, default: 20): Items per page
-
-- **reserved-ipv6-list**  
-  List reserved IPv6 addresses with pagination.  
-  - `Page` (number, optional, default: 1): Page number  
-  - `PerPage` (number, optional, default: 20): Items per page
-
-- **reserved-ipv4-get**  
+- **reserved-ip-get**  
   Get reserved IPv4 information by IP.  
-  - `IP` (string, required): The reserved IPv4 address
+  - `IP` (string, required): The reserved IPv4 or IPv6 address
 
-- **reserved-ipv6-get**  
-  Get reserved IPv6 information by IP.  
-  - `IP` (string, required): The reserved IPv6 address
-  
 ---
 
 ### VPC Peering
@@ -267,42 +249,6 @@ This directory contains tools and resources for managing DigitalOcean networking
 
 ---
 
-### Partner Attachments
-
-- **partner-attachment-create**
-  Create a new partner attachment.
-  - `Name` (string, required): Name of the partner attachment
-  - `Region` (string, required): Region for the partner attachment
-  - `Bandwidth` (number, required): Bandwidth in Mbps
-
-- **partner-attachment-delete**
-  Delete a partner attachment.
-  - `ID` (string, required): ID of the partner attachment
-
-- **partner-attachment-get-service-key**
-  Get the service key of a partner attachment.
-  - `ID` (string, required): ID of the partner attachment
-
-- **partner-attachment-get-bgp-config**
-  Get the BGP configuration of a partner attachment.
-  - `ID` (string, required): ID of the partner attachment
-
-- **partner-attachment-update**
-  Update a partner attachment.
-  - `ID` (string, required): ID of the partner attachment
-  - `Name` (string, required): New name
-  - `VPCIDs` (array of strings, required): VPC IDs to associate
-
-- **partner-attachment-get**  
-  Get partner attachment information by ID.  
-  - `ID` (string, required): ID of the partner attachment
-
-- **partner-attachment-list**  
-  List partner attachments with pagination.  
-  - `Page` (number, default: 1): Page number  
-  - `PerPage` (number, default: 20): Items per page
-
----
 
 ## Example Queries Using Networking MCP Tools
 
@@ -319,7 +265,6 @@ This directory contains tools and resources for managing DigitalOcean networking
 - Assign reserved IP "198.51.100.5" to droplet 987654.
 - Create a new VPC named "private-net" in region "sfo2".
 - Flush the cache for CDN with ID "cdn-xyz" for file "/static/logo.png".
-- Create a partner attachment named "fast-connect" in region "nyc3" with 1000 Mbps bandwidth.
 
 ---
 

--- a/internal/networking/reserved_ips_tools_test.go
+++ b/internal/networking/reserved_ips_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/netip"
 	"testing"
 
 	"reflect"
@@ -28,24 +29,35 @@ func setupReservedIPToolWithMocks(
 	return NewReservedIPTool(client)
 }
 
-func TestReservedIPTool_getReservedIPv4(t *testing.T) {
+func TestReservedIPTool_getReservedIP(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	testIPv4 := &godo.ReservedIP{IP: "192.0.2.1", Region: &godo.Region{Slug: "nyc3"}}
+	testIPv6 := &godo.ReservedIPV6{IP: "2604::2001", RegionSlug: "nyc3"}
 	tests := []struct {
 		name        string
 		ip          string
-		mockSetup   func(*MockReservedIPsService)
+		mockSetup   func(*MockReservedIPsService, *MockReservedIPV6sService)
 		expectError bool
 	}{
 		{
 			name: "Successful get IPv4",
 			ip:   "192.0.2.1",
-			mockSetup: func(m *MockReservedIPsService) {
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
 				m.EXPECT().
 					Get(gomock.Any(), "192.0.2.1").
 					Return(testIPv4, nil, nil).
+					Times(1)
+			},
+		},
+		{
+			name: "Successful get IPv6",
+			ip:   "2604::2001",
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
+				m6.EXPECT().
+					Get(gomock.Any(), "2604::2001").
+					Return(testIPv6, nil, nil).
 					Times(1)
 			},
 		},
@@ -58,7 +70,7 @@ func TestReservedIPTool_getReservedIPv4(t *testing.T) {
 		{
 			name: "API error",
 			ip:   "203.0.113.1",
-			mockSetup: func(m *MockReservedIPsService) {
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
 				m.EXPECT().
 					Get(gomock.Any(), "203.0.113.1").
 					Return(nil, nil, errors.New("api error")).
@@ -73,7 +85,7 @@ func TestReservedIPTool_getReservedIPv4(t *testing.T) {
 			mockIPv4 := NewMockReservedIPsService(ctrl)
 			mockIPv6 := NewMockReservedIPV6sService(ctrl)
 			if tc.mockSetup != nil {
-				tc.mockSetup(mockIPv4)
+				tc.mockSetup(mockIPv4, mockIPv6)
 			}
 			tool := setupReservedIPToolWithMocks(mockIPv4, mockIPv6, nil, nil)
 			args := map[string]any{}
@@ -81,7 +93,7 @@ func TestReservedIPTool_getReservedIPv4(t *testing.T) {
 				args["IP"] = tc.ip
 			}
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: args}}
-			resp, err := tool.getReservedIPv4(context.Background(), req)
+			resp, err := tool.getReservedIP(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)
@@ -90,14 +102,21 @@ func TestReservedIPTool_getReservedIPv4(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.False(t, resp.IsError)
-			var outIP godo.ReservedIP
-			require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &outIP))
-			require.Equal(t, testIPv4.IP, outIP.IP)
+			if netip.MustParseAddr(tc.ip).Is4() {
+				var outIP godo.ReservedIP
+				require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &outIP))
+				require.Equal(t, testIPv4.IP, outIP.IP)
+			} else {
+				var outIP godo.ReservedIPV6
+				require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &outIP))
+				require.Equal(t, testIPv6.IP, outIP.IP)
+
+			}
 		})
 	}
 }
 
-func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
+func TestReservedIPTool_listReservedIPs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -105,17 +124,21 @@ func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
 		{IP: "192.0.2.1", Region: &godo.Region{Slug: "nyc3"}},
 		{IP: "192.0.2.2", Region: &godo.Region{Slug: "sfo2"}},
 	}
+	testIPv6s := []godo.ReservedIPV6{
+		{IP: "2001::2002", RegionSlug: "nyc3"},
+		{IP: "2001::2003", RegionSlug: "sfo2"},
+	}
 	tests := []struct {
 		name        string
 		args        map[string]any
-		mockSetup   func(*MockReservedIPsService)
+		mockSetup   func(*MockReservedIPsService, *MockReservedIPV6sService)
 		expectError bool
 		expectIPs   []string
 	}{
 		{
 			name: "List IPv4s default pagination",
-			args: map[string]any{},
-			mockSetup: func(m *MockReservedIPsService) {
+			args: map[string]any{"Type": "ipv4"},
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
 				m.EXPECT().
 					List(gomock.Any(), &godo.ListOptions{Page: 1, PerPage: 20}).
 					Return(testIPs, nil, nil).
@@ -124,9 +147,20 @@ func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
 			expectIPs: []string{"192.0.2.1", "192.0.2.2"},
 		},
 		{
+			name: "List IPv6s default pagination",
+			args: map[string]any{"Type": "ipv6"},
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
+				m6.EXPECT().
+					List(gomock.Any(), &godo.ListOptions{Page: 1, PerPage: 20}).
+					Return(testIPv6s, nil, nil).
+					Times(1)
+			},
+			expectIPs: []string{"2001::2002", "2001::2003"},
+		},
+		{
 			name: "List IPv4s custom pagination",
-			args: map[string]any{"Page": float64(2), "PerPage": float64(1)},
-			mockSetup: func(m *MockReservedIPsService) {
+			args: map[string]any{"Page": float64(2), "PerPage": float64(1), "Type": "ipv4"},
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
 				m.EXPECT().
 					List(gomock.Any(), &godo.ListOptions{Page: 2, PerPage: 1}).
 					Return(testIPs[:1], nil, nil).
@@ -136,8 +170,8 @@ func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
 		},
 		{
 			name: "API error",
-			args: map[string]any{},
-			mockSetup: func(m *MockReservedIPsService) {
+			args: map[string]any{"Type": "ipv4"},
+			mockSetup: func(m *MockReservedIPsService, m6 *MockReservedIPV6sService) {
 				m.EXPECT().
 					List(gomock.Any(), &godo.ListOptions{Page: 1, PerPage: 20}).
 					Return(nil, nil, errors.New("api error")).
@@ -152,11 +186,11 @@ func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
 			mockIPv4 := NewMockReservedIPsService(ctrl)
 			mockIPv6 := NewMockReservedIPV6sService(ctrl)
 			if tc.mockSetup != nil {
-				tc.mockSetup(mockIPv4)
+				tc.mockSetup(mockIPv4, mockIPv6)
 			}
 			tool := setupReservedIPToolWithMocks(mockIPv4, mockIPv6, nil, nil)
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.listReservedIPv4s(context.Background(), req)
+			resp, err := tool.listReservedIPs(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)
@@ -165,161 +199,25 @@ func TestReservedIPTool_listReservedIPv4s(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.False(t, resp.IsError)
-			var out []godo.ReservedIP
-			require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &out))
-			gotIPs := make([]string, len(out))
-			for i, ip := range out {
-				gotIPs[i] = ip.IP
-			}
-			require.True(t, reflect.DeepEqual(tc.expectIPs, gotIPs))
-		})
-	}
-}
 
-func TestReservedIPTool_listReservedIPv6s(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+			if tc.args["Type"] == "ipv4" {
+				var out []godo.ReservedIP
+				require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &out))
+				gotIPs := make([]string, len(out))
+				for i, ip := range out {
+					gotIPs[i] = ip.IP
+				}
+				require.True(t, reflect.DeepEqual(tc.expectIPs, gotIPs))
+			} else {
+				var out []godo.ReservedIPV6
+				require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &out))
+				gotIPs := make([]string, len(out))
+				for i, ip := range out {
+					gotIPs[i] = ip.IP
+				}
+				require.True(t, reflect.DeepEqual(tc.expectIPs, gotIPs))
 
-	testIPs := []godo.ReservedIPV6{
-		{IP: "2001:db8::1", RegionSlug: "nyc3"},
-		{IP: "2001:db8::2", RegionSlug: "sfo2"},
-	}
-	tests := []struct {
-		name        string
-		args        map[string]any
-		mockSetup   func(*MockReservedIPV6sService)
-		expectError bool
-		expectIPs   []string
-	}{
-		{
-			name: "List IPv6s default pagination",
-			args: map[string]any{},
-			mockSetup: func(m *MockReservedIPV6sService) {
-				m.EXPECT().
-					List(gomock.Any(), &godo.ListOptions{Page: 1, PerPage: 20}).
-					Return(testIPs, nil, nil).
-					Times(1)
-			},
-			expectIPs: []string{"2001:db8::1", "2001:db8::2"},
-		},
-		{
-			name: "List IPv6s custom pagination",
-			args: map[string]any{"Page": float64(2), "PerPage": float64(1)},
-			mockSetup: func(m *MockReservedIPV6sService) {
-				m.EXPECT().
-					List(gomock.Any(), &godo.ListOptions{Page: 2, PerPage: 1}).
-					Return(testIPs[:1], nil, nil).
-					Times(1)
-			},
-			expectIPs: []string{"2001:db8::1"},
-		},
-		{
-			name: "API error",
-			args: map[string]any{},
-			mockSetup: func(m *MockReservedIPV6sService) {
-				m.EXPECT().
-					List(gomock.Any(), &godo.ListOptions{Page: 1, PerPage: 20}).
-					Return(nil, nil, errors.New("api error")).
-					Times(1)
-			},
-			expectError: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mockIPv4 := NewMockReservedIPsService(ctrl)
-			mockIPv6 := NewMockReservedIPV6sService(ctrl)
-			if tc.mockSetup != nil {
-				tc.mockSetup(mockIPv6)
 			}
-			tool := setupReservedIPToolWithMocks(mockIPv4, mockIPv6, nil, nil)
-			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.listReservedIPv6s(context.Background(), req)
-			if tc.expectError {
-				require.NotNil(t, resp)
-				require.True(t, resp.IsError)
-				return
-			}
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.False(t, resp.IsError)
-			var out []godo.ReservedIPV6
-			require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &out))
-			gotIPs := make([]string, len(out))
-			for i, ip := range out {
-				gotIPs[i] = ip.IP
-			}
-			require.True(t, reflect.DeepEqual(tc.expectIPs, gotIPs))
-		})
-	}
-}
-
-func TestReservedIPTool_getReservedIPv6(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	testIPv6 := &godo.ReservedIPV6{IP: "2001:db8::1", RegionSlug: "nyc3"}
-	tests := []struct {
-		name        string
-		ip          string
-		mockSetup   func(*MockReservedIPV6sService)
-		expectError bool
-	}{
-		{
-			name: "Successful get IPv6",
-			ip:   "2001:db8::1",
-			mockSetup: func(m *MockReservedIPV6sService) {
-				m.EXPECT().
-					Get(gomock.Any(), "2001:db8::1").
-					Return(testIPv6, nil, nil).
-					Times(1)
-			},
-		},
-		{
-			name:        "Missing IP argument",
-			ip:          "",
-			mockSetup:   nil,
-			expectError: true,
-		},
-		{
-			name: "API error",
-			ip:   "2001:db8::dead:beef",
-			mockSetup: func(m *MockReservedIPV6sService) {
-				m.EXPECT().
-					Get(gomock.Any(), "2001:db8::dead:beef").
-					Return(nil, nil, errors.New("api error")).
-					Times(1)
-			},
-			expectError: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mockIPv4 := NewMockReservedIPsService(ctrl)
-			mockIPv6 := NewMockReservedIPV6sService(ctrl)
-			if tc.mockSetup != nil {
-				tc.mockSetup(mockIPv6)
-			}
-			tool := setupReservedIPToolWithMocks(mockIPv4, mockIPv6, nil, nil)
-			args := map[string]any{}
-			if tc.name != "Missing IP argument" {
-				args["IP"] = tc.ip
-			}
-			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: args}}
-			resp, err := tool.getReservedIPv6(context.Background(), req)
-			if tc.expectError {
-				require.NotNil(t, resp)
-				require.True(t, resp.IsError)
-				return
-			}
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.False(t, resp.IsError)
-			var outIP godo.ReservedIPV6
-			require.NoError(t, json.Unmarshal([]byte(resp.Content[0].(mcp.TextContent).Text), &outIP))
-			require.Equal(t, testIPv6.IP, outIP.IP)
 		})
 	}
 }

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -67,7 +67,8 @@ func registerNetworkingTools(s *server.MCPServer, c *godo.Client) error {
 	s.AddTools(networking.NewDomainsTool(c).Tools()...)
 	s.AddTools(networking.NewFirewallTool(c).Tools()...)
 	s.AddTools(networking.NewReservedIPTool(c).Tools()...)
-	s.AddTools(networking.NewPartnerAttachmentTool(c).Tools()...)
+	// Partner attachments doesn't have much users so this has been disabled
+	// s.AddTools(networking.NewPartnerAttachmentTool(c).Tools()...)
 	s.AddTools(networking.NewVPCTool(c).Tools()...)
 	s.AddTools(networking.NewVPCPeeringTool(c).Tools()...)
 	return nil


### PR DESCRIPTION
Partner network attachment is a very recent product targeting very niche customers so it has been disabled from being registered, such networking tools can be enabled in future when MCP clients can support more tools.  With this we are exactly at 40 tools.

Fixes #80