### PR TITLE
feat: add function to retrieve available Kubernetes options

### DIFF
--- a/internal/doks/doks.go
+++ b/internal/doks/doks.go
@@ -653,6 +653,23 @@ func (d *DoksTool) recycleDOKSNodes(ctx context.Context, req mcp.CallToolRequest
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully recycled %d nodes in node pool %s", len(nodeIDs), nodePoolID)), nil
 }
 
+// getKubernetesOptions gets available Kubernetes options including versions, regions, and sizes
+func (d *DoksTool) getKubernetesOptions(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Make the API call to get Kubernetes options
+	options, _, err := d.client.Kubernetes.GetOptions(ctx)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to get kubernetes options", err), nil
+	}
+
+	// Marshal the response
+	optionsJSON, err := json.MarshalIndent(options, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to marshal kubernetes options", err), nil
+	}
+
+	return mcp.NewToolResultText(string(optionsJSON)), nil
+}
+
 // getDayFromString converts a day string to the format expected by the API
 func getDayFromString(day string) int {
 	// Normalize the day string
@@ -832,6 +849,12 @@ func (d *DoksTool) Tools() []server.ServerTool {
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
 				mcp.WithArray("NodeIDs", mcp.Required(), mcp.Description("List of node IDs to recycle")),
+			),
+		},
+		{
+			Handler: d.getKubernetesOptions,
+			Tool: mcp.NewTool("doks-list-options",
+				mcp.WithDescription("List available Kubernetes options including versions, regions, and sizes"),
 			),
 		},
 	}


### PR DESCRIPTION
This pull request adds a new feature to the DOKS tool, allowing users to list available Kubernetes options such as versions, regions, and sizes. The main changes include the implementation of the handler function and its registration as a new tool.

**New functionality:**

* Added a new method `getKubernetesOptions` to the `DoksTool` struct, which retrieves Kubernetes options (versions, regions, sizes) from the DigitalOcean API and returns them as formatted JSON.

**Tool registration:**

* Registered the new handler as the `doks-list-options` tool in the `Tools()` method, making it available for use with a description of its purpose.