### PR TITLE
Lower pagination to reflect default pagination

### DIFF
--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -18,7 +18,7 @@ import (
 var eFS embed.FS
 
 const (
-	defaultPageSize = 30 // Default page size for listing apps
+	defaultPageSize = 20 // Default page size for listing apps
 	defaultPage     = 1
 )
 


### PR DESCRIPTION
DigitalOcean rest api documentation says the default is 20. I think the MCP should be consistent with that. 

https://docs.digitalocean.com/reference/api/digitalocean/#section/Introduction/Links-and-Pagination