### PR TITLE
fix: Updated the mock to return a DatabaseOptions struct with an Engi…

### DIFF
--- a/internal/dbaas/cluster_test.go
+++ b/internal/dbaas/cluster_test.go
@@ -182,7 +182,11 @@ func TestClusterTool_listOptions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mocks.NewMockDatabasesService(ctrl)
-	mockDB.EXPECT().ListOptions(gomock.Any()).Return(&godo.DatabaseOptions{}, nil, nil)
+	mockDB.EXPECT().ListOptions(gomock.Any()).Return(&godo.DatabaseOptions{
+		Engines: map[string]godo.DatabaseEngineOptions{
+			"pg": {},
+		},
+	}, nil, nil)
 	client := &godo.Client{}
 	client.Databases = mockDB
 	ct := &ClusterTool{client: client}


### PR DESCRIPTION
The test was asserting that the response contains "pg", but the mock returned an empty DatabaseOptions{} struct, causing the test to fail.
The test TestClusterTool_listOptions is checking if the response contains "pg", but the mock returns an empty DatabaseOptions{} struct. This test will always fail because an empty struct won't contain "pg" in its JSON representation.

Fix: Updated the mock to return a DatabaseOptions struct with an Engines map containing "pg", so the assertion will now pass correctly.