### PR TITLE
configure client side retries. configure godo retries. allow no ssh k…

### DIFF
--- a/testing/e2e_droplet_actions_test.go
+++ b/testing/e2e_droplet_actions_test.go
@@ -4,15 +4,18 @@ package testing
 
 import (
 	"fmt"
-	"mcp-digitalocean/internal/testhelpers"
 	"testing"
 	"time"
+
+	"mcp-digitalocean/internal/testhelpers"
 
 	"github.com/digitalocean/godo"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDropletReboot(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -23,6 +26,8 @@ func TestDropletReboot(t *testing.T) {
 }
 
 func TestDropletPowerCycle(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -33,6 +38,8 @@ func TestDropletPowerCycle(t *testing.T) {
 }
 
 func TestDropletSnapshotAction(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -61,6 +68,8 @@ func TestDropletSnapshotAction(t *testing.T) {
 }
 
 func TestDropletRename(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -86,6 +95,8 @@ func TestDropletRename(t *testing.T) {
 }
 
 func TestDropletEnableIPv6(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -104,6 +115,8 @@ func TestDropletEnableIPv6(t *testing.T) {
 }
 
 func TestDropletEnableBackups(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -131,6 +144,8 @@ func TestDropletEnableBackups(t *testing.T) {
 }
 
 func TestDropletActionTool(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 

--- a/testing/e2e_droplet_core_test.go
+++ b/testing/e2e_droplet_core_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestDropletLifecycle(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -44,6 +46,8 @@ func TestDropletLifecycle(t *testing.T) {
 }
 
 func TestDropletSnapshot(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, gclient, teardown := setupTest(t)
 	defer teardown()
 
@@ -75,6 +79,8 @@ func TestDropletSnapshot(t *testing.T) {
 }
 
 func TestDropletRebuildBySlug(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, _, teardown := setupTest(t)
 	defer teardown()
 
@@ -115,6 +121,8 @@ func TestDropletRebuildBySlug(t *testing.T) {
 }
 
 func TestDropletRestore(t *testing.T) {
+	t.Parallel()
+
 	ctx, c, _, teardown := setupTest(t)
 	defer teardown()
 


### PR DESCRIPTION
## Summary

This PR improves the resilience and performance of the E2E test suite by configuring proper client-side timeouts and retries, allowing tests to run without pre-existing SSH keys, and enabling parallel execution for droplet tests.

## Changes

- **Configure client-side retries**: Configured the `godo` client in test helpers with a strict 30-second HTTP timeout to prevent indefinite hangs on zombie connections.
- **Configure godo retries**: Added `godo.RetryConfig` to automatically retry requests on 429 (rate limit) and 5xx errors, improving stability against temporary API flakes.
- **Allow no SSH key for droplet tests**: Updated `getSSHKeys` to handle accounts with zero SSH keys gracefully, preventing immediate test failure for fresh accounts.
- **Run all droplet tests in parallel**: Enabled `t.Parallel()` for droplet lifecycle and action tests to significantly reduce the total runtime of the E2E suite.

## Motivation

The E2E tests were occasionally hanging indefinitely due to stalled HTTP/2 connections that never timed out. Additionally, the suite was brittle on fresh accounts (missing SSH keys) and took a long time to run sequentially. These changes ensure the test suite fails fast on real network issues, recovers from transient API errors, and runs much faster.
