### PR TITLE
CON-13190 Add e2e tests for DOKS (Create, Get, Delete) cluster

### DIFF
--- a/testing/e2e_doks_test.go
+++ b/testing/e2e_doks_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
+	"github.com/google/uuid"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestCreateCluster(t *testing.T) {
 	defer c.Close()
 
 	create := godo.KubernetesClusterCreateRequest{
-		Name:        "mcp-test-cluster",
+		Name:        uuid.New().String(),
 		RegionSlug:  "sfo3",
 		VersionSlug: "latest",
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{


### PR DESCRIPTION
Add DOKS e2e tests covering (Create, Get and Delete) operations. 

Note: The new e2e test does not wait until the cluster finished its creation. 

```shell
=== RUN   TestCreateCluster
created doks cluster: {0db4589d-fdf8-45a1-ba8f-b69fcd96d2fa mcp-test-cluster sfo3 1.34.1-do.0 10.155.0.0/16 10.124.128.0/19   [k8s k8s:0db4589d-fdf8-45a1-ba8f-b69fcd96d2fa] 9d233828-d7b2-46df-9d70-42370b508c51 false [0x14000616fa0] 0x14000163f50 false false false <nil> <nil> 0x140003161d8 0x140003161e0 0x140003161f0 0x140003161f8 0x14000316200 0x14000081ea0 2025-11-26 22:29:59 +0000 UTC 2025-11-26 22:29:59 +0000 UTC}+doks cluster 0db4589d-fdf8-45a1-ba8f-b69fcd96d2fa deleted--- PASS: TestCreateCluster (2.65s)
PASS

Process finished with the exit code 0
```