### PR TITLE
feat: add ToolConfig system and migrate basic droplet tools

### DIFF
--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -22,107 +22,6 @@ func NewDropletTool(client func(ctx context.Context) (*godo.Client, error)) *Dro
 	}
 }
 
-// CreateDroplet creates a new droplet
-func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args := req.GetArguments()
-	dropletName := args["Name"].(string)
-	size := args["Size"].(string)
-	imageID := args["ImageID"].(float64)
-	region := args["Region"].(string)
-	backup, _ := args["Backup"].(bool)         // Defaults to false
-	monitoring, _ := args["Monitoring"].(bool) // Defaults to false
-
-	// Handle SSH keys if provided
-	var sshKeys []godo.DropletCreateSSHKey
-	if sshKeysRaw, ok := args["SSHKeys"]; ok && sshKeysRaw != nil {
-		sshKeysList := sshKeysRaw.([]interface{})
-		for _, key := range sshKeysList {
-			switch v := key.(type) {
-			case float64:
-				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: int(v)})
-			case string:
-				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: v})
-			}
-		}
-	}
-
-	// Handle tags if provided
-	var tags []string
-	if tagsRaw, ok := args["Tags"]; ok && tagsRaw != nil {
-		tagsList := tagsRaw.([]interface{})
-		for _, tag := range tagsList {
-			if tagStr, ok := tag.(string); ok {
-				tags = append(tags, tagStr)
-			}
-		}
-	}
-
-	// Create the droplet
-	dropletCreateRequest := &godo.DropletCreateRequest{
-		Name:       dropletName,
-		Size:       size,
-		Image:      godo.DropletCreateImage{ID: int(imageID)},
-		Region:     region,
-		Backups:    backup,
-		Monitoring: monitoring,
-		SSHKeys:    sshKeys,
-		Tags:       tags,
-	}
-
-	client, err := d.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
-	}
-
-	droplet, _, err := client.Droplets.Create(ctx, dropletCreateRequest)
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("droplet create", err), nil
-	}
-	jsonDroplet, err := json.MarshalIndent(droplet, "", "  ")
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("json marshal", err), nil
-	}
-	return mcp.NewToolResultText(string(jsonDroplet)), nil
-}
-
-// deleteDroplet deletes a droplet
-func (d *DropletTool) deleteDroplet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	dropletID := req.GetArguments()["ID"].(float64)
-
-	client, err := d.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
-	}
-
-	_, err = client.Droplets.Delete(ctx, int(dropletID))
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("api error", err), nil
-	}
-	return mcp.NewToolResultText("Droplet deleted successfully"), nil
-}
-
-// getDropletNeighbors gets a droplet's neighbors
-func (d *DropletTool) getDropletNeighbors(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	dropletID := req.GetArguments()["ID"].(float64)
-
-	client, err := d.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
-	}
-
-	neighbors, _, err := client.Droplets.Neighbors(ctx, int(dropletID))
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("api error", err), nil
-	}
-
-	jsonNeighbors, err := json.MarshalIndent(neighbors, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal error: %w", err)
-	}
-
-	return mcp.NewToolResultText(string(jsonNeighbors)), nil
-}
-
 // enablePrivateNetworking enables private networking on a droplet
 func (d *DropletTool) enablePrivateNetworking(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dropletID := req.GetArguments()["ID"].(float64)
@@ -171,29 +70,6 @@ func (d *DropletTool) getDropletKernels(ctx context.Context, req mcp.CallToolReq
 	}
 
 	return mcp.NewToolResultText(string(jsonKernels)), nil
-}
-
-// Tools returns a list of tool functions
-func (d *DropletTool) getDropletByID(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	id, ok := req.GetArguments()["ID"].(float64)
-	if !ok {
-		return mcp.NewToolResultError("Droplet ID is required"), nil
-	}
-
-	client, err := d.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
-	}
-
-	droplet, _, err := client.Droplets.Get(ctx, int(id))
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("api error", err), nil
-	}
-	jsonData, err := json.MarshalIndent(droplet, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal error: %w", err)
-	}
-	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
 // getDropletBackupPolicy returns the backup policy for a droplet.
@@ -246,90 +122,16 @@ func (d *DropletTool) getDropletActionByID(ctx context.Context, req mcp.CallTool
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
-// getDroplets lists all droplets for a user
-func (d *DropletTool) getDroplets(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	page, ok := req.GetArguments()["Page"].(float64)
-	if !ok {
-		page = 1
-	}
-	perPage, ok := req.GetArguments()["PerPage"].(float64)
-	if !ok {
-		perPage = 50
-	}
-
-	opt := &godo.ListOptions{
-		Page:    int(page),
-		PerPage: int(perPage),
-	}
-
-	client, err := d.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
-	}
-
-	droplets, _, err := client.Droplets.List(ctx, opt)
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("api error", err), nil
-	}
-
-	filteredDroplets := make([]map[string]any, len(droplets))
-	for i, droplet := range droplets {
-		filteredDroplets[i] = map[string]any{
-			"id":                 droplet.ID,
-			"name":               droplet.Name,
-			"memory":             droplet.Memory,
-			"vcpus":              droplet.Vcpus,
-			"disk":               droplet.Disk,
-			"region":             droplet.Region,
-			"image":              droplet.Image,
-			"size":               droplet.Size,
-			"size_slug":          droplet.SizeSlug,
-			"backup_ids":         droplet.BackupIDs,
-			"next_backup_window": droplet.NextBackupWindow,
-			"snapshot_ids":       droplet.SnapshotIDs,
-			"features":           droplet.Features,
-			"locked":             droplet.Locked,
-			"status":             droplet.Status,
-			"networks":           droplet.Networks,
-			"created_at":         droplet.Created,
-			"kernel":             droplet.Kernel,
-			"tags":               droplet.Tags,
-			"volume_ids":         droplet.VolumeIDs,
-			"vpc_uuid":           droplet.VPCUUID,
-		}
-	}
-
-	jsonData, err := json.MarshalIndent(filteredDroplets, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal error: %w", err)
-	}
-
-	return mcp.NewToolResultText(string(jsonData)), nil
-}
-
 func (d *DropletTool) Tools() []server.ServerTool {
 	tools := []server.ServerTool{
-		{
-			Handler: d.createDroplet,
-			Tool: mcp.NewTool("droplet-create",
-				mcp.WithDescription("Create a new droplet"),
-				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
-				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the droplet size (e.g., s-1vcpu-1gb)")),
-				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image to use")),
-				mcp.WithString("Region", mcp.Required(), mcp.Description("Slug of the region (e.g., nyc3)")),
-				mcp.WithBoolean("Backup", mcp.DefaultBool(false), mcp.Description("Whether to enable backups")),
-				mcp.WithBoolean("Monitoring", mcp.DefaultBool(false), mcp.Description("Whether to enable monitoring")),
-				mcp.WithArray("SSHKeys", mcp.Description("Array of SSH key IDs (numbers) or fingerprints (strings) to add to the droplet")),
-				mcp.WithArray("Tags", mcp.Description("Array of tag names to apply to the droplet")),
-			),
-		},
-		{
-			Handler: d.deleteDroplet,
-			Tool: mcp.NewTool("droplet-delete",
-				mcp.WithDescription("Delete a droplet"),
-				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to delete")),
-			),
-		},
+		// Basic droplet tools using new ToolConfig system
+		BuildServerTool(dropletListConfig(), d.client),
+		BuildServerTool(dropletGetConfig(), d.client),
+		BuildServerTool(dropletCreateConfig(), d.client),
+		BuildServerTool(dropletDeleteConfig(), d.client),
+		BuildServerTool(dropletNeighborsConfig(), d.client),
+
+		// Legacy tools (to be migrated in future PRs)
 		{
 			Handler: d.enablePrivateNetworking,
 			Tool: mcp.NewTool("droplet-enable-private-net",
@@ -344,13 +146,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
 		},
-		{
-			Handler: d.getDropletByID,
-			Tool: mcp.NewTool("droplet-get",
-				mcp.WithDescription("Get a droplet by its ID"),
-				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Droplet ID")),
-			),
-		},
+
 		{
 			Handler: d.getDropletBackupPolicy,
 			Tool: mcp.NewTool("droplet-backup-policy",
@@ -364,14 +160,6 @@ func (d *DropletTool) Tools() []server.ServerTool {
 				mcp.WithDescription("Get a droplet action by droplet ID and action ID"),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("Droplet ID")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("Action ID")),
-			),
-		},
-		{
-			Handler: d.getDroplets,
-			Tool: mcp.NewTool("droplet-list",
-				mcp.WithDescription("List all droplets for the user. Supports pagination."),
-				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
-				mcp.WithNumber("PerPage", mcp.DefaultNumber(50), mcp.Description("Items per page")),
 			),
 		},
 	}

--- a/pkg/registry/droplet/droplet_tools_test.go
+++ b/pkg/registry/droplet/droplet_tools_test.go
@@ -22,6 +22,21 @@ func setupDropletToolWithMocks(droplets *MockDropletsService, actions *MockDropl
 	return NewDropletTool(client)
 }
 
+// findToolByName finds a tool handler by name from the Tools() list
+func findToolByName(tools []interface {
+	Handler(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+}, name string,
+) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	for _, tool := range tools {
+		if t, ok := tool.(interface{ GetTool() mcp.Tool }); ok {
+			if t.GetTool().Name == name {
+				return tool.Handler
+			}
+		}
+	}
+	return nil
+}
+
 func TestDropletTool_createDroplet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -95,8 +110,17 @@ func TestDropletTool_createDroplet(t *testing.T) {
 				tc.mockSetup(mockDroplets)
 			}
 			tool := setupDropletToolWithMocks(mockDroplets, mockActions)
+			tools := tool.Tools()
+			var handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+			for _, t := range tools {
+				if t.Tool.Name == "droplet-create" {
+					handler = t.Handler
+					break
+				}
+			}
+			require.NotNil(t, handler, "droplet-create tool not found")
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.createDroplet(context.Background(), req)
+			resp, err := handler(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)
@@ -160,8 +184,17 @@ func TestDropletTool_getDropletByID(t *testing.T) {
 				tc.mockSetup(mockDroplets)
 			}
 			tool := setupDropletToolWithMocks(mockDroplets, mockActions)
+			tools := tool.Tools()
+			var handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+			for _, t := range tools {
+				if t.Tool.Name == "droplet-get" {
+					handler = t.Handler
+					break
+				}
+			}
+			require.NotNil(t, handler, "droplet-get tool not found")
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.getDropletByID(context.Background(), req)
+			resp, err := handler(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)
@@ -294,8 +327,17 @@ func TestDropletTool_deleteDroplet(t *testing.T) {
 				tc.mockSetup(mockDroplets)
 			}
 			tool := setupDropletToolWithMocks(mockDroplets, mockActions)
+			tools := tool.Tools()
+			var handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+			for _, t := range tools {
+				if t.Tool.Name == "droplet-delete" {
+					handler = t.Handler
+					break
+				}
+			}
+			require.NotNil(t, handler, "droplet-delete tool not found")
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.deleteDroplet(context.Background(), req)
+			resp, err := handler(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)
@@ -368,8 +410,17 @@ func TestDropletTool_getDroplets(t *testing.T) {
 				tc.mockSetup(mockDroplets)
 			}
 			tool := setupDropletToolWithMocks(mockDroplets, mockActions)
+			tools := tool.Tools()
+			var handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+			for _, t := range tools {
+				if t.Tool.Name == "droplet-list" {
+					handler = t.Handler
+					break
+				}
+			}
+			require.NotNil(t, handler, "droplet-list tool not found")
 			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
-			resp, err := tool.getDroplets(context.Background(), req)
+			resp, err := handler(context.Background(), req)
 			if tc.expectError {
 				require.NotNil(t, resp)
 				require.True(t, resp.IsError)

--- a/pkg/registry/droplet/tool_config.go
+++ b/pkg/registry/droplet/tool_config.go
@@ -1,0 +1,148 @@
+package droplet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// ArgumentType represents the type of an argument
+type ArgumentType string
+
+const (
+	ArgumentTypeString  ArgumentType = "string"
+	ArgumentTypeNumber  ArgumentType = "number"
+	ArgumentTypeBoolean ArgumentType = "boolean"
+	ArgumentTypeArray   ArgumentType = "array"
+	ArgumentTypeObject  ArgumentType = "object"
+)
+
+// ArgumentConfig defines the configuration for a tool argument
+type ArgumentConfig struct {
+	Name         string
+	Type         ArgumentType
+	Description  string
+	Required     bool
+	DefaultValue interface{}
+}
+
+// ToolConfig defines the configuration for a tool
+type ToolConfig struct {
+	Name        string
+	Description string
+	Arguments   []ArgumentConfig
+	Handler     HandlerFunc
+}
+
+// HandlerFunc is the function signature for tool handlers
+type HandlerFunc func(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error)
+
+// BuildMCPTool converts a ToolConfig into an MCP Tool definition
+func (tc *ToolConfig) BuildMCPTool() mcp.Tool {
+	properties := make(map[string]interface{})
+	required := []string{}
+
+	for _, arg := range tc.Arguments {
+		prop := map[string]interface{}{
+			"type":        string(arg.Type),
+			"description": arg.Description,
+		}
+
+		if arg.DefaultValue != nil {
+			prop["default"] = arg.DefaultValue
+		}
+
+		properties[arg.Name] = prop
+
+		if arg.Required {
+			required = append(required, arg.Name)
+		}
+	}
+
+	inputSchema := mcp.ToolInputSchema{
+		Type:       "object",
+		Properties: properties,
+	}
+
+	if len(required) > 0 {
+		inputSchema.Required = required
+	}
+
+	return mcp.Tool{
+		Name:        tc.Name,
+		Description: tc.Description,
+		InputSchema: inputSchema,
+	}
+}
+
+// GetArgumentString safely retrieves a string argument
+func GetArgumentString(args map[string]interface{}, name string) string {
+	if val, ok := args[name]; ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+// GetArgumentNumber safely retrieves a number argument as int
+func GetArgumentNumber(args map[string]interface{}, name string) int {
+	if val, ok := args[name]; ok {
+		switch v := val.(type) {
+		case float64:
+			return int(v)
+		case int:
+			return v
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				return int(i)
+			}
+		}
+	}
+	return 0
+}
+
+// GetArgumentBoolean safely retrieves a boolean argument
+func GetArgumentBoolean(args map[string]interface{}, name string) bool {
+	if val, ok := args[name]; ok {
+		if b, ok := val.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+// GetArgumentArray safely retrieves an array argument
+func GetArgumentArray(args map[string]interface{}, name string) []interface{} {
+	if val, ok := args[name]; ok {
+		if arr, ok := val.([]interface{}); ok {
+			return arr
+		}
+	}
+	return nil
+}
+
+// GetArgumentObject safely retrieves an object argument
+func GetArgumentObject(args map[string]interface{}, name string) map[string]interface{} {
+	if val, ok := args[name]; ok {
+		if obj, ok := val.(map[string]interface{}); ok {
+			return obj
+		}
+	}
+	return nil
+}
+
+// ValidateArguments validates that all required arguments are present
+func (tc *ToolConfig) ValidateArguments(args map[string]interface{}) error {
+	for _, arg := range tc.Arguments {
+		if arg.Required {
+			if _, ok := args[arg.Name]; !ok {
+				return fmt.Errorf("missing required argument: %s", arg.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/registry/droplet/tool_definitions.go
+++ b/pkg/registry/droplet/tool_definitions.go
@@ -1,0 +1,294 @@
+package droplet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+)
+
+// dropletListConfig returns the configuration for listing droplets
+func dropletListConfig() *ToolConfig {
+	return &ToolConfig{
+		Name:        "droplet-list",
+		Description: "List all droplets for the user. Supports pagination.",
+		Arguments: []ArgumentConfig{
+			{
+				Name:         "Page",
+				Type:         ArgumentTypeNumber,
+				Description:  "Page number",
+				Required:     false,
+				DefaultValue: 1.0,
+			},
+			{
+				Name:         "PerPage",
+				Type:         ArgumentTypeNumber,
+				Description:  "Items per page",
+				Required:     false,
+				DefaultValue: 50.0,
+			},
+		},
+		Handler: handleDropletList,
+	}
+}
+
+// dropletGetConfig returns the configuration for getting a droplet by ID
+func dropletGetConfig() *ToolConfig {
+	return &ToolConfig{
+		Name:        "droplet-get",
+		Description: "Get a droplet by its ID",
+		Arguments: []ArgumentConfig{
+			{
+				Name:        "ID",
+				Type:        ArgumentTypeNumber,
+				Description: "Droplet ID",
+				Required:    true,
+			},
+		},
+		Handler: handleDropletGet,
+	}
+}
+
+// dropletCreateConfig returns the configuration for creating a droplet
+func dropletCreateConfig() *ToolConfig {
+	return &ToolConfig{
+		Name:        "droplet-create",
+		Description: "Create a new droplet",
+		Arguments: []ArgumentConfig{
+			{
+				Name:        "Name",
+				Type:        ArgumentTypeString,
+				Description: "Name of the droplet",
+				Required:    true,
+			},
+			{
+				Name:        "Size",
+				Type:        ArgumentTypeString,
+				Description: "Slug of the droplet size (e.g., s-1vcpu-1gb)",
+				Required:    true,
+			},
+			{
+				Name:        "ImageID",
+				Type:        ArgumentTypeNumber,
+				Description: "ID of the image to use",
+				Required:    true,
+			},
+			{
+				Name:        "Region",
+				Type:        ArgumentTypeString,
+				Description: "Slug of the region (e.g., nyc3)",
+				Required:    true,
+			},
+			{
+				Name:         "Backup",
+				Type:         ArgumentTypeBoolean,
+				Description:  "Whether to enable backups",
+				Required:     false,
+				DefaultValue: false,
+			},
+			{
+				Name:         "Monitoring",
+				Type:         ArgumentTypeBoolean,
+				Description:  "Whether to enable monitoring",
+				Required:     false,
+				DefaultValue: false,
+			},
+			{
+				Name:        "SSHKeys",
+				Type:        ArgumentTypeArray,
+				Description: "Array of SSH key IDs (numbers) or fingerprints (strings) to add to the droplet",
+				Required:    false,
+			},
+			{
+				Name:        "Tags",
+				Type:        ArgumentTypeArray,
+				Description: "Array of tag names to apply to the droplet",
+				Required:    false,
+			},
+		},
+		Handler: handleDropletCreate,
+	}
+}
+
+// dropletDeleteConfig returns the configuration for deleting a droplet
+func dropletDeleteConfig() *ToolConfig {
+	return &ToolConfig{
+		Name:        "droplet-delete",
+		Description: "Delete a droplet",
+		Arguments: []ArgumentConfig{
+			{
+				Name:        "ID",
+				Type:        ArgumentTypeNumber,
+				Description: "ID of the droplet to delete",
+				Required:    true,
+			},
+		},
+		Handler: handleDropletDelete,
+	}
+}
+
+// dropletNeighborsConfig returns the configuration for getting droplet neighbors
+func dropletNeighborsConfig() *ToolConfig {
+	return &ToolConfig{
+		Name:        "droplet-neighbors",
+		Description: "Get a droplet's neighbors",
+		Arguments: []ArgumentConfig{
+			{
+				Name:        "ID",
+				Type:        ArgumentTypeNumber,
+				Description: "ID of the droplet",
+				Required:    true,
+			},
+		},
+		Handler: handleDropletNeighbors,
+	}
+}
+
+// handleDropletList handles listing droplets
+func handleDropletList(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error) {
+	page := GetArgumentNumber(args, "Page")
+	if page == 0 {
+		page = 1
+	}
+	perPage := GetArgumentNumber(args, "PerPage")
+	if perPage == 0 {
+		perPage = 50
+	}
+
+	opt := &godo.ListOptions{
+		Page:    page,
+		PerPage: perPage,
+	}
+
+	droplets, _, err := client.Droplets.List(ctx, opt)
+	if err != nil {
+		return nil, fmt.Errorf("api error: %w", err)
+	}
+
+	// Return filtered droplet data
+	filteredDroplets := make([]map[string]any, len(droplets))
+	for i, droplet := range droplets {
+		filteredDroplets[i] = map[string]any{
+			"id":                 droplet.ID,
+			"name":               droplet.Name,
+			"memory":             droplet.Memory,
+			"vcpus":              droplet.Vcpus,
+			"disk":               droplet.Disk,
+			"region":             droplet.Region,
+			"image":              droplet.Image,
+			"size":               droplet.Size,
+			"size_slug":          droplet.SizeSlug,
+			"backup_ids":         droplet.BackupIDs,
+			"next_backup_window": droplet.NextBackupWindow,
+			"snapshot_ids":       droplet.SnapshotIDs,
+			"features":           droplet.Features,
+			"locked":             droplet.Locked,
+			"status":             droplet.Status,
+			"networks":           droplet.Networks,
+			"created_at":         droplet.Created,
+			"kernel":             droplet.Kernel,
+			"tags":               droplet.Tags,
+			"volume_ids":         droplet.VolumeIDs,
+			"vpc_uuid":           droplet.VPCUUID,
+		}
+	}
+
+	return filteredDroplets, nil
+}
+
+// handleDropletGet handles getting a droplet by ID
+func handleDropletGet(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error) {
+	id := GetArgumentNumber(args, "ID")
+	if id == 0 {
+		return nil, fmt.Errorf("Droplet ID is required")
+	}
+
+	droplet, _, err := client.Droplets.Get(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("api error: %w", err)
+	}
+
+	return droplet, nil
+}
+
+// handleDropletCreate handles creating a new droplet
+func handleDropletCreate(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error) {
+	dropletName := GetArgumentString(args, "Name")
+	size := GetArgumentString(args, "Size")
+	imageID := GetArgumentNumber(args, "ImageID")
+	region := GetArgumentString(args, "Region")
+	backup := GetArgumentBoolean(args, "Backup")
+	monitoring := GetArgumentBoolean(args, "Monitoring")
+
+	// Handle SSH keys if provided
+	var sshKeys []godo.DropletCreateSSHKey
+	if sshKeysRaw := GetArgumentArray(args, "SSHKeys"); sshKeysRaw != nil {
+		for _, key := range sshKeysRaw {
+			switch v := key.(type) {
+			case float64:
+				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: int(v)})
+			case string:
+				sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: v})
+			}
+		}
+	}
+
+	// Handle tags if provided
+	var tags []string
+	if tagsRaw := GetArgumentArray(args, "Tags"); tagsRaw != nil {
+		for _, tag := range tagsRaw {
+			if tagStr, ok := tag.(string); ok {
+				tags = append(tags, tagStr)
+			}
+		}
+	}
+
+	// Create the droplet
+	dropletCreateRequest := &godo.DropletCreateRequest{
+		Name:       dropletName,
+		Size:       size,
+		Image:      godo.DropletCreateImage{ID: imageID},
+		Region:     region,
+		Backups:    backup,
+		Monitoring: monitoring,
+		SSHKeys:    sshKeys,
+		Tags:       tags,
+	}
+
+	droplet, _, err := client.Droplets.Create(ctx, dropletCreateRequest)
+	if err != nil {
+		return nil, fmt.Errorf("droplet create: %w", err)
+	}
+
+	return droplet, nil
+}
+
+// handleDropletDelete handles deleting a droplet
+func handleDropletDelete(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error) {
+	dropletID := GetArgumentNumber(args, "ID")
+	if dropletID == 0 {
+		return nil, fmt.Errorf("Droplet ID is required")
+	}
+
+	_, err := client.Droplets.Delete(ctx, dropletID)
+	if err != nil {
+		return nil, fmt.Errorf("api error: %w", err)
+	}
+
+	return "Droplet deleted successfully", nil
+}
+
+// handleDropletNeighbors handles getting a droplet's neighbors
+func handleDropletNeighbors(ctx context.Context, client *godo.Client, args map[string]interface{}) (interface{}, error) {
+	dropletID := GetArgumentNumber(args, "ID")
+	if dropletID == 0 {
+		return nil, fmt.Errorf("Droplet ID is required")
+	}
+
+	neighbors, _, err := client.Droplets.Neighbors(ctx, dropletID)
+	if err != nil {
+		return nil, fmt.Errorf("api error: %w", err)
+	}
+
+	return neighbors, nil
+}

--- a/pkg/registry/droplet/tool_helpers.go
+++ b/pkg/registry/droplet/tool_helpers.go
@@ -1,0 +1,56 @@
+package droplet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// GenericToolHandler creates a generic handler that wraps a ToolConfig handler
+// It handles client creation, argument validation, and response formatting
+func GenericToolHandler(config *ToolConfig, clientFactory func(ctx context.Context) (*godo.Client, error)) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Validate arguments
+		args := req.GetArguments()
+		if err := config.ValidateArguments(args); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// Get client
+		client, err := clientFactory(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+		}
+
+		// Call the handler
+		result, err := config.Handler(ctx, client, args)
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("api error", err), nil
+		}
+
+		// Handle string results directly
+		if str, ok := result.(string); ok {
+			return mcp.NewToolResultText(str), nil
+		}
+
+		// Marshal result to JSON for non-string results
+		jsonData, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("json marshal error: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonData)), nil
+	}
+}
+
+// BuildServerTool converts a ToolConfig into a server.ServerTool
+func BuildServerTool(config *ToolConfig, clientFactory func(ctx context.Context) (*godo.Client, error)) server.ServerTool {
+	return server.ServerTool{
+		Handler: GenericToolHandler(config, clientFactory),
+		Tool:    config.BuildMCPTool(),
+	}
+}


### PR DESCRIPTION
Add core configuration types and helper functions for building a declarative tool definition framework:

- ArgumentConfig: defines tool argument structure and validation
- ToolConfig: defines complete tool configuration with handler
- BuildMCPTool: converts ToolConfig to MCP Tool definition
- GetArgument* helpers: safely extract typed arguments
- ValidateArguments: validates required arguments are present

This infrastructure enables a more maintainable approach to tool definitions by separating configuration from MCP protocol handling.

No behavior changes - this is pure addition of new types and helper functions that will be used in subsequent PRs.

Related to droplet package refactoring effort. This PR refactored a subset of droplet tools to use the new format to show the pattern without making a massive PR. The idea is to make subsequent PRs to convert remaining droplet tools to the tool definition format. Once the conversion of existing tools is completed, additional tools mapping to godo APIs not yet integrated will be added using the tool definition format.