### PR TITLE
CON-13190 Fix DOKS cluster naming convention in e2e tests

### DIFF
--- a/testing/e2e_doks_test.go
+++ b/testing/e2e_doks_test.go
@@ -20,7 +20,7 @@ func TestCreateCluster(t *testing.T) {
 	defer c.Close()
 
 	create := godo.KubernetesClusterCreateRequest{
-		Name:        uuid.New().String(),
+		Name:        fmt.Sprintf("doks-%s", uuid.New().String()),
 		RegionSlug:  "sfo3",
 		VersionSlug: "latest",
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{


### PR DESCRIPTION
Fix the DOKS cluster naminv convention in e2e tests. With the current uuid naming, if the uuid starts with a numerical value, the cluster_spec.invalid name is returned from the DOKS api. This PR is forcing the `doks-` prefix for each e2e doks clusters . 