### PR TITLE
feat: add service category filtering to reduce context window usage

### DIFF
--- a/docs/SERVICE_FILTERING.md
+++ b/docs/SERVICE_FILTERING.md
@@ -1,0 +1,107 @@
+# Service Category Filtering
+
+The MCP DigitalOcean server supports granular tool filtering to reduce context window usage. By default, only "basic" tools are loaded for each service.
+
+## Usage
+
+```bash
+# Load basic tools for all services (default)
+--services droplets,networking,databases
+
+# Load specific categories
+--services droplets:basic,networking:lb,databases:postgresql
+
+# Load all tools for a service
+--services droplets:all
+
+# Mix and match
+--services droplets:basic,droplets:actions,networking:all
+```
+
+## Available Categories
+
+### droplets
+| Category | Description |
+|----------|-------------|
+| `basic` | Droplet CRUD operations (create, delete, get, list, power ops) |
+| `actions` | Droplet actions (reboot, snapshot, resize, etc.) |
+| `images` | Image management and actions |
+| `sizes` | List available droplet sizes |
+| `all` | All droplet tools |
+
+### networking
+| Category | Description |
+|----------|-------------|
+| `basic` / `lb` | Load balancer management |
+| `firewall` | Firewall rules |
+| `dns` | Domains and certificates |
+| `vpc` | VPC and VPC peering |
+| `ip` | Reserved IPs and BYOIP |
+| `all` | All networking tools |
+
+### databases
+| Category | Description |
+|----------|-------------|
+| `basic` / `cluster` | Generic cluster operations |
+| `postgresql` | PostgreSQL-specific tools |
+| `mysql` | MySQL-specific tools |
+| `mongodb` | MongoDB-specific tools |
+| `redis` | Redis-specific tools |
+| `kafka` | Kafka-specific tools |
+| `opensearch` | OpenSearch-specific tools |
+| `users` | Database user management |
+| `firewall` | Database firewall rules |
+| `all` | All database tools |
+
+### accounts
+| Category | Description |
+|----------|-------------|
+| `basic` / `info` | Account information |
+| `billing` | Balance, billing history, invoices |
+| `keys` | SSH key management |
+| `actions` | Account actions |
+| `all` | All account tools |
+
+### spaces
+| Category | Description |
+|----------|-------------|
+| `basic` / `keys` | Spaces key management |
+| `cdn` | CDN endpoints |
+| `all` | All spaces tools |
+
+### insights
+| Category | Description |
+|----------|-------------|
+| `basic` / `uptime` | Uptime checks and alerts |
+| `alerts` | Alert policies |
+| `all` | All insights tools |
+
+### apps, doks, marketplace
+These services currently load all tools regardless of category (small tool sets).
+
+## Examples
+
+### Minimal setup for droplet management
+```bash
+--services droplets:basic,accounts:info
+```
+
+### Web application deployment
+```bash
+--services droplets:basic,networking:lb,networking:dns,databases:postgresql
+```
+
+### Full infrastructure management
+```bash
+--services droplets:all,networking:all,databases:all
+```
+
+## Context Window Impact
+
+Using category filtering can significantly reduce context window usage:
+
+| Configuration | Approximate Tools |
+|---------------|-------------------|
+| All services (no filtering) | ~200 tools |
+| All services (basic only) | ~50 tools |
+| droplets:basic,networking:lb | ~20 tools |

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -23,172 +23,256 @@ import (
 
 type getClientFn func(ctx context.Context) (*godo.Client, error)
 
-// supportedServices is a set of services that we support in this MCP server.
-var supportedServices = map[string]struct{}{
-	"apps":        {},
-	"networking":  {},
-	"droplets":    {},
-	"accounts":    {},
-	"spaces":      {},
-	"databases":   {},
-	"marketplace": {},
-	"insights":    {},
-	"doks":        {},
+// supportedServices maps service names to their default category.
+var supportedServices = map[string]string{
+	"apps":        "basic",
+	"networking":  "basic",
+	"droplets":    "basic",
+	"accounts":    "basic",
+	"spaces":      "basic",
+	"databases":   "basic",
+	"marketplace": "basic",
+	"insights":    "basic",
+	"doks":        "basic",
 }
 
-// registerAppTools registers the app platform tools with the MCP server.
-func registerAppTools(s *server.MCPServer, getClient getClientFn) error {
+// parseServiceFilters parses service specifications with optional categories.
+// Format: "service" or "service:category" or "service:cat1,service:cat2"
+// If no category specified, uses "basic" as default.
+// Use "service:all" to load all tools for a service.
+func parseServiceFilters(services []string) map[string][]string {
+	result := make(map[string][]string)
+
+	for _, svc := range services {
+		if idx := strings.Index(svc, ":"); idx != -1 {
+			serviceName := svc[:idx]
+			category := svc[idx+1:]
+			if category != "" {
+				result[serviceName] = append(result[serviceName], category)
+			}
+		} else {
+			// No category specified - use default "basic"
+			if _, exists := result[svc]; !exists {
+				result[svc] = []string{"basic"}
+			}
+		}
+	}
+
+	return result
+}
+
+// hasCategory checks if a category is in the list, or if "all" is specified.
+func hasCategory(categories []string, cat string) bool {
+	for _, c := range categories {
+		if c == cat || c == "all" {
+			return true
+		}
+	}
+	return false
+}
+
+// registerAppTools registers app platform tools.
+// Categories: basic, all
+func registerAppTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
 	appTools, err := apps.NewAppPlatformTool(getClient)
 	if err != nil {
 		return fmt.Errorf("failed to create apps tool: %w", err)
 	}
-
+	// Apps currently has no sub-categories, always load all
 	s.AddTools(appTools.Tools()...)
-
 	return nil
 }
 
-// registerCommonTools registers the common tools with the MCP server.
+// registerCommonTools registers common tools (always loaded).
 func registerCommonTools(s *server.MCPServer, getClient getClientFn) error {
 	s.AddTools(common.NewRegionTools(getClient).Tools()...)
-
 	return nil
 }
 
-// registerDropletTools registers the droplet tools with the MCP server.
-func registerDropletTools(s *server.MCPServer, getClient getClientFn) error {
-	s.AddTools(droplet.NewDropletTool(getClient).Tools()...)
-	s.AddTools(droplet.NewDropletActionsTool(getClient).Tools()...)
-	s.AddTools(droplet.NewImageTool(getClient).Tools()...)
-	s.AddTools(droplet.NewImageActionsTool(getClient).Tools()...)
-	s.AddTools(droplet.NewSizesTool(getClient).Tools()...)
+// registerDropletTools registers droplet tools.
+// Categories: basic, actions, images, sizes, all
+func registerDropletTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	if hasCategory(categories, "basic") {
+		s.AddTools(droplet.NewDropletTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "actions") {
+		s.AddTools(droplet.NewDropletActionsTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "images") {
+		s.AddTools(droplet.NewImageTool(getClient).Tools()...)
+		s.AddTools(droplet.NewImageActionsTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "sizes") {
+		s.AddTools(droplet.NewSizesTool(getClient).Tools()...)
+	}
 	return nil
 }
 
-// registerNetworkingTools registers the networking tools with the MCP server.
-func registerNetworkingTools(s *server.MCPServer, getClient getClientFn) error {
-	s.AddTools(networking.NewCertificateTool(getClient).Tools()...)
-	s.AddTools(networking.NewDomainsTool(getClient).Tools()...)
-	s.AddTools(networking.NewFirewallTool(getClient).Tools()...)
-	s.AddTools(networking.NewLoadBalancersTool(getClient).Tools()...)
-	s.AddTools(networking.NewReservedIPTool(getClient).Tools()...)
-	s.AddTools(networking.NewBYOIPPrefixTool(getClient).Tools()...)
-	// Partner attachments doesn't have much users so this has been disabled
-	// s.AddTools(networking.NewPartnerAttachmentTool(c).Tools()...)
-	s.AddTools(networking.NewVPCTool(getClient).Tools()...)
-	s.AddTools(networking.NewVPCPeeringTool(getClient).Tools()...)
+// registerNetworkingTools registers networking tools.
+// Categories: basic (lb), lb, firewall, dns, vpc, ip, all
+func registerNetworkingTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	// "basic" for networking means load balancers (most common use case)
+	if hasCategory(categories, "basic") || hasCategory(categories, "lb") {
+		s.AddTools(networking.NewLoadBalancersTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "firewall") {
+		s.AddTools(networking.NewFirewallTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "dns") {
+		s.AddTools(networking.NewDomainsTool(getClient).Tools()...)
+		s.AddTools(networking.NewCertificateTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "vpc") {
+		s.AddTools(networking.NewVPCTool(getClient).Tools()...)
+		s.AddTools(networking.NewVPCPeeringTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "ip") {
+		s.AddTools(networking.NewReservedIPTool(getClient).Tools()...)
+		s.AddTools(networking.NewBYOIPPrefixTool(getClient).Tools()...)
+	}
 	return nil
 }
 
-// registerAccountTools registers the account tools with the MCP server.
-func registerAccountTools(s *server.MCPServer, getClient getClientFn) error {
-	s.AddTools(account.NewAccountTools(getClient).Tools()...)
-	s.AddTools(account.NewActionTools(getClient).Tools()...)
-	s.AddTools(account.NewBalanceTools(getClient).Tools()...)
-	s.AddTools(account.NewBillingTools(getClient).Tools()...)
-	s.AddTools(account.NewInvoiceTools(getClient).Tools()...)
-	s.AddTools(account.NewKeysTool(getClient).Tools()...)
-
+// registerAccountTools registers account tools.
+// Categories: basic (info), info, billing, keys, actions, all
+func registerAccountTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	if hasCategory(categories, "basic") || hasCategory(categories, "info") {
+		s.AddTools(account.NewAccountTools(getClient).Tools()...)
+	}
+	if hasCategory(categories, "billing") {
+		s.AddTools(account.NewBalanceTools(getClient).Tools()...)
+		s.AddTools(account.NewBillingTools(getClient).Tools()...)
+		s.AddTools(account.NewInvoiceTools(getClient).Tools()...)
+	}
+	if hasCategory(categories, "keys") {
+		s.AddTools(account.NewKeysTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "actions") {
+		s.AddTools(account.NewActionTools(getClient).Tools()...)
+	}
 	return nil
 }
 
-// registerSpacesTools registers the spaces tools and resources with the MCP server.
-func registerSpacesTools(s *server.MCPServer, getClient getClientFn) error {
-	// Register the tools for spaces keys
-	s.AddTools(spaces.NewSpacesKeysTool(getClient).Tools()...)
-	s.AddTools(spaces.NewCDNTool(getClient).Tools()...)
-
+// registerSpacesTools registers spaces/object storage tools.
+// Categories: basic (keys), keys, cdn, all
+func registerSpacesTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	if hasCategory(categories, "basic") || hasCategory(categories, "keys") {
+		s.AddTools(spaces.NewSpacesKeysTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "cdn") {
+		s.AddTools(spaces.NewCDNTool(getClient).Tools()...)
+	}
 	return nil
 }
 
-// registerMarketplaceTools registers the marketplace tools with the MCP server.
-func registerMarketplaceTools(s *server.MCPServer, getClient getClientFn) error {
+// registerMarketplaceTools registers marketplace tools.
+// Categories: basic, all (marketplace has limited tools)
+func registerMarketplaceTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
 	s.AddTools(marketplace.NewOneClickTool(getClient).Tools()...)
-
 	return nil
 }
 
-func registerInsightsTools(s *server.MCPServer, getClient getClientFn) error {
-	s.AddTools(insights.NewUptimeTool(getClient).Tools()...)
-	s.AddTools(insights.NewUptimeCheckAlertTool(getClient).Tools()...)
-	s.AddTools(insights.NewAlertPolicyTool(getClient).Tools()...)
+// registerInsightsTools registers monitoring/insights tools.
+// Categories: basic (uptime), uptime, alerts, all
+func registerInsightsTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	if hasCategory(categories, "basic") || hasCategory(categories, "uptime") {
+		s.AddTools(insights.NewUptimeTool(getClient).Tools()...)
+		s.AddTools(insights.NewUptimeCheckAlertTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "alerts") {
+		s.AddTools(insights.NewAlertPolicyTool(getClient).Tools()...)
+	}
 	return nil
 }
 
-func registerDOKSTools(s *server.MCPServer, getClient getClientFn) error {
+// registerDOKSTools registers Kubernetes tools.
+// Categories: basic, all (DOKS has single tool set)
+func registerDOKSTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
 	s.AddTools(doks.NewDoksTool(getClient).Tools()...)
-
 	return nil
 }
 
-func registerDatabasesTools(s *server.MCPServer, getClient getClientFn) error {
-	s.AddTools(dbaas.NewClusterTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewFirewallTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewKafkaTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewMongoTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewMysqlTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewOpenSearchTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewPostgreSQLTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewRedisTool(getClient).Tools()...)
-	s.AddTools(dbaas.NewUserTool(getClient).Tools()...)
-
+// registerDatabasesTools registers database tools.
+// Categories: basic (cluster), cluster, postgresql, mysql, mongodb, redis, kafka, opensearch, users, firewall, all
+func registerDatabasesTools(s *server.MCPServer, getClient getClientFn, categories []string) error {
+	if hasCategory(categories, "basic") || hasCategory(categories, "cluster") {
+		s.AddTools(dbaas.NewClusterTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "postgresql") {
+		s.AddTools(dbaas.NewPostgreSQLTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "mysql") {
+		s.AddTools(dbaas.NewMysqlTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "mongodb") {
+		s.AddTools(dbaas.NewMongoTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "redis") {
+		s.AddTools(dbaas.NewRedisTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "kafka") {
+		s.AddTools(dbaas.NewKafkaTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "opensearch") {
+		s.AddTools(dbaas.NewOpenSearchTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "users") {
+		s.AddTools(dbaas.NewUserTool(getClient).Tools()...)
+	}
+	if hasCategory(categories, "firewall") {
+		s.AddTools(dbaas.NewFirewallTool(getClient).Tools()...)
+	}
 	return nil
 }
 
-// Register registers the set of tools for the specified services with the MCP server.
-// We either register a subset of tools of the services are specified, or we register all tools if no services are specified.
+// Register registers tools for the specified services with the MCP server.
+// Services can be specified with categories: "service:category" (e.g., "droplets:basic").
+// If no category is specified, "basic" is used as default.
+// Use "service:all" to load all tools for a service.
 func Register(logger *slog.Logger, s *server.MCPServer, getClient getClientFn, servicesToActivate ...string) error {
 	if len(servicesToActivate) == 0 {
-		logger.Warn("no services specified, loading all supported services")
+		logger.Warn("no services specified, loading basic tools for all services")
 		for k := range supportedServices {
 			servicesToActivate = append(servicesToActivate, k)
 		}
 	}
-	for _, svc := range servicesToActivate {
-		logger.Debug(fmt.Sprintf("Registering tool and resources for service: %s", svc))
+
+	serviceFilters := parseServiceFilters(servicesToActivate)
+
+	for svc, categories := range serviceFilters {
+		logger.Debug(fmt.Sprintf("Registering tools for service: %s, categories: %v", svc, categories))
+
+		if _, ok := supportedServices[svc]; !ok {
+			return fmt.Errorf("unsupported service: %s, supported services are: %v", svc, setToString(supportedServices))
+		}
+
+		var err error
 		switch svc {
 		case "apps":
-			if err := registerAppTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register app tools: %w", err)
-			}
+			err = registerAppTools(s, getClient, categories)
 		case "networking":
-			if err := registerNetworkingTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register networking tools: %w", err)
-			}
+			err = registerNetworkingTools(s, getClient, categories)
 		case "droplets":
-			if err := registerDropletTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register droplets tool: %w", err)
-			}
+			err = registerDropletTools(s, getClient, categories)
 		case "accounts":
-			if err := registerAccountTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register account tools: %w", err)
-			}
+			err = registerAccountTools(s, getClient, categories)
 		case "spaces":
-			if err := registerSpacesTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register spaces tools: %w", err)
-			}
+			err = registerSpacesTools(s, getClient, categories)
 		case "databases":
-			if err := registerDatabasesTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register databases tools: %w", err)
-			}
+			err = registerDatabasesTools(s, getClient, categories)
 		case "marketplace":
-			if err := registerMarketplaceTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register marketplace tools: %w", err)
-			}
+			err = registerMarketplaceTools(s, getClient, categories)
 		case "insights":
-			if err := registerInsightsTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register insights tools: %w", err)
-			}
+			err = registerInsightsTools(s, getClient, categories)
 		case "doks":
-			if err := registerDOKSTools(s, getClient); err != nil {
-				return fmt.Errorf("failed to register DOKS tools: %w", err)
-			}
-		default:
-			return fmt.Errorf("unsupported service: %s, supported service are: %v", svc, setToString(supportedServices))
+			err = registerDOKSTools(s, getClient, categories)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to register %s tools: %w", svc, err)
 		}
 	}
 
-	// Common tools are always registered because they provide common functionality for all services such as region resources
+	// Common tools always registered
 	if err := registerCommonTools(s, getClient); err != nil {
 		return fmt.Errorf("failed to register common tools: %w", err)
 	}
@@ -196,11 +280,10 @@ func Register(logger *slog.Logger, s *server.MCPServer, getClient getClientFn, s
 	return nil
 }
 
-func setToString(set map[string]struct{}) string {
+func setToString(set map[string]string) string {
 	var result []string
 	for key := range set {
 		result = append(result, key)
 	}
-
 	return strings.Join(result, ",")
 }


### PR DESCRIPTION
## Summary

Implement granular tool filtering with `service:category` syntax to significantly reduce the number of tools loaded, optimizing LLM context window usage.

- Add `parseServiceFilters()` for parsing `service:category` syntax  
- Add `hasCategory()` helper for category matching
- Default to "basic" category when no category specified
- Support "all" keyword to load all tools for a service
- Add category support to all 9 services

## Usage Examples

```bash
# Default: loads only basic tools (~50 instead of ~200)
--services droplets

# Specific categories
--services droplets:basic,networking:lb,databases:postgresql

# All tools for a service
--services droplets:all

# Mix and match
--services droplets:basic,droplets:actions,networking:all
```

## Available Categories

| Service | Categories |
|---------|------------|
| droplets | basic, actions, images, sizes, all |
| networking | basic/lb, firewall, dns, vpc, ip, all |
| databases | basic/cluster, postgresql, mysql, mongodb, redis, kafka, opensearch, users, firewall, all |
| accounts | basic/info, billing, keys, actions, all |
| spaces | basic/keys, cdn, all |
| insights | basic/uptime, alerts, all |
| apps, doks, marketplace | all (small tool sets) |

## Context Window Impact

| Configuration | Approximate Tools |
|---------------|-------------------|
| All services (no filtering) | ~200 tools |
| All services (basic only) | ~50 tools |
| droplets:basic,networking:lb | ~20 tools |

## Test Plan

- [x] Format check passes (`make format`)
- [x] Build succeeds (`make build`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual testing with MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)