### PR TITLE
randomize kafka topic name

### DIFF
--- a/cmd/mcp-digitalocean/main.go
+++ b/cmd/mcp-digitalocean/main.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	mcpName                 = "mcp-digitalocean"
-	mcpVersion              = "1.0.30"
+	mcpVersion              = "1.0.31"
 	wsLoggingContextTimeout = 15 * time.Second
 )
 

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/mcp",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "DigitalOcean MCP Implementation,",
   "author": "DigitalOcean",
   "homepage": "https://github.com/digitalocean-labs/mcp-digitalocean?tab=readme-ov-file#mcp-digitalocean-integration",

--- a/testing/e2e_dbaas_test.go
+++ b/testing/e2e_dbaas_test.go
@@ -67,8 +67,7 @@ func TestDbaasKafkaLifecycle(t *testing.T) {
 	defer c.Close()
 
 	registerClusterCleanup(t)
-
-	topicName := "mcp-e2e-test-topic"
+	topicName := uuid.New().String()
 	// Create cluster with unique name
 	clusterName := fmt.Sprintf("mcp-e2e-test-kafka-%s", uuid.New().String())
 


### PR DESCRIPTION
e2e fails because topic looks to have already been created. This generates a unique topic to prevent collision.