### PR TITLE
Fix AppSlugs array schema items

### DIFF
--- a/pkg/registry/marketplace/1-click_tools.go
+++ b/pkg/registry/marketplace/1-click_tools.go
@@ -131,7 +131,7 @@ func (o *OneClickTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool("1-click-kubernetes-app-install",
 				mcp.WithDescription("Install 1-click applications on a Kubernetes cluster"),
 				mcp.WithString("ClusterUUID", mcp.Required(), mcp.Description("UUID of the Kubernetes cluster to install apps on")),
-				mcp.WithArray("AppSlugs", mcp.Required(), mcp.Description("Array of app slugs to install")),
+				mcp.WithArray("AppSlugs", mcp.Required(), mcp.Description("Array of app slugs to install"), mcp.Items(map[string]any{"type": "string"})),
 			),
 		},
 	}


### PR DESCRIPTION
## Summary
- add item schema for AppSlugs to define string array type
- align 1-click-kubernetes-app-install parameters with other array definitions