### PR TITLE
Fix failure to create DOKS cluster when multiple create calls result in the same VPC range to be picked

### DIFF
--- a/testing/e2e_doks_test.go
+++ b/testing/e2e_doks_test.go
@@ -21,7 +21,7 @@ func TestCreateCluster(t *testing.T) {
 
 	create := godo.KubernetesClusterCreateRequest{
 		Name:        fmt.Sprintf("doks-%s", uuid.New().String()),
-		RegionSlug:  "sfo3",
+		RegionSlug:  "fra1",
 		VersionSlug: "latest",
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{
 			{

--- a/testing/e2e_marketplace_test.go
+++ b/testing/e2e_marketplace_test.go
@@ -92,7 +92,7 @@ func TestInstallKubernetesApps(t *testing.T) {
 
 	createClusterReq := godo.KubernetesClusterCreateRequest{
 		Name:        clusterName,
-		RegionSlug:  "sfo3",
+		RegionSlug:  "tor1",
 		VersionSlug: "latest",
 		NodePools: []*godo.KubernetesNodePoolCreateRequest{
 			{


### PR DESCRIPTION
Fix failure to create DOKS cluster when multiple create calls result in the same VPC range to be picked. 

failed to create cluster: (status: 422): POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 (request "<redacted-uuid>") creating vpc pod subnet overlay: rpc error: code = InvalidArgument desc = This range/size overlaps with another VPC network in your account: <redacted-account-uuid> 10.247.0.0/16.    e2e_doks_test.go:55: 