### PR TITLE
Add docs service to Example Tools, align docs README with peer format

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,8 @@ Each service provides a detailed README describing all available tools, resource
 - Flush a CDN cache: `cdn-flush-cache`
 - Create a VPC peering connection: `vpc-peering-create`
 - Delete a VPC peering connection: `vpc-peering-delete`
+- Search DigitalOcean documentation: `docs-search`
+- Get a quickstart guide for a service: `docs-get-quickstart`
 
 ## Contributing
 

--- a/pkg/registry/docs/README.md
+++ b/pkg/registry/docs/README.md
@@ -1,15 +1,33 @@
-# Documentation Tools
+## Documentation Tools
 
 Read-only tools for querying DigitalOcean's public documentation. No authentication required.
 
-## Tools
+---
 
-| Tool | Description |
-|------|-------------|
-| `docs-search` | Full-text search across all DigitalOcean documentation |
-| `docs-get-page` | Fetch the full markdown content of a specific docs page |
-| `docs-find-for-service` | List documentation pages for a given DigitalOcean service |
-| `docs-get-quickstart` | Get the quickstart guide for a service |
+## Supported Tools
+
+- **docs-search**
+  Full-text search across all DigitalOcean documentation.
+  **Arguments:**
+    - `Query` (string, required): Search query string
+    - `Limit` (number, default: 10): Maximum number of results to return
+
+- **docs-get-page**
+  Fetch the full markdown content of a specific docs page.
+  **Arguments:**
+    - `URL` (string, required): Full URL or path of the docs page (e.g., `https://docs.digitalocean.com/products/droplets/getting-started/quickstart/` or `/products/droplets/getting-started/quickstart/`)
+
+- **docs-find-for-service**
+  List documentation pages for a given DigitalOcean service.
+  **Arguments:**
+    - `Service` (string, required): DigitalOcean service name (e.g., `"droplets"`, `"kubernetes"`, `"app platform"`, `"databases"`)
+
+- **docs-get-quickstart**
+  Get the quickstart or getting-started guide for a service.
+  **Arguments:**
+    - `Service` (string, required): DigitalOcean service name (e.g., `"droplets"`, `"kubernetes"`, `"app platform"`)
+
+---
 
 ## How It Works
 
@@ -18,40 +36,36 @@ Read-only tools for querying DigitalOcean's public documentation. No authenticat
 - In-memory caching (30 min for pages, 1 hour for indexes)
 - Supports common service name aliases (e.g., "k8s" → "kubernetes", "gpu" → "bare-metal-gpus")
 
-## Examples
+---
 
-### Search Documentation
+## Example Usage
 
-Search for documentation about Kubernetes networking:
+- **Search documentation:**
+  Tool: `docs-search`
+  Arguments:
+    - `Query`: `"kubernetes networking"`
+    - `Limit`: `5`
 
-```
-Tool: docs-search
-Arguments: { "Query": "kubernetes networking", "Limit": 5 }
-```
+- **Fetch a specific page:**
+  Tool: `docs-get-page`
+  Arguments:
+    - `URL`: `"/products/droplets/getting-started/quickstart/"`
 
-### Get a Specific Page
+- **Browse a service:**
+  Tool: `docs-find-for-service`
+  Arguments:
+    - `Service`: `"app platform"`
 
-Fetch the Droplets quickstart guide:
+- **Get a quickstart guide:**
+  Tool: `docs-get-quickstart`
+  Arguments:
+    - `Service`: `"databases"`
 
-```
-Tool: docs-get-page
-Arguments: { "URL": "/products/droplets/getting-started/quickstart/" }
-```
+---
 
-### Browse a Service
+## Notes
 
-List all documentation for App Platform:
-
-```
-Tool: docs-find-for-service
-Arguments: { "Service": "app platform" }
-```
-
-### Get a Quickstart Guide
-
-Get the getting-started guide for databases:
-
-```
-Tool: docs-get-quickstart
-Arguments: { "Service": "databases" }
-```
+- All tools are read-only and do not require a DigitalOcean API token.
+- All tools use argument-based input; do not use resource URIs.
+- All responses are returned as markdown text.
+- Service name aliases are supported (e.g., "k8s" for "kubernetes", "postgres" for "postgresql").


### PR DESCRIPTION
## Summary

Follow-up to #295. The docs service was added to the Available Services
table and Documentation links but was missed in the Example Tools section.
This adds `docs-search` and `docs-get-quickstart` to that list.

Also restructures `pkg/registry/docs/README.md` to match the format used
by other service READMEs (doks, spaces, etc.):
- H2 title instead of H1
- Per-tool argument documentation with types and required/optional
- `Supported Tools` / `Example Usage` / `Notes` heading structure
- Horizontal rule separators between sections

README-only changes, no code.