### PR TITLE
Bump godo to v1.187.0 and fix GetKubeConfig signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module mcp-digitalocean
 go 1.25.3
 
 require (
-	github.com/digitalocean/godo v1.186.0
+	github.com/digitalocean/godo v1.187.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/invopop/jsonschema v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.186.0 h1:aEYwSumR47vD1tX5mdPdznHrR72DBfHcmh0v9MxCwCw=
-github.com/digitalocean/godo v1.186.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.187.0 h1:Ga+pkJdebdhnzWmIjusyehDzm+WZ/joLiXM00tPOXVs=
+github.com/digitalocean/godo v1.187.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=

--- a/pkg/registry/doks/doks.go
+++ b/pkg/registry/doks/doks.go
@@ -319,7 +319,7 @@ func (d *DoksTool) getDOKSClusterKubeConfig(ctx context.Context, req mcp.CallToo
 	}
 
 	// Make the API call
-	kubecfg, _, err := client.Kubernetes.GetKubeConfig(ctx, clusterID)
+	kubecfg, _, err := client.Kubernetes.GetKubeConfig(ctx, clusterID, nil)
 	if err != nil {
 		return mcp.NewToolResultErrorFromErr("failed to get kubeconfig", err), nil
 	}

--- a/pkg/registry/doks/spec/cluster-create-schema.json
+++ b/pkg/registry/doks/spec/cluster-create-schema.json
@@ -177,6 +177,23 @@
         }
       },
       "type": "object"
+    },
+    "sso": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "issuer_url": {
+          "type": "string"
+        },
+        "client_id": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "type": "object"


### PR DESCRIPTION
## Summary

- Bump `github.com/digitalocean/godo` from `v1.186.0` to `v1.187.0`
- Fix `GetKubeConfig` call in `pkg/registry/doks/doks.go` to match the updated godo interface (new `*KubernetesClusterKubeconfigGetRequest` parameter added in [godo#995](https://github.com/digitalocean/godo/pull/995))
- Auto-regenerated `cluster-create-schema.json` with new SSO fields from godo v1.187.0

## Context

godo v1.187.0 includes two changes relevant to this repo:
1. **BatchInferenceService** ([godo#998](https://github.com/digitalocean/godo/pull/998)) — needed by [PR #325](https://github.com/digitalocean-labs/mcp-digitalocean/pull/325)
2. **DOKS per-cluster SSO config** ([godo#995](https://github.com/digitalocean/godo/pull/995)) — changed `GetKubeConfig` signature, breaking the existing doks code

This PR lands the godo bump + doks fix so that PR #325 can rebase cleanly on main.

## Test plan

- [x] `go build ./...` compiles
- [x] `go mod tidy` clean
- [ ] CI: lint, build, test

Made with [Cursor](https://cursor.com)