### PR TITLE
fix(testing): stabilize TestDropletLifecycle list check against flaky pagination and lag

### DIFF
--- a/testing/e2e_droplet_core_test.go
+++ b/testing/e2e_droplet_core_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/digitalocean/godo"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDropletLifecycle(t *testing.T) {
@@ -16,19 +15,7 @@ func TestDropletLifecycle(t *testing.T) {
 
 	droplet := CreateTestDroplet(t, "mcp-e2e-test")
 
-	type dropletShort struct {
-		ID int `json:"id"`
-	}
-	droplets := callTool[[]dropletShort](t, "droplet-list", map[string]interface{}{"Page": defaultPage, "PerPage": defaultPerPage})
-
-	found := false
-	for _, d := range droplets {
-		if d.ID == droplet.ID {
-			found = true
-			break
-		}
-	}
-	require.True(t, found, "Created droplet not found in list")
+	requireDropletListedViaMCPTool(t, droplet.ID)
 
 	DeleteResource(t, "droplet", droplet.ID)
 

--- a/testing/e2e_helpers_test.go
+++ b/testing/e2e_helpers_test.go
@@ -36,23 +36,28 @@ const (
 	resourcePollInterval = 3 * time.Second
 
 	// Timeouts
-	defaultActionTimeout     = 5 * time.Minute
-	imageTransferTimeout     = 15 * time.Minute
-	dropletActiveTimeout     = 10 * time.Minute
-	dropletDeleteTimeout     = 2 * time.Minute
-	imageAvailableTimeout    = 5 * time.Minute
-	snapshotDiscoveryTimeout = 2 * time.Minute
-	renameVerifyTimeout      = 30 * time.Second
-	ipv6AssignTimeout        = 1 * time.Minute
-	backupsEnableTimeout     = 1 * time.Minute
-	imageDeleteTimeout       = 1 * time.Minute
-	restoreActionTimeout     = 2 * time.Minute
-	rebuildActionTimeout     = 5 * time.Minute
+	defaultActionTimeout        = 5 * time.Minute
+	imageTransferTimeout        = 15 * time.Minute
+	dropletActiveTimeout        = 10 * time.Minute
+	dropletDeleteTimeout        = 2 * time.Minute
+	imageAvailableTimeout       = 5 * time.Minute
+	snapshotDiscoveryTimeout    = 2 * time.Minute
+	renameVerifyTimeout         = 30 * time.Second
+	ipv6AssignTimeout           = 1 * time.Minute
+	backupsEnableTimeout        = 1 * time.Minute
+	imageDeleteTimeout          = 1 * time.Minute
+	restoreActionTimeout        = 2 * time.Minute
+	rebuildActionTimeout        = 5 * time.Minute
+	dropletListInclusionTimeout = 2 * time.Minute
 
 	// Pagination
 	defaultPerPage   = 50
 	imageListPerPage = 20
 	defaultPage      = 1
+	// dropletListMaxPerPage is the maximum supported by GET /v2/droplets (minimizes pages under parallel E2E load).
+	dropletListMaxPerPage = 200
+	// dropletListMaxPages caps pagination in pathological cases (misbehaving API returning full pages).
+	dropletListMaxPages = 500
 
 	// Test Regions
 	testRegionNYC1 = "nyc1"
@@ -179,6 +184,46 @@ func requireFoundInList[T any](t *testing.T, items []T, match func(T) bool, item
 		}
 	}
 	t.Fatalf("%s not found in list", itemName)
+}
+
+// requireDropletListedViaMCPTool asserts droplet-list eventually returns dropletID when scanning
+// all pages at the maximum page size, with retries. Covers (a) accounts that temporarily exceed
+// one page of droplets during parallel tests and (b) brief list inconsistency after create.
+func requireDropletListedViaMCPTool(t *testing.T, dropletID int) {
+	t.Helper()
+
+	deadline := time.Now().Add(dropletListInclusionTimeout)
+	for time.Now().Before(deadline) {
+		if dropletListedOnAnyMCPPage(t, dropletID) {
+			return
+		}
+		time.Sleep(resourcePollInterval)
+	}
+
+	require.Fail(t, fmt.Sprintf("droplet %d not found in droplet-list after %v (all pages, retries)", dropletID, dropletListInclusionTimeout))
+}
+
+func dropletListedOnAnyMCPPage(t *testing.T, dropletID int) bool {
+	t.Helper()
+
+	type entry struct {
+		ID int `json:"id"`
+	}
+	for page := 1; page <= dropletListMaxPages; page++ {
+		droplets := callTool[[]entry](t, "droplet-list", map[string]any{
+			"Page":    float64(page),
+			"PerPage": float64(dropletListMaxPerPage),
+		})
+		for _, d := range droplets {
+			if d.ID == dropletID {
+				return true
+			}
+		}
+		if len(droplets) < dropletListMaxPerPage {
+			return false
+		}
+	}
+	return false
 }
 
 // --- Resource Lifecycle Helpers ---


### PR DESCRIPTION
## Problem

`TestDropletLifecycle` was intermittently failing with **"Created droplet not found in list"**. Two root causes:

1. **Single-page scan** — the test called `droplet-list` once at `Page=1, PerPage=50`. Under parallel E2E load the account can hold >50 active droplets, pushing the newly created one to a later page.
2. **Read-after-write lag** — a single immediate list call sometimes doesn't include a droplet that was just created and confirmed active.

## Fix

Replace the one-shot list assertion with `requireDropletListedViaMCPTool`, which:

- Scans **all pages** at `PerPage=200` (the DO API max) on each attempt.
- **Retries with 3 s backoff** for up to **2 minutes** before failing.

This makes the check resilient to both causes without weakening the assertion — the droplet must still appear in the list before the test proceeds to delete.

## Testing

All unit tests pass (`go test ./...`). Integration tests require a live DO token and are validated in CI.