### PR TITLE
genai-custom-models: add get model card and unified search tools

### DIFF
--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -131,6 +131,15 @@ func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRe
 	if v, ok := sourceRefRaw["hf_token"].(string); ok {
 		sourceRef.HFToken = v
 	}
+	if v, ok := sourceRefRaw["bucket"].(string); ok {
+		sourceRef.Bucket = v
+	}
+	if v, ok := sourceRefRaw["region"].(string); ok {
+		sourceRef.Region = v
+	}
+	if v, ok := sourceRefRaw["prefix"].(string); ok {
+		sourceRef.Prefix = v
+	}
 
 	acceptTerms, _ := args["accept_terms_and_conditions"].(bool)
 
@@ -326,7 +335,7 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 				mcp.WithDescription("Import a custom model from an external source (e.g. HuggingFace). Starts an async import job."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the custom model")),
 				mcp.WithString("source_type", mcp.Required(), mcp.Description("Source type: SOURCE_TYPE_HUGGINGFACE, SOURCE_TYPE_SPACES_BUCKET, SOURCE_TYPE_SDK_UPLOAD, SOURCE_TYPE_FINE_TUNING")),
-				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference: repo_id (string), commit_sha (string, optional), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models)")),
+				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference. For HuggingFace: repo_id (string), commit_sha (string, optional), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models). For Spaces Bucket: bucket (string, required), region (string, optional), prefix (string, optional)")),
 				mcp.WithBoolean("accept_terms_and_conditions", mcp.Description("Accept terms and conditions for importing the model")),
 				mcp.WithString("description", mcp.Description("Description of the model")),
 				mcp.WithString("preferred_gpu_region", mcp.Description("Preferred GPU region for the model (e.g. nyc3)")),

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -244,6 +244,37 @@ func (cmt *CustomModelsTool) updateMetadata(ctx context.Context, req mcp.CallToo
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
+// getModel retrieves a single custom model by UUID (public endpoint).
+func (cmt *CustomModelsTool) getModel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	uuid, _ := req.GetArguments()["uuid"].(string)
+	if uuid == "" {
+		return mcp.NewToolResultError("uuid is required"), nil
+	}
+
+	client, err := cmt.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	apiReq, err := newRequestWithContext(ctx, client, "GET", customModelsAPIPath+"/"+uuid, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
+	}
+
+	var output GetCustomModelOutput
+	resp, err := client.Do(ctx, apiReq, &output)
+	if err != nil || resp.StatusCode >= 400 {
+		return mcp.NewToolResultErrorFromErr("failed to get custom model", err), nil
+	}
+
+	jsonData, err := json.MarshalIndent(output.Model, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
 // deleteModel deletes a custom model.
 func (cmt *CustomModelsTool) deleteModel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	uuid, _ := req.GetArguments()["uuid"].(string)
@@ -314,11 +345,27 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			),
 		},
 		{
+			Handler: cmt.getModel,
+			Tool: mcp.NewTool(
+				"genai-custom-models-get",
+				mcp.WithDescription("Get the full catalog card for a custom model, including its status, architecture, source info, size, license, tags, active deployments, and cost estimate."),
+				mcp.WithString("uuid", mcp.Required(), mcp.Description("UUID of the custom model to retrieve")),
+			),
+		},
+		{
 			Handler: cmt.deleteModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-delete",
 				mcp.WithDescription("Delete a custom model."),
 				mcp.WithString("uuid", mcp.Required(), mcp.Description("UUID of the custom model to delete")),
+			),
+		},
+		{
+			Handler: cmt.unifiedSearch,
+			Tool: mcp.NewTool(
+				"genai-models-unified-search",
+				mcp.WithDescription("Search across both the DigitalOcean model catalog and your custom models in a single call. Returns a merged list of models with a 'source' field indicating whether each result is from the 'catalog' or 'custom' models. When a query is provided, catalog models are searched server-side and custom models are filtered client-side by name, description, architecture, and tags. An empty query returns all models from both sources."),
+				mcp.WithString("query", mcp.Description("Search query string to find models (optional; empty or omitted returns all models from both sources)")),
 			),
 		},
 	}

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -22,13 +22,15 @@ func TestCustomModelsTool_Tools(t *testing.T) {
 	})
 
 	tools := tool.Tools()
-	require.Len(t, tools, 4, "should have 4 custom models tools")
+	require.Len(t, tools, 6, "should have 6 custom models tools")
 
 	expectedTools := map[string]bool{
 		"genai-custom-models-list":            false,
 		"genai-custom-models-import":          false,
 		"genai-custom-models-update-metadata": false,
+		"genai-custom-models-get":             false,
 		"genai-custom-models-delete":          false,
+		"genai-models-unified-search":         false,
 	}
 
 	for _, st := range tools {
@@ -133,6 +135,37 @@ func TestCustomModelsTool_updateMetadata_clientError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCustomModelsTool_getModel_validation(t *testing.T) {
+	tool := setupCustomModelsToolWithFailingClient()
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing uuid", args: map[string]any{}},
+		{name: "empty uuid", args: map[string]any{"uuid": ""}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.getModel(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.True(t, resp.IsError)
+		})
+	}
+}
+
+func TestCustomModelsTool_getModel_clientError(t *testing.T) {
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"uuid": "test-uuid",
+	}}}
+	_, err := tool.getModel(context.Background(), req)
+	require.Error(t, err)
+}
+
 func TestCustomModelsTool_deleteModel_validation(t *testing.T) {
 	tool := setupCustomModelsToolWithFailingClient()
 
@@ -162,4 +195,66 @@ func TestCustomModelsTool_deleteModel_clientError(t *testing.T) {
 	}}}
 	_, err := tool.deleteModel(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestCustomModelsTool_unifiedSearch_clientError(t *testing.T) {
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"query": "llama",
+	}}}
+	_, err := tool.unifiedSearch(context.Background(), req)
+	require.Error(t, err)
+}
+
+func TestCustomModelMatchesQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *CustomModel
+		query    string
+		expected bool
+	}{
+		{
+			name:     "match by name",
+			model:    &CustomModel{Name: "my-llama-model"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by description",
+			model:    &CustomModel{Name: "some-model", Description: "A fine-tuned Llama variant"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by tag",
+			model:    &CustomModel{Name: "some-model", Tags: &CustomModelTags{Tags: []string{"llm", "llama"}}},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by architecture",
+			model:    &CustomModel{Name: "some-model", Architecture: "LlamaForCausalLM"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			model:    &CustomModel{Name: "my-gpt-model", Description: "A GPT variant"},
+			query:    "llama",
+			expected: false,
+		},
+		{
+			name:     "case insensitive",
+			model:    &CustomModel{Name: "My-LLAMA-Model"},
+			query:    "llama",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := customModelMatchesQuery(tc.model, tc.query)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -84,6 +84,22 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 	}
 }
 
+func TestCustomModelsTool_importModel_spacesSourceRef(t *testing.T) {
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name":        "my-spaces-model",
+		"source_type": "SOURCE_TYPE_SPACES_BUCKET",
+		"source_ref": map[string]interface{}{
+			"bucket": "my-bucket",
+			"region": "nyc3",
+			"prefix": "models/mistral/",
+		},
+		"accept_terms_and_conditions": true,
+	}}}
+	_, err := tool.importModel(context.Background(), req)
+	require.Error(t, err, "should fail due to client error, not validation")
+}
+
 func TestCustomModelsTool_importModel_clientError(t *testing.T) {
 	tool := setupCustomModelsToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
@@ -204,6 +220,13 @@ func TestCustomModelsTool_unifiedSearch_clientError(t *testing.T) {
 	}}}
 	_, err := tool.unifiedSearch(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestCustomModelsTool_unifiedSearch_emptyQuery_clientError(t *testing.T) {
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	_, err := tool.unifiedSearch(context.Background(), req)
+	require.Error(t, err, "empty query should still attempt API call and fail on client error")
 }
 
 func TestCustomModelMatchesQuery(t *testing.T) {

--- a/pkg/registry/genai-custom-models/models.go
+++ b/pkg/registry/genai-custom-models/models.go
@@ -39,10 +39,15 @@ const (
 
 // CustomModelSourceRef describes where the model files come from.
 type CustomModelSourceRef struct {
+	// HuggingFace fields
 	RepoID     string                `json:"repo_id,omitempty"`
 	CommitSHA  string                `json:"commit_sha,omitempty"`
 	AccessType CustomModelAccessType `json:"access_type,omitempty"`
 	HFToken    string                `json:"hf_token,omitempty"`
+	// Spaces Bucket fields
+	Bucket string `json:"bucket,omitempty"`
+	Region string `json:"region,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
 }
 
 // CustomModelTags wraps a list of tag strings.

--- a/pkg/registry/genai-custom-models/models.go
+++ b/pkg/registry/genai-custom-models/models.go
@@ -89,6 +89,8 @@ type CustomModel struct {
 	OutputModalities     []string                       `json:"output_modalities,omitempty"`
 	Parameters           json.Number                    `json:"parameters,omitempty"`
 	TeamID               json.Number                    `json:"team_id,omitempty"`
+	ConfigJSON           map[string]interface{}         `json:"config_json,omitempty"`
+	StorageRegion        string                         `json:"storage_region,omitempty"`
 }
 
 // PaginationLinks holds pagination links from the API.
@@ -172,4 +174,37 @@ type UpdateCustomModelMetadataOutput struct {
 type DeleteCustomModelOutput struct {
 	Status string `json:"status"`
 	Error  string `json:"error,omitempty"`
+}
+
+// GetCustomModelOutput is the response from getting a single custom model.
+type GetCustomModelOutput struct {
+	Model *CustomModel `json:"model"`
+}
+
+// UnifiedModel is a normalized representation that can hold either a catalog model
+// or a custom model, identified by the Source field.
+type UnifiedModel struct {
+	UUID             string   `json:"uuid"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description,omitempty"`
+	Source           string   `json:"source"`
+	Status           string   `json:"status,omitempty"`
+	Provider         string   `json:"provider,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	Architecture     string   `json:"architecture,omitempty"`
+	ContextWindow    string   `json:"context_window,omitempty"`
+	Capabilities     []string `json:"capabilities,omitempty"`
+	InputModalities  []string `json:"input_modalities,omitempty"`
+	OutputModalities []string `json:"output_modalities,omitempty"`
+}
+
+// UnifiedSearchResponse is the response from the unified model search tool.
+type UnifiedSearchResponse struct {
+	Query   string          `json:"query"`
+	Results []*UnifiedModel `json:"results"`
+	Counts  struct {
+		Catalog int `json:"catalog"`
+		Custom  int `json:"custom"`
+		Total   int `json:"total"`
+	} `json:"counts"`
 }

--- a/pkg/registry/genai-custom-models/unified_search_tool.go
+++ b/pkg/registry/genai-custom-models/unified_search_tool.go
@@ -1,0 +1,228 @@
+package genaicustommodels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const (
+	sourceCatalog = "catalog"
+	sourceCustom  = "custom"
+)
+
+// unifiedSearch searches both the model catalog and custom models, returning
+// a merged, normalized list. The catalog is searched via GradientAI.SearchModels
+// and custom models are fetched from the v2/gen-ai/custom_models endpoint with
+// client-side name/description/tag substring matching.
+func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query, _ := req.GetArguments()["query"].(string)
+
+	client, err := cmt.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	type catalogResult struct {
+		models []*UnifiedModel
+		err    error
+	}
+	type customResult struct {
+		models []*UnifiedModel
+		err    error
+	}
+
+	var wg sync.WaitGroup
+	catalogCh := make(chan catalogResult, 1)
+	customCh := make(chan customResult, 1)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		models, err := fetchCatalogModels(ctx, client, query)
+		catalogCh <- catalogResult{models: models, err: err}
+	}()
+	go func() {
+		defer wg.Done()
+		models, err := fetchCustomModels(ctx, client, query)
+		customCh <- customResult{models: models, err: err}
+	}()
+
+	wg.Wait()
+	close(catalogCh)
+	close(customCh)
+
+	cr := <-catalogCh
+	cu := <-customCh
+
+	var catalogModels, customModels []*UnifiedModel
+	var errors []string
+
+	if cr.err != nil {
+		errors = append(errors, fmt.Sprintf("catalog: %s", cr.err))
+	} else {
+		catalogModels = cr.models
+	}
+
+	if cu.err != nil {
+		errors = append(errors, fmt.Sprintf("custom: %s", cu.err))
+	} else {
+		customModels = cu.models
+	}
+
+	if len(errors) == 2 {
+		return mcp.NewToolResultError(fmt.Sprintf("both sources failed: %s", strings.Join(errors, "; "))), nil
+	}
+
+	merged := make([]*UnifiedModel, 0, len(catalogModels)+len(customModels))
+	merged = append(merged, catalogModels...)
+	merged = append(merged, customModels...)
+
+	resp := UnifiedSearchResponse{
+		Query:   query,
+		Results: merged,
+	}
+	resp.Counts.Catalog = len(catalogModels)
+	resp.Counts.Custom = len(customModels)
+	resp.Counts.Total = len(merged)
+
+	jsonData, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	result := mcp.NewToolResultText(string(jsonData))
+	if len(errors) == 1 {
+		result = mcp.NewToolResultText(fmt.Sprintf("partial results (one source failed: %s)\n\n%s", errors[0], string(jsonData)))
+	}
+
+	return result, nil
+}
+
+// fetchCatalogModels searches the model catalog and fetches metadata for each
+// matching UUID, converting results into UnifiedModel.
+func fetchCatalogModels(ctx context.Context, client *godo.Client, query string) ([]*UnifiedModel, error) {
+	uuids, _, err := client.GradientAI.SearchModels(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search catalog: %w", err)
+	}
+
+	type result struct {
+		model *UnifiedModel
+		err   error
+	}
+
+	const maxConcurrent = 20
+	sem := make(chan struct{}, maxConcurrent)
+	results := make([]result, len(uuids))
+
+	var wg sync.WaitGroup
+	for i, uuid := range uuids {
+		wg.Add(1)
+		go func(idx int, id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			model, _, getErr := client.GradientAI.GetModelByUUID(ctx, id)
+			if getErr != nil || model == nil {
+				results[idx] = result{err: getErr}
+				return
+			}
+
+			var inputMod, outputMod []string
+			if model.Modalities != nil {
+				inputMod = model.Modalities.Input
+				outputMod = model.Modalities.Output
+			}
+
+			results[idx] = result{model: &UnifiedModel{
+				UUID:             model.Uuid,
+				Name:             model.Name,
+				Description:      model.Description,
+				Source:           sourceCatalog,
+				Provider:         model.Provider,
+				Type:             model.Type,
+				ContextWindow:    model.ContextWindow,
+				Capabilities:     model.Capabilities,
+				InputModalities:  inputMod,
+				OutputModalities: outputMod,
+			}}
+		}(i, uuid)
+	}
+	wg.Wait()
+
+	models := make([]*UnifiedModel, 0, len(results))
+	for _, r := range results {
+		if r.model != nil {
+			models = append(models, r.model)
+		}
+	}
+	return models, nil
+}
+
+// fetchCustomModels lists all custom models and applies client-side substring
+// filtering on name, description, and tags when a query is provided.
+func fetchCustomModels(ctx context.Context, client *godo.Client, query string) ([]*UnifiedModel, error) {
+	apiReq, err := client.NewRequest(ctx, http.MethodGet, customModelsAPIPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, apiReq.Method, apiReq.URL.String(), apiReq.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build http request: %w", err)
+	}
+	httpReq.Header = apiReq.Header.Clone()
+
+	var output ListCustomModelsOutput
+	resp, err := client.Do(ctx, httpReq, &output)
+	if err != nil || resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed to list custom models: %w", err)
+	}
+
+	queryLower := strings.ToLower(strings.TrimSpace(query))
+	models := make([]*UnifiedModel, 0, len(output.Models))
+	for _, cm := range output.Models {
+		if queryLower != "" && !customModelMatchesQuery(cm, queryLower) {
+			continue
+		}
+		models = append(models, &UnifiedModel{
+			UUID:             cm.UUID,
+			Name:             cm.Name,
+			Description:      cm.Description,
+			Source:           sourceCustom,
+			Status:           string(cm.Status),
+			Architecture:     cm.Architecture,
+			InputModalities:  cm.InputModalities,
+			OutputModalities: cm.OutputModalities,
+		})
+	}
+	return models, nil
+}
+
+func customModelMatchesQuery(cm *CustomModel, queryLower string) bool {
+	if strings.Contains(strings.ToLower(cm.Name), queryLower) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(cm.Description), queryLower) {
+		return true
+	}
+	if cm.Tags != nil {
+		for _, tag := range cm.Tags.Tags {
+			if strings.Contains(strings.ToLower(tag), queryLower) {
+				return true
+			}
+		}
+	}
+	if strings.Contains(strings.ToLower(cm.Architecture), queryLower) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Add genai-custom-models-get tool to retrieve full model details by UUID. Add unified search tool to query across both catalog and custom models in a single call. Include tests for validation, client errors, and query matching.