### PR TITLE
MS-614: Hugging Face commit resolution and import consent

### DIFF
--- a/pkg/registry/genai-custom-models/README.md
+++ b/pkg/registry/genai-custom-models/README.md
@@ -41,11 +41,13 @@ List custom models with optional status filter and pagination.
 ### `genai-custom-models-import`
 Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.
 
+**Consent (required every import):** Before calling this tool, the assistant must present import terms to the user and obtain explicit consent (yes) in the conversation. Set `accept_terms_and_conditions` to `true` only after the user agrees. This applies to every import, including re-imports of the same model. The tool rejects omitted or `false` values.
+
 **Arguments:**
 - `name` (string, required): Name for the custom model
 - `source_type` (string, required): `SOURCE_TYPE_HUGGINGFACE`, `SOURCE_TYPE_SPACES_BUCKET`, `SOURCE_TYPE_SDK_UPLOAD`, `SOURCE_TYPE_FINE_TUNING`
-- `source_ref` (object, required): Source reference with `repo_id`, `commit_sha` (optional), `access_type`, `hf_token` (for private/gated)
-- `accept_terms_and_conditions` (boolean): Accept terms for importing
+- `source_ref` (object, required): Source reference with `repo_id`, `commit_sha` (optional for HuggingFace; if omitted, fetched from Hugging Face Hub before the import API is called), `access_type`, `hf_token` (for private/gated)
+- `accept_terms_and_conditions` (boolean, required): Must be `true` after explicit user consent in chat
 - `description` (string, optional): Model description
 - `preferred_gpu_region` (string, optional): Preferred GPU region (e.g. `nyc3`)
 - `tags` (object, optional): Tags object with a `tags` array of strings
@@ -112,24 +114,26 @@ Delete a custom model.
 ## Workflow Example
 
 ```
-1. Import a model from HuggingFace:
+1. Ask the user to accept import terms (storage cost, license, source). Wait for explicit yes.
+
+2. Import a model from HuggingFace:
    genai-custom-models-import
      name: "my-mistral-7b"
      source_type: "SOURCE_TYPE_HUGGINGFACE"
      source_ref: { "repo_id": "mistralai/Mistral-7B-v0.1", "access_type": "ACCESS_TYPE_PUBLIC" }
      accept_terms_and_conditions: true
 
-2. Check import status by listing models:
+3. Check import status by listing models:
    genai-custom-models-list
      status: "STATUS_IMPORTING"
 
-3. Once ready, update metadata:
+4. Once ready, update metadata:
    genai-custom-models-update-metadata
-     uuid: "<uuid from step 1>"
+     uuid: "<uuid from step 2>"
      description: "Production model for customer support"
      tags: { "tags": ["production", "v1"] }
 
-4. When no longer needed, delete:
+5. When no longer needed, delete:
    genai-custom-models-delete
      uuid: "<uuid>"
 ```

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -14,6 +14,18 @@ import (
 
 const customModelsAPIPath = "v2/gen-ai/custom_models"
 
+const (
+	importConsentRequiredMsg = "accept_terms_and_conditions must be true. Before importing, present the import terms to the user and obtain explicit consent (yes) in this conversation. Consent is required for every import, including re-imports of the same model."
+
+	genaiCustomModelsImportToolDescription = "Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.\n\n" +
+		"CONSENT REQUIRED (every import): Do not call this tool until the user has explicitly agreed to the import terms in the current conversation. " +
+		"Present the terms (storage cost, license, source) and ask for yes/no. This applies to every import request, even if the same model was imported before. " +
+		"Only pass accept_terms_and_conditions: true after the user says yes."
+
+	genaiCustomModelsImportAcceptTermsDescription = "Must be true only after the end user has explicitly agreed in conversation to the import terms (yes/no in chat). " +
+		"Omitted or false is rejected. Required on every import, including re-imports."
+)
+
 // CustomModelsTool provides custom model management tools.
 type CustomModelsTool struct {
 	client func(ctx context.Context) (*godo.Client, error)
@@ -142,6 +154,15 @@ func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRe
 	}
 
 	acceptTerms, _ := args["accept_terms_and_conditions"].(bool)
+	if !acceptTerms {
+		return mcp.NewToolResultError(importConsentRequiredMsg), nil
+	}
+
+	if CustomModelSourceType(sourceType) == CustomModelSourceTypeHuggingFace {
+		if err := ensureHuggingFaceCommitSHA(ctx, &sourceRef); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to resolve Hugging Face commit_sha: %v", err)), nil
+		}
+	}
 
 	input := &ImportCustomModelInput{
 		Name:                     name,
@@ -332,11 +353,11 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.importModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-import",
-				mcp.WithDescription("Import a custom model from an external source (e.g. HuggingFace). Starts an async import job."),
+				mcp.WithDescription(genaiCustomModelsImportToolDescription),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the custom model")),
 				mcp.WithString("source_type", mcp.Required(), mcp.Description("Source type: SOURCE_TYPE_HUGGINGFACE, SOURCE_TYPE_SPACES_BUCKET, SOURCE_TYPE_SDK_UPLOAD, SOURCE_TYPE_FINE_TUNING")),
-				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference. For HuggingFace: repo_id (string), commit_sha (string, optional), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models). For Spaces Bucket: bucket (string, required), region (string, optional), prefix (string, optional)")),
-				mcp.WithBoolean("accept_terms_and_conditions", mcp.Description("Accept terms and conditions for importing the model")),
+				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference. For HuggingFace: repo_id (string, required), commit_sha (string, optional; if omitted, resolved from Hugging Face Hub before import), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models). For Spaces Bucket: bucket (string, required), region (string, optional), prefix (string, optional)")),
+				mcp.WithBoolean("accept_terms_and_conditions", mcp.Required(), mcp.Description(genaiCustomModelsImportAcceptTermsDescription)),
 				mcp.WithString("description", mcp.Description("Description of the model")),
 				mcp.WithString("preferred_gpu_region", mcp.Description("Preferred GPU region for the model (e.g. nyc3)")),
 				mcp.WithObject("tags", mcp.Description("Tags object with a 'tags' array of strings")),

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -71,6 +71,17 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 			"name":        "my-model",
 			"source_type": "SOURCE_TYPE_HUGGINGFACE",
 		}},
+		{name: "missing accept_terms_and_conditions", args: map[string]any{
+			"name":        "my-model",
+			"source_type": "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":  map[string]interface{}{"repo_id": "test/model"},
+		}},
+		{name: "accept_terms_and_conditions false", args: map[string]any{
+			"name":                        "my-model",
+			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+			"accept_terms_and_conditions": false,
+		}},
 	}
 
 	for _, tc := range tests {
@@ -101,11 +112,18 @@ func TestCustomModelsTool_importModel_spacesSourceRef(t *testing.T) {
 }
 
 func TestCustomModelsTool_importModel_clientError(t *testing.T) {
+	oldFetch := fetchHuggingFaceCommitSHA
+	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
+		return "abc123def456", nil
+	}
+	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
+
 	tool := setupCustomModelsToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-		"name":        "my-model",
-		"source_type": "SOURCE_TYPE_HUGGINGFACE",
-		"source_ref":  map[string]interface{}{"repo_id": "test/model"},
+		"name":                        "my-model",
+		"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+		"accept_terms_and_conditions": true,
 	}}}
 	_, err := tool.importModel(context.Background(), req)
 	require.Error(t, err)

--- a/pkg/registry/genai-custom-models/huggingface.go
+++ b/pkg/registry/genai-custom-models/huggingface.go
@@ -1,0 +1,89 @@
+package genaicustommodels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var huggingFaceModelsAPIBase = "https://huggingface.co/api/models"
+
+// fetchHuggingFaceCommitSHA resolves the default-branch commit for a Hugging Face repo.
+// Overridden in unit tests.
+var fetchHuggingFaceCommitSHA = defaultFetchHuggingFaceCommitSHA
+
+// FetchHuggingFaceCommitSHA returns the default-branch Git commit SHA for a Hugging Face model repo.
+func FetchHuggingFaceCommitSHA(ctx context.Context, repoID, hfToken string) (string, error) {
+	return fetchHuggingFaceCommitSHA(ctx, repoID, hfToken)
+}
+
+// ResolveHuggingFaceCommitSHA sets sourceRef.CommitSHA from Hugging Face Hub when it is empty.
+func ResolveHuggingFaceCommitSHA(ctx context.Context, sourceRef *CustomModelSourceRef) error {
+	return ensureHuggingFaceCommitSHA(ctx, sourceRef)
+}
+
+func defaultFetchHuggingFaceCommitSHA(ctx context.Context, repoID, hfToken string) (string, error) {
+	repoID = strings.TrimSpace(repoID)
+	if repoID == "" {
+		return "", fmt.Errorf("repo_id is required")
+	}
+
+	apiURL, err := url.JoinPath(huggingFaceModelsAPIBase, repoID)
+	if err != nil {
+		return "", fmt.Errorf("invalid repo_id: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	if hfToken != "" {
+		req.Header.Set("Authorization", "Bearer "+hfToken)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("hugging face API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read hugging face API response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("hugging face API returned %d for repo %q", resp.StatusCode, repoID)
+	}
+
+	var info struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return "", fmt.Errorf("parse hugging face API response: %w", err)
+	}
+	if info.SHA == "" {
+		return "", fmt.Errorf("hugging face API returned no sha for repo %q", repoID)
+	}
+	return info.SHA, nil
+}
+
+func ensureHuggingFaceCommitSHA(ctx context.Context, sourceRef *CustomModelSourceRef) error {
+	if strings.TrimSpace(sourceRef.CommitSHA) != "" {
+		return nil
+	}
+	if strings.TrimSpace(sourceRef.RepoID) == "" {
+		return fmt.Errorf("source_ref.repo_id is required for Hugging Face imports")
+	}
+	sha, err := fetchHuggingFaceCommitSHA(ctx, sourceRef.RepoID, sourceRef.HFToken)
+	if err != nil {
+		return err
+	}
+	sourceRef.CommitSHA = sha
+	return nil
+}

--- a/pkg/registry/genai-custom-models/huggingface_test.go
+++ b/pkg/registry/genai-custom-models/huggingface_test.go
@@ -1,0 +1,99 @@
+package genaicustommodels
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureHuggingFaceCommitSHA_usesProvidedSHA(t *testing.T) {
+	ref := &CustomModelSourceRef{
+		RepoID:    "org/model",
+		CommitSHA: "already-set",
+	}
+	err := ensureHuggingFaceCommitSHA(context.Background(), ref)
+	require.NoError(t, err)
+	require.Equal(t, "already-set", ref.CommitSHA)
+}
+
+func TestEnsureHuggingFaceCommitSHA_fetchesWhenMissing(t *testing.T) {
+	oldFetch := fetchHuggingFaceCommitSHA
+	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
+		require.Equal(t, "org/model", repoID)
+		require.Empty(t, hfToken)
+		return "fetched-sha", nil
+	}
+	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
+
+	ref := &CustomModelSourceRef{RepoID: "org/model"}
+	err := ensureHuggingFaceCommitSHA(context.Background(), ref)
+	require.NoError(t, err)
+	require.Equal(t, "fetched-sha", ref.CommitSHA)
+}
+
+func TestEnsureHuggingFaceCommitSHA_requiresRepoID(t *testing.T) {
+	ref := &CustomModelSourceRef{}
+	err := ensureHuggingFaceCommitSHA(context.Background(), ref)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "repo_id")
+}
+
+func TestDefaultFetchHuggingFaceCommitSHA(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/models/org/model", r.URL.Path)
+		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "token-sha"})
+	}))
+	t.Cleanup(srv.Close)
+
+	oldBase := huggingFaceModelsAPIBase
+	huggingFaceModelsAPIBase = srv.URL + "/api/models"
+	t.Cleanup(func() { huggingFaceModelsAPIBase = oldBase })
+
+	sha, err := defaultFetchHuggingFaceCommitSHA(context.Background(), "org/model", "secret")
+	require.NoError(t, err)
+	require.Equal(t, "token-sha", sha)
+}
+
+func TestImportModel_hfFetchFailsBeforeClient(t *testing.T) {
+	oldFetch := fetchHuggingFaceCommitSHA
+	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
+		return "", context.Canceled
+	}
+	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
+
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name":                        "my-model",
+		"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+		"accept_terms_and_conditions": true,
+	}}}
+	resp, err := tool.importModel(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.IsError)
+}
+
+func TestImportModel_hfResolvesCommitBeforeClient(t *testing.T) {
+	oldFetch := fetchHuggingFaceCommitSHA
+	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
+		return "resolved-sha", nil
+	}
+	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
+
+	tool := setupCustomModelsToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name":                        "my-model",
+		"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+		"accept_terms_and_conditions": true,
+	}}}
+	_, err := tool.importModel(context.Background(), req)
+	require.Error(t, err, "should fail at DigitalOcean client after commit_sha is resolved")
+}

--- a/testing/README.md
+++ b/testing/README.md
@@ -16,5 +16,8 @@ DIGITALOCEAN_API_TOKEN=your_token_here  DIGITALOCEAN_API_URL=https://api.digital
 
 Optional environment variables:
 
+- `MCP_SERVER_URL` — use an existing MCP server instead of starting a testcontainer (e.g. `https://genai-custom-models.mcp.digitalocean.com/mcp` for custom-models-only E2E).
 - `GENAI_EVALUATION_TEST_AGENT_WORKSPACE_NAME` — when set, enables `TestGenAIListEvaluationTestCases` in [e2e_genai_evaluation_test.go](e2e_genai_evaluation_test.go) against that agent workspace.
+
+GenAI custom models Hugging Face commit resolution and import behavior are covered in [e2e_custom_models_test.go](e2e_custom_models_test.go) and [e2e_custom_models_huggingface_test.go](e2e_custom_models_huggingface_test.go).
 

--- a/testing/e2e_custom_models_huggingface_test.go
+++ b/testing/e2e_custom_models_huggingface_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	genaicustommodels "mcp-digitalocean/pkg/registry/genai-custom-models"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireGitCommitSHA(t *testing.T, sha string) {
+	t.Helper()
+	require.Len(t, sha, 40)
+	require.Regexp(t, `^[0-9a-f]{40}$`, sha)
+}
+
+// TestCustomModelsFetchHuggingFaceCommitSHA calls the live Hugging Face Hub API.
+func TestCustomModelsFetchHuggingFaceCommitSHA(t *testing.T) {
+	t.Parallel()
+
+	sha, err := genaicustommodels.FetchHuggingFaceCommitSHA(context.Background(), e2eHFRepoID, "")
+	require.NoError(t, err)
+	requireGitCommitSHA(t, sha)
+
+	sha2, err := genaicustommodels.FetchHuggingFaceCommitSHA(context.Background(), e2eHFRepoID, "")
+	require.NoError(t, err)
+	require.Equal(t, sha, sha2)
+}
+
+// TestCustomModelsResolveHuggingFaceCommitSHA verifies commit resolution before any DigitalOcean import.
+func TestCustomModelsResolveHuggingFaceCommitSHA(t *testing.T) {
+	t.Parallel()
+
+	ref := &genaicustommodels.CustomModelSourceRef{RepoID: e2eHFRepoID}
+	err := genaicustommodels.ResolveHuggingFaceCommitSHA(context.Background(), ref)
+	require.NoError(t, err)
+	requireGitCommitSHA(t, ref.CommitSHA)
+}
+
+// TestCustomModelsFetchHuggingFaceCommitSHA_invalidRepo expects a clear failure from Hugging Face.
+func TestCustomModelsFetchHuggingFaceCommitSHA_invalidRepo(t *testing.T) {
+	t.Parallel()
+
+	_, err := genaicustommodels.FetchHuggingFaceCommitSHA(context.Background(), "this-org/does-not-exist-xyz-404", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "404")
+}

--- a/testing/e2e_custom_models_test.go
+++ b/testing/e2e_custom_models_test.go
@@ -3,10 +3,17 @@
 package testing
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
+
+const e2eHFRepoID = "Qwen/Qwen2.5-0.5B"
 
 // TestCustomModelsListModels calls genai-custom-models-list against the live GenAI API.
 func TestCustomModelsListModels(t *testing.T) {
@@ -79,4 +86,134 @@ func TestCustomModelsListModelsWithStatusFilter(t *testing.T) {
 		require.Equal(t, "STATUS_READY", m.Status, "all models should have STATUS_READY")
 	}
 	t.Logf("listed %d custom model(s) with STATUS_READY filter", out.Count)
+}
+
+// TestCustomModelsImportHuggingFaceResolvesCommitSHA imports without commit_sha and
+// verifies the MCP server resolved it from Hugging Face before calling DigitalOcean.
+func TestCustomModelsImportHuggingFaceResolvesCommitSHA(t *testing.T) {
+	modelName := fmt.Sprintf("it-hf-commit-%d", time.Now().Unix())
+
+	type sourceRef struct {
+		RepoID    string `json:"repo_id"`
+		CommitSHA string `json:"commit_sha"`
+	}
+	type customModel struct {
+		UUID      string    `json:"uuid"`
+		Name      string    `json:"name"`
+		Status    string    `json:"status"`
+		SourceRef sourceRef `json:"source_ref"`
+	}
+	type importResponse struct {
+		Model customModel `json:"model"`
+	}
+
+	ctx, c := getTestClient(t)
+	importArgs := map[string]any{
+		"name":        modelName,
+		"source_type": "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref": map[string]any{
+			"repo_id":     e2eHFRepoID,
+			"access_type": "ACCESS_TYPE_PUBLIC",
+		},
+		"accept_terms_and_conditions": true,
+	}
+
+	const importRetryAttempts = 4
+	var resp *mcp.CallToolResult
+	var lastErrText string
+	for attempt := 0; attempt < importRetryAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+		var err error
+		resp, err = c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{Name: "genai-custom-models-import", Arguments: importArgs},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		if !resp.IsError {
+			break
+		}
+		lastErrText = callToolResultText(resp)
+		if strings.Contains(lastErrText, "already imported") && strings.Contains(lastErrText, e2eHFRepoID) {
+			require.Regexp(t, `[0-9a-f]{40}`, lastErrText, "error should reference resolved commit revision")
+			t.Logf("revision already imported (commit_sha reached API): %s", lastErrText)
+			return
+		}
+		if strings.Contains(lastErrText, "404") && strings.Contains(lastErrText, "not found") {
+			t.Logf("attempt %d/%d: transient 404 on import: %s", attempt+1, importRetryAttempts, lastErrText)
+			continue
+		}
+		t.Fatalf("Tool genai-custom-models-import failed: %s", lastErrText)
+	}
+	if resp != nil && resp.IsError {
+		if strings.Contains(lastErrText, "404") {
+			t.Skipf("GenAI import returned transient 404 after %d attempts: %s", importRetryAttempts, lastErrText)
+		}
+		t.Fatalf("Tool genai-custom-models-import failed: %s", lastErrText)
+	}
+
+	var out importResponse
+	require.NoError(t, json.Unmarshal([]byte(callToolResultText(resp)), &out))
+	require.NotEmpty(t, out.Model.UUID)
+	require.Len(t, out.Model.SourceRef.CommitSHA, 40, "import should pin commit_sha from Hugging Face Hub")
+	require.Regexp(t, `^[0-9a-f]{40}$`, out.Model.SourceRef.CommitSHA)
+	require.Equal(t, e2eHFRepoID, out.Model.SourceRef.RepoID)
+	t.Logf("import started model uuid=%s name=%s commit_sha=%s status=%s",
+		out.Model.UUID, out.Model.Name, out.Model.SourceRef.CommitSHA, out.Model.Status)
+
+	t.Cleanup(func() {
+		callTool[map[string]any](t, "genai-custom-models-delete", map[string]any{
+			"uuid": out.Model.UUID,
+		})
+	})
+}
+
+func callToolResultText(resp *mcp.CallToolResult) string {
+	if resp == nil || len(resp.Content) == 0 {
+		return ""
+	}
+	if tc, ok := resp.Content[0].(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return fmt.Sprintf("%v", resp.Content)
+}
+
+// TestCustomModelsImportHuggingFaceInvalidRepoFailsBeforeImport ensures an unknown
+// Hugging Face repo fails during commit_sha resolution without starting an import job.
+func TestCustomModelsImportHuggingFaceInvalidRepoFailsBeforeImport(t *testing.T) {
+	t.Parallel()
+
+	errText := callToolExpectError(t, "genai-custom-models-import", map[string]any{
+		"name":        fmt.Sprintf("it-hf-invalid-%d", time.Now().Unix()),
+		"source_type": "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref": map[string]any{
+			"repo_id":     "this-org/does-not-exist-xyz-404",
+			"access_type": "ACCESS_TYPE_PUBLIC",
+		},
+		"accept_terms_and_conditions": true,
+	})
+
+	require.True(t,
+		strings.Contains(errText, "commit_sha") || strings.Contains(errText, "404"),
+		"expected commit_sha resolution failure, got: %s", errText)
+}
+
+func callToolExpectError(t *testing.T, name string, args map[string]any) string {
+	t.Helper()
+
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: name, Arguments: args},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError, "tool %s should return an error", name)
+
+	if len(resp.Content) == 0 {
+		return ""
+	}
+	if tc, ok := resp.Content[0].(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return fmt.Sprintf("%v", resp.Content)
 }


### PR DESCRIPTION
## Summary

- Resolve Hugging Face `commit_sha` from the Hub when omitted, before calling the GenAI import API (avoids transient 404s).
- Require explicit `accept_terms_and_conditions` consent on every import.
- Add unit tests and E2E integration tests under `testing/`.

(Spaces Bucket `source_ref` fields were merged in #361.)

## Test plan

- [x] `go test ./pkg/registry/genai-custom-models/...`
- [x] `go test -tags=integration ./testing/... -run TestCustomModels` (with `MCP_SERVER_URL`)
