### PR TITLE
Add model evaluation preset MCP tools

### DIFF
--- a/pkg/registry/genai/model_evaluation_models.go
+++ b/pkg/registry/genai/model_evaluation_models.go
@@ -17,6 +17,29 @@ const (
 	ModelEvalRunStatusFailed              ModelEvaluationRunStatus = "FAILED"
 )
 
+// ModelEvaluationPreset represents a reusable model evaluation configuration.
+type ModelEvaluationPreset struct {
+	EvalPresetUUID string              `json:"eval_preset_uuid"`
+	Name           string              `json:"name"`
+	DatasetUUID    string              `json:"dataset_uuid"`
+	DatasetName    string              `json:"dataset_name"`
+	JudgeModelUUID string              `json:"judge_model_uuid"`
+	JudgeModelName string              `json:"judge_model_name"`
+	Metrics        []*EvaluationMetric `json:"metrics,omitempty"`
+	StarMetric     *StarMetric         `json:"star_metric,omitempty"`
+	CreatedAt      *time.Time          `json:"created_at,omitempty"`
+}
+
+// ListModelEvaluationPresetsOutput is the response from listing presets.
+type ListModelEvaluationPresetsOutput struct {
+	Presets []*ModelEvaluationPreset `json:"presets"`
+}
+
+// GetModelEvaluationPresetOutput is the response from getting a single preset.
+type GetModelEvaluationPresetOutput struct {
+	Preset *ModelEvaluationPreset `json:"preset"`
+}
+
 // CandidateInferenceConfig holds inference parameters for the candidate model.
 type CandidateInferenceConfig struct {
 	MaxTokens   *int     `json:"max_tokens,omitempty"`

--- a/pkg/registry/genai/model_evaluation_tools.go
+++ b/pkg/registry/genai/model_evaluation_tools.go
@@ -18,6 +18,7 @@ import (
 
 const modelEvalAPIPath = genAIAPIPath + "/model_evaluation"
 const modelEvalRunsAPIPath = genAIAPIPath + "/model_evaluation_runs"
+const modelEvalPresetsAPIPath = genAIAPIPath + "/model_evaluation_presets"
 const modelEvalMetricsAPIPath = genAIAPIPath + "/model_evaluation_metrics"
 
 // ModelEvaluationTool provides model evaluation management tools.
@@ -61,6 +62,73 @@ func (met *ModelEvaluationTool) listMetrics(ctx context.Context, req mcp.CallToo
 	}
 
 	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// listPresets lists all model evaluation presets.
+func (met *ModelEvaluationTool) listPresets(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	client, err := met.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	apiReq, err := newGodoRequestWithContext(ctx, client, "GET", modelEvalPresetsAPIPath, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
+	}
+
+	var output ListModelEvaluationPresetsOutput
+	resp, err := client.Do(ctx, apiReq, &output)
+	if err != nil || resp.StatusCode >= 400 {
+		return mcp.NewToolResultErrorFromErr("failed to list model evaluation presets", err), nil
+	}
+
+	type PresetsResponse struct {
+		Presets []*ModelEvaluationPreset `json:"presets"`
+		Count   int                      `json:"count"`
+	}
+
+	response := PresetsResponse{
+		Presets: output.Presets,
+		Count:   len(output.Presets),
+	}
+
+	jsonData, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// getPreset gets a single model evaluation preset by UUID.
+func (met *ModelEvaluationTool) getPreset(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	presetUUID, ok := req.GetArguments()["eval_preset_uuid"].(string)
+	if !ok || presetUUID == "" {
+		return mcp.NewToolResultError("eval_preset_uuid is required"), nil
+	}
+
+	client, err := met.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	apiReq, err := newGodoRequestWithContext(ctx, client, "GET", modelEvalPresetsAPIPath+"/"+presetUUID, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
+	}
+
+	var output GetModelEvaluationPresetOutput
+	resp, err := client.Do(ctx, apiReq, &output)
+	if err != nil || resp.StatusCode >= 400 {
+		return mcp.NewToolResultErrorFromErr("failed to get model evaluation preset", err), nil
+	}
+
+	jsonData, err := json.MarshalIndent(output.Preset, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -659,6 +727,21 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-model-eval-list-metrics",
 				mcp.WithDescription("List all available model evaluation metrics."),
+			),
+		},
+		{
+			Handler: met.listPresets,
+			Tool: mcp.NewTool(
+				"genai-model-eval-list-presets",
+				mcp.WithDescription("List all model evaluation presets. Presets are reusable evaluation configurations containing a dataset, judge model, and metrics."),
+			),
+		},
+		{
+			Handler: met.getPreset,
+			Tool: mcp.NewTool(
+				"genai-model-eval-get-preset",
+				mcp.WithDescription("Get a single model evaluation preset by UUID."),
+				mcp.WithString("eval_preset_uuid", mcp.Required(), mcp.Description("UUID of the evaluation preset")),
 			),
 		},
 		{

--- a/pkg/registry/genai/model_evaluation_tools_test.go
+++ b/pkg/registry/genai/model_evaluation_tools_test.go
@@ -22,10 +22,12 @@ func TestModelEvaluationTool_Tools(t *testing.T) {
 	})
 
 	tools := tool.Tools()
-	require.Len(t, tools, 7, "should have 7 model evaluation tools")
+	require.Len(t, tools, 9, "should have 9 model evaluation tools")
 
 	expectedTools := map[string]bool{
 		"genai-model-eval-list-metrics":             false,
+		"genai-model-eval-list-presets":             false,
+		"genai-model-eval-get-preset":               false,
 		"genai-model-eval-create-dataset":           false,
 		"genai-model-eval-create-run":               false,
 		"genai-model-eval-list-runs":                false,
@@ -50,6 +52,44 @@ func TestModelEvaluationTool_listMetrics_clientError(t *testing.T) {
 	tool := setupModelEvalToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
 	_, err := tool.listMetrics(context.Background(), req)
+	require.Error(t, err)
+}
+
+func TestModelEvaluationTool_listPresets_clientError(t *testing.T) {
+	tool := setupModelEvalToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	_, err := tool.listPresets(context.Background(), req)
+	require.Error(t, err)
+}
+
+func TestModelEvaluationTool_getPreset_missingUUID(t *testing.T) {
+	tool := setupModelEvalToolWithFailingClient()
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing eval_preset_uuid", args: map[string]any{}},
+		{name: "empty eval_preset_uuid", args: map[string]any{"eval_preset_uuid": ""}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.getPreset(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.True(t, resp.IsError)
+		})
+	}
+}
+
+func TestModelEvaluationTool_getPreset_clientError(t *testing.T) {
+	tool := setupModelEvalToolWithFailingClient()
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"eval_preset_uuid": "test-uuid",
+	}}}
+	_, err := tool.getPreset(context.Background(), req)
 	require.Error(t, err)
 }
 

--- a/testing/e2e_model_evaluation_test.go
+++ b/testing/e2e_model_evaluation_test.go
@@ -30,6 +30,62 @@ func TestModelEvalListMetrics(t *testing.T) {
 	t.Logf("listed %d model evaluation metric(s)", out.Count)
 }
 
+// TestModelEvalListPresets calls genai-model-eval-list-presets against the live GenAI API.
+func TestModelEvalListPresets(t *testing.T) {
+	t.Parallel()
+
+	type presetSummary struct {
+		EvalPresetUUID string `json:"eval_preset_uuid"`
+		Name           string `json:"name"`
+	}
+	type listPresetsResponse struct {
+		Presets []presetSummary `json:"presets"`
+		Count   int             `json:"count"`
+	}
+
+	out := callTool[listPresetsResponse](t, "genai-model-eval-list-presets", map[string]any{})
+
+	require.GreaterOrEqual(t, out.Count, 0)
+	require.Len(t, out.Presets, out.Count)
+	t.Logf("listed %d model evaluation preset(s)", out.Count)
+}
+
+// TestModelEvalGetPreset gets a single preset using a UUID from list-presets.
+// Skipped if no presets exist.
+func TestModelEvalGetPreset(t *testing.T) {
+	t.Parallel()
+
+	type presetSummary struct {
+		EvalPresetUUID string `json:"eval_preset_uuid"`
+		Name           string `json:"name"`
+	}
+	type listPresetsResponse struct {
+		Presets []presetSummary `json:"presets"`
+		Count   int             `json:"count"`
+	}
+
+	listOut := callTool[listPresetsResponse](t, "genai-model-eval-list-presets", map[string]any{})
+	if listOut.Count == 0 {
+		t.Skip("no model evaluation presets available to test get-preset")
+	}
+
+	presetUUID := listOut.Presets[0].EvalPresetUUID
+	require.NotEmpty(t, presetUUID)
+
+	type presetDetail struct {
+		EvalPresetUUID string `json:"eval_preset_uuid"`
+		Name           string `json:"name"`
+	}
+
+	out := callTool[presetDetail](t, "genai-model-eval-get-preset", map[string]any{
+		"eval_preset_uuid": presetUUID,
+	})
+
+	require.Equal(t, presetUUID, out.EvalPresetUUID)
+	require.NotEmpty(t, out.Name)
+	t.Logf("got preset %s (%s)", out.Name, out.EvalPresetUUID)
+}
+
 // TestModelEvalListRuns calls genai-model-eval-list-runs against the live GenAI API.
 func TestModelEvalListRuns(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Add `genai-model-eval-list-presets` for `GET /v2/gen-ai/model_evaluation_presets`
- Add `genai-model-eval-get-preset` for `GET /v2/gen-ai/model_evaluation_presets/{eval_preset_uuid}`
- Include unit tests and integration tests for the new tools

## Test plan
- [x] `go test ./pkg/registry/genai/...`
- [ ] Run integration tests with `DIGITALOCEAN_API_TOKEN` set: `go test -tags=integration ./testing/... -run TestModelEvalListPresets`
- [ ] Run integration tests: `go test -tags=integration ./testing/... -run TestModelEvalGetPreset`
- [ ] Verify tools appear under `genai-evaluation` service in local MCP


Made with [Cursor](https://cursor.com)