### PR TITLE
feat(genai-custom-models): safe delete by exact name/uuid with consent

### DIFF
--- a/pkg/registry/genai-custom-models/README.md
+++ b/pkg/registry/genai-custom-models/README.md
@@ -41,10 +41,12 @@ List custom models with optional status filter and pagination.
 ### `genai-custom-models-import`
 Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.
 
-**Consent (required every import):** Before calling this tool, the assistant must present import terms to the user and obtain explicit consent (yes) in the conversation. Set `accept_terms_and_conditions` to `true` only after the user agrees. This applies to every import, including re-imports of the same model. The tool rejects omitted or `false` values.
+**Model name (validated first):** Do not call this tool until the user has provided a non-empty model name (`name` must be a string; whitespace-only is rejected). The server checks `name` before any other import logic—for example it does **not** resolve Hugging Face `commit_sha`, validate consent arguments, or call the DigitalOcean API until `name` is valid.
+
+**Consent (required every import):** After you have a name, present import terms and obtain explicit consent (yes). Set `accept_terms_and_conditions` to `true` only after the user agrees. This applies to every import, including re-imports of the same model. The tool rejects omitted or `false` values.
 
 **Arguments:**
-- `name` (string, required): Name for the custom model
+- `name` (string, required): Non-empty display name from the user (leading/trailing spaces are trimmed and must leave a non-empty value)
 - `source_type` (string, required): `SOURCE_TYPE_HUGGINGFACE`, `SOURCE_TYPE_SPACES_BUCKET`, `SOURCE_TYPE_SDK_UPLOAD`, `SOURCE_TYPE_FINE_TUNING`
 - `source_ref` (object, required): Source reference with `repo_id`, `commit_sha` (optional for HuggingFace; if omitted, fetched from Hugging Face Hub before the import API is called), `access_type`, `hf_token` (for private/gated)
 - `accept_terms_and_conditions` (boolean, required): Must be `true` after explicit user consent in chat
@@ -77,17 +79,38 @@ At least one of `name`, `description`, or `tags` must be provided.
 **Returns:** JSON object with the updated model
 
 ### `genai-custom-models-delete`
-Delete a custom model.
+Delete a custom model by exact UUID or exact name.
+
+**Exact identifier:** Provide `uuid` OR `name` (at least one). Only a full UUID or an exact model name deletes. Partial uuid or partial name returns candidates only — never deletes, even with a single match. Do not substitute values from a partial-match list.
+
+**Consent (required for every delete):** Before calling with `confirm_deletion: true`, tell the user which model will be deleted (name and uuid), that deletion is permanent, and obtain explicit consent (yes).
 
 **Arguments:**
-- `uuid` (string, required): UUID of the custom model to delete
+- `name` (string, optional): Exact custom model name (case-sensitive after trimming). Partial names return name matches only.
+- `uuid` (string, optional): Exact full model UUID. Partial uuids return uuid matches only.
+- `confirm_deletion` (boolean): Must be `true` after explicit user consent when performing a delete
 
-**Returns:** JSON object with status
+**Returns:** JSON object with status on success
 
 ```json
 {
   "status": "DELETE_CUSTOM_MODEL_STATUS_SUCCESS",
   "error": ""
+}
+```
+
+**Returns (name not exact):** JSON object listing candidate models
+
+```json
+{
+  "message": "no custom model with exact name \"llama\"; ask the user to provide the exact name ...",
+  "query": "llama",
+  "matches": [
+    { "uuid": "...", "name": "my-llama-model", "status": "STATUS_READY" }
+  ],
+  "query_field": "name",
+  "requires_exact_match": true,
+  "do_not_substitute_name_or_uuid_from_matches": true
 }
 ```
 
@@ -114,26 +137,35 @@ Delete a custom model.
 ## Workflow Example
 
 ```
-1. Ask the user to accept import terms (storage cost, license, source). Wait for explicit yes.
+1. Ask the user for the custom model name. Do not import until they provide a non-empty name.
 
-2. Import a model from HuggingFace:
+2. Ask the user to accept import terms (storage cost, license, source). Wait for explicit yes.
+
+3. Import a model from HuggingFace:
    genai-custom-models-import
      name: "my-mistral-7b"
      source_type: "SOURCE_TYPE_HUGGINGFACE"
      source_ref: { "repo_id": "mistralai/Mistral-7B-v0.1", "access_type": "ACCESS_TYPE_PUBLIC" }
      accept_terms_and_conditions: true
 
-3. Check import status by listing models:
+4. Check import status by listing models:
    genai-custom-models-list
      status: "STATUS_IMPORTING"
 
-4. Once ready, update metadata:
+5. Once ready, update metadata:
    genai-custom-models-update-metadata
-     uuid: "<uuid from step 2>"
+     uuid: "<uuid from step 3>"
      description: "Production model for customer support"
      tags: { "tags": ["production", "v1"] }
 
-5. When no longer needed, delete:
+6. Confirm deletion with the user (permanent removal). Wait for explicit yes.
+
+7. Delete using the exact name or uuid the user confirmed:
    genai-custom-models-delete
-     uuid: "<uuid>"
+     name: "my-mistral-7b"
+     confirm_deletion: true
+   # or
+   genai-custom-models-delete
+     uuid: "<full-uuid>"
+     confirm_deletion: true
 ```

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -15,9 +16,14 @@ import (
 const customModelsAPIPath = "v2/gen-ai/custom_models"
 
 const (
+	importModelNameRequiredMsg = "name is required: ask the user for a non-empty model name before importing or calling this tool. Name is validated first; source checks (such as resolving Hugging Face commit_sha) and the API request do not run until name is valid."
+
+	importModelNameTypeMsg = "name must be a non-empty string supplied by the user; do not use numbers or other types."
+
 	importConsentRequiredMsg = "accept_terms_and_conditions must be true. Before importing, present the import terms to the user and obtain explicit consent (yes) in this conversation. Consent is required for every import, including re-imports of the same model."
 
 	genaiCustomModelsImportToolDescription = "Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.\n\n" +
+		"MODEL NAME REQUIRED: Do not call this tool until the user has supplied a non-empty model name string. Name is checked before anything else — no Hugging Face resolution, consent validation of other arguments, or API calls occur until name is valid.\n\n" +
 		"CONSENT REQUIRED (every import): Do not call this tool until the user has explicitly agreed to the import terms in the current conversation. " +
 		"Present the terms (storage cost, license, source) and ask for yes/no. This applies to every import request, even if the same model was imported before. " +
 		"Only pass accept_terms_and_conditions: true after the user says yes."
@@ -115,9 +121,17 @@ func (cmt *CustomModelsTool) listModels(ctx context.Context, req mcp.CallToolReq
 func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
-	name, _ := args["name"].(string)
+	nameRaw, hasName := args["name"]
+	if !hasName || nameRaw == nil {
+		return mcp.NewToolResultError(importModelNameRequiredMsg), nil
+	}
+	name, ok := nameRaw.(string)
+	if !ok {
+		return mcp.NewToolResultError(importModelNameTypeMsg), nil
+	}
+	name = strings.TrimSpace(name)
 	if name == "" {
-		return mcp.NewToolResultError("name is required"), nil
+		return mcp.NewToolResultError(importModelNameRequiredMsg), nil
 	}
 
 	sourceType, _ := args["source_type"].(string)
@@ -305,11 +319,24 @@ func (cmt *CustomModelsTool) getModel(ctx context.Context, req mcp.CallToolReque
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
-// deleteModel deletes a custom model.
+// deleteModel deletes a custom model by exact uuid or exact name (partial identifiers return candidates only).
 func (cmt *CustomModelsTool) deleteModel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	uuid, _ := req.GetArguments()["uuid"].(string)
-	if uuid == "" {
-		return mcp.NewToolResultError("uuid is required"), nil
+	args := req.GetArguments()
+	uuid, _ := args["uuid"].(string)
+	uuid = strings.TrimSpace(uuid)
+
+	name := ""
+	if nameRaw, hasName := args["name"]; hasName && nameRaw != nil {
+		var ok bool
+		name, ok = nameRaw.(string)
+		if !ok {
+			return mcp.NewToolResultError(deleteModelNameTypeMsg), nil
+		}
+		name = strings.TrimSpace(name)
+	}
+
+	if uuid == "" && name == "" {
+		return mcp.NewToolResultError(deleteModelIdentifierRequiredMsg), nil
 	}
 
 	client, err := cmt.client(ctx)
@@ -317,6 +344,40 @@ func (cmt *CustomModelsTool) deleteModel(ctx context.Context, req mcp.CallToolRe
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
+	models, err := listAllCustomModels(ctx, client)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to list custom models for delete resolution", err), nil
+	}
+
+	target, unresolved, err := resolveDeleteTarget(uuid, name, models)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	if unresolved != nil {
+		text, err := marshalDeleteUnresolvedResult(unresolved)
+		if err != nil {
+			return nil, err
+		}
+		return mcp.NewToolResultError(text), nil
+	}
+
+	confirmDeletion, _ := args["confirm_deletion"].(bool)
+	if !confirmDeletion {
+		return mcp.NewToolResultError(deleteConsentRequiredMsg), nil
+	}
+
+	model, err := getCustomModelByUUID(ctx, client, target.UUID)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to verify custom model before delete", err), nil
+	}
+	if model.Name != target.Name {
+		return mcp.NewToolResultError(fmt.Sprintf("model name mismatch: resolved %q but API returned %q", target.Name, model.Name)), nil
+	}
+
+	return cmt.deleteModelByUUID(ctx, client, target.UUID, target.Name)
+}
+
+func (cmt *CustomModelsTool) deleteModelByUUID(ctx context.Context, client *godo.Client, uuid, name string) (*mcp.CallToolResult, error) {
 	apiReq, err := newRequestWithContext(ctx, client, "DELETE", customModelsAPIPath+"/"+uuid, nil)
 	if err != nil {
 		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
@@ -324,8 +385,16 @@ func (cmt *CustomModelsTool) deleteModel(ctx context.Context, req mcp.CallToolRe
 
 	var output DeleteCustomModelOutput
 	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"DELETE returned 404 for model %q (%s) but the model still exists. Deletion may be blocked (for example active deployments) or the delete API may be unavailable in this environment — verify in the control panel or remove deployments first.",
+				name, uuid)), nil
+		}
 		return mcp.NewToolResultErrorFromErr("failed to delete custom model", err), nil
+	}
+	if resp.StatusCode >= 400 {
+		return mcp.NewToolResultErrorFromErr("failed to delete custom model", fmt.Errorf("status %d", resp.StatusCode)), nil
 	}
 
 	jsonData, err := json.MarshalIndent(output, "", "  ")
@@ -354,7 +423,7 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-custom-models-import",
 				mcp.WithDescription(genaiCustomModelsImportToolDescription),
-				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the custom model")),
+				mcp.WithString("name", mcp.Required(), mcp.Description("Non-empty name for the custom model (leading/trailing whitespace is rejected). Obtain this from the user before calling — it is validated before any import checks.")),
 				mcp.WithString("source_type", mcp.Required(), mcp.Description("Source type: SOURCE_TYPE_HUGGINGFACE, SOURCE_TYPE_SPACES_BUCKET, SOURCE_TYPE_SDK_UPLOAD, SOURCE_TYPE_FINE_TUNING")),
 				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference. For HuggingFace: repo_id (string, required), commit_sha (string, optional; if omitted, resolved from Hugging Face Hub before import), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models). For Spaces Bucket: bucket (string, required), region (string, optional), prefix (string, optional)")),
 				mcp.WithBoolean("accept_terms_and_conditions", mcp.Required(), mcp.Description(genaiCustomModelsImportAcceptTermsDescription)),
@@ -386,8 +455,10 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.deleteModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-delete",
-				mcp.WithDescription("Delete a custom model."),
-				mcp.WithString("uuid", mcp.Required(), mcp.Description("UUID of the custom model to delete")),
+				mcp.WithDescription(genaiCustomModelsDeleteToolDescription),
+				mcp.WithString("name", mcp.Description("Exact custom model name the user provided or confirmed (character-for-character, whitespace trimmed). Use this OR uuid. Partial names return candidates only.")),
+				mcp.WithString("uuid", mcp.Description("Exact full custom model UUID (8-4-4-4-12 hex). Use this OR name. Partial uuids return candidates only; never delete on a partial uuid even if one match.")),
+				mcp.WithBoolean("confirm_deletion", mcp.Description(genaiCustomModelsDeleteConfirmDescription)),
 			),
 		},
 		{

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -412,7 +412,7 @@ func TestCustomModelsTool_deleteModel_consentRequired(t *testing.T) {
 		{name: "missing confirm_deletion by name", args: map[string]any{"name": "my-model"}},
 		{name: "missing confirm_deletion by uuid", args: map[string]any{"uuid": modelUUID}},
 		{name: "confirm_deletion false", args: map[string]any{
-			"name":               "my-model",
+			"name":             "my-model",
 			"confirm_deletion": false,
 		}},
 	}
@@ -446,7 +446,7 @@ func TestCustomModelsTool_deleteModel_partialNameWithoutConsent(t *testing.T) {
 func TestCustomModelsTool_deleteModel_clientError(t *testing.T) {
 	tool := setupCustomModelsToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-		"uuid":               "123e4567-e89b-12d3-a456-426614174000",
+		"uuid":             "123e4567-e89b-12d3-a456-426614174000",
 		"confirm_deletion": true,
 	}}}
 	_, err := tool.deleteModel(context.Background(), req)

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -2,11 +2,17 @@ package genaicustommodels
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func setupCustomModelsToolWithFailingClient() *CustomModelsTool {
@@ -82,6 +88,17 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
 			"accept_terms_and_conditions": false,
 		}},
+		{name: "name whitespace only", args: map[string]any{
+			"name":        " \t ",
+			"source_type": "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":  map[string]interface{}{"repo_id": "test/model"},
+		}},
+		{name: "name wrong type", args: map[string]any{
+			"name":                        float64(42),
+			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+			"accept_terms_and_conditions": true,
+		}},
 	}
 
 	for _, tc := range tests {
@@ -93,6 +110,45 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 			require.True(t, resp.IsError)
 		})
 	}
+}
+
+func TestImportModel_invalidNameDoesNotResolveHuggingFace(t *testing.T) {
+	oldFetch := fetchHuggingFaceCommitSHA
+	hfCalled := false
+	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
+		hfCalled = true
+		return "", errors.New("Hugging Face resolution should not run without a valid name")
+	}
+	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
+
+	tool := setupCustomModelsToolWithFailingClient()
+
+	t.Run("missing name", func(t *testing.T) {
+		hfCalled = false
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+			"accept_terms_and_conditions": true,
+		}}}
+		resp, err := tool.importModel(context.Background(), req)
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.False(t, hfCalled)
+	})
+
+	t.Run("whitespace name", func(t *testing.T) {
+		hfCalled = false
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"name":                        " ",
+			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
+			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
+			"accept_terms_and_conditions": true,
+		}}}
+		resp, err := tool.importModel(context.Background(), req)
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.False(t, hfCalled)
+	})
 }
 
 func TestCustomModelsTool_importModel_spacesSourceRef(t *testing.T) {
@@ -207,8 +263,10 @@ func TestCustomModelsTool_deleteModel_validation(t *testing.T) {
 		name string
 		args map[string]any
 	}{
-		{name: "missing uuid", args: map[string]any{}},
-		{name: "empty uuid", args: map[string]any{"uuid": ""}},
+		{name: "missing uuid and name", args: map[string]any{}},
+		{name: "empty uuid and name", args: map[string]any{"uuid": "", "name": ""}},
+		{name: "whitespace name only", args: map[string]any{"name": "  "}},
+		{name: "name wrong type", args: map[string]any{"name": float64(1)}},
 	}
 
 	for _, tc := range tests {
@@ -222,10 +280,174 @@ func TestCustomModelsTool_deleteModel_validation(t *testing.T) {
 	}
 }
 
+func TestCustomModelsTool_deleteModel_partialUUIDWithoutConsent(t *testing.T) {
+	const modelUUID = "123e4567-e89b-12d3-a456-426614174000"
+	tool := setupCustomModelsToolWithTestServer(t, []*CustomModel{
+		{UUID: modelUUID, Name: "mcp-delete-test-3", Status: CustomModelStatusReady},
+	})
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"uuid": "123e4567",
+	}}}
+	resp, err := tool.deleteModel(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	requireToolErrorContains(t, resp, "partial uuid")
+	requireToolErrorContains(t, resp, modelUUID)
+}
+
+func TestResolveCustomModelUUIDByName(t *testing.T) {
+	models := []*CustomModel{
+		{UUID: "uuid-1", Name: "my-llama-model", Status: CustomModelStatusReady},
+		{UUID: "uuid-2", Name: "my-gpt-model", Status: CustomModelStatusReady},
+		{UUID: "uuid-3", Name: "my-llama-model", Status: CustomModelStatusReady},
+		{UUID: "uuid-deleted", Name: "old-llama", Status: CustomModelStatusDeleted},
+	}
+
+	t.Run("exact name match", func(t *testing.T) {
+		uuid, unresolved, err := resolveCustomModelUUIDByName("my-gpt-model", models)
+		require.NoError(t, err)
+		require.Nil(t, unresolved)
+		require.Equal(t, "uuid-2", uuid)
+	})
+
+	t.Run("partial name returns matches", func(t *testing.T) {
+		uuid, unresolved, err := resolveCustomModelUUIDByName("llama", models)
+		require.NoError(t, err)
+		require.Empty(t, uuid)
+		require.NotNil(t, unresolved)
+		require.Len(t, unresolved.Matches, 2)
+		require.Equal(t, "llama", unresolved.Query)
+		require.True(t, unresolved.RequiresExactMatch)
+		require.Equal(t, "name", unresolved.QueryField)
+		require.True(t, unresolved.DoNotSubstituteFromList)
+	})
+
+	t.Run("single partial match still unresolved", func(t *testing.T) {
+		only := []*CustomModel{
+			{UUID: "uuid-1", Name: "mcp-delete-test-3", Status: CustomModelStatusReady},
+		}
+		uuid, unresolved, err := resolveCustomModelUUIDByName("mcp-delete-tes", only)
+		require.NoError(t, err)
+		require.Empty(t, uuid)
+		require.NotNil(t, unresolved)
+		require.Len(t, unresolved.Matches, 1)
+		require.Contains(t, unresolved.Message, "mcp-delete-test-3")
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		_, unresolved, err := resolveCustomModelUUIDByName("mistral", models)
+		require.NoError(t, err)
+		require.NotNil(t, unresolved)
+		require.Empty(t, unresolved.Matches)
+	})
+
+	t.Run("duplicate exact names", func(t *testing.T) {
+		_, _, err := resolveCustomModelUUIDByName("my-llama-model", models)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "multiple custom models")
+	})
+
+	t.Run("deleted model excluded from partial match", func(t *testing.T) {
+		onlyDeleted := []*CustomModel{
+			{UUID: "uuid-deleted", Name: "old-llama", Status: CustomModelStatusDeleted},
+		}
+		_, unresolved, err := resolveCustomModelUUIDByName("llama", onlyDeleted)
+		require.NoError(t, err)
+		require.NotNil(t, unresolved)
+		require.Empty(t, unresolved.Matches)
+	})
+}
+
+func TestResolveCustomModelUUIDByUUID(t *testing.T) {
+	fullUUID := "123e4567-e89b-12d3-a456-426614174000"
+	models := []*CustomModel{
+		{UUID: fullUUID, Name: "my-model", Status: CustomModelStatusReady},
+		{UUID: "223e4567-e89b-12d3-a456-426614174001", Name: "other", Status: CustomModelStatusReady},
+	}
+
+	t.Run("exact uuid match", func(t *testing.T) {
+		uuid, unresolved, err := resolveCustomModelUUIDByUUID(fullUUID, models)
+		require.NoError(t, err)
+		require.Nil(t, unresolved)
+		require.Equal(t, fullUUID, uuid)
+	})
+
+	t.Run("partial uuid returns matches never deletes", func(t *testing.T) {
+		uuid, unresolved, err := resolveCustomModelUUIDByUUID("123e4567", models)
+		require.NoError(t, err)
+		require.Empty(t, uuid)
+		require.NotNil(t, unresolved)
+		require.Len(t, unresolved.Matches, 1)
+		require.Equal(t, "uuid", unresolved.QueryField)
+	})
+
+	t.Run("single partial uuid still unresolved", func(t *testing.T) {
+		uuid, unresolved, err := resolveCustomModelUUIDByUUID("426614174000", models)
+		require.NoError(t, err)
+		require.Empty(t, uuid)
+		require.NotNil(t, unresolved)
+		require.Len(t, unresolved.Matches, 1)
+	})
+
+	t.Run("unknown exact uuid format", func(t *testing.T) {
+		unknown := "00000000-0000-4000-8000-000000000099"
+		_, unresolved, err := resolveCustomModelUUIDByUUID(unknown, models)
+		require.NoError(t, err)
+		require.NotNil(t, unresolved)
+		require.Empty(t, unresolved.Matches)
+	})
+}
+
+func TestCustomModelsTool_deleteModel_consentRequired(t *testing.T) {
+	const modelUUID = "123e4567-e89b-12d3-a456-426614174000"
+	tool := setupCustomModelsToolWithTestServer(t, []*CustomModel{
+		{UUID: modelUUID, Name: "my-model", Status: CustomModelStatusReady},
+	})
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing confirm_deletion by name", args: map[string]any{"name": "my-model"}},
+		{name: "missing confirm_deletion by uuid", args: map[string]any{"uuid": modelUUID}},
+		{name: "confirm_deletion false", args: map[string]any{
+			"name":               "my-model",
+			"confirm_deletion": false,
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.deleteModel(context.Background(), req)
+			require.NoError(t, err, "consent rejection should be a tool error, not a client failure")
+			require.True(t, resp.IsError)
+			requireToolErrorContains(t, resp, "confirm_deletion")
+		})
+	}
+}
+
+func TestCustomModelsTool_deleteModel_partialNameWithoutConsent(t *testing.T) {
+	tool := setupCustomModelsToolWithTestServer(t, []*CustomModel{
+		{UUID: "123e4567-e89b-12d3-a456-426614174001", Name: "mcp-delete-test-3", Status: CustomModelStatusReady},
+	})
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name": "mcp-delete-tes",
+	}}}
+	resp, err := tool.deleteModel(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	requireToolErrorContains(t, resp, "requires_exact_match")
+	requireToolErrorContains(t, resp, "mcp-delete-test-3")
+}
+
 func TestCustomModelsTool_deleteModel_clientError(t *testing.T) {
 	tool := setupCustomModelsToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-		"uuid": "test-uuid",
+		"uuid":               "123e4567-e89b-12d3-a456-426614174000",
+		"confirm_deletion": true,
 	}}}
 	_, err := tool.deleteModel(context.Background(), req)
 	require.Error(t, err)
@@ -297,5 +519,50 @@ func TestCustomModelMatchesQuery(t *testing.T) {
 			result := customModelMatchesQuery(tc.model, tc.query)
 			require.Equal(t, tc.expected, result)
 		})
+	}
+}
+
+func setupCustomModelsToolWithTestServer(t *testing.T, models []*CustomModel) *CustomModelsTool {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v2/gen-ai/custom_models") {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/custom_models/") {
+			uuid := strings.TrimPrefix(r.URL.Path, "/v2/gen-ai/custom_models/")
+			for _, m := range models {
+				if m.UUID == uuid {
+					_ = json.NewEncoder(w).Encode(GetCustomModelOutput{Model: m})
+					return
+				}
+			}
+			http.NotFound(w, r)
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(ListCustomModelsOutput{Models: models})
+	}))
+	t.Cleanup(srv.Close)
+
+	httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}))
+	client, err := godo.New(httpClient, godo.SetBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	return NewCustomModelsTool(func(ctx context.Context) (*godo.Client, error) {
+		return client, nil
+	})
+}
+
+func requireToolErrorContains(t *testing.T, resp *mcp.CallToolResult, substr string) {
+	t.Helper()
+	require.True(t, resp.IsError)
+	if len(resp.Content) == 0 {
+		return
+	}
+	if tc, ok := resp.Content[0].(mcp.TextContent); ok {
+		require.Contains(t, tc.Text, substr)
 	}
 }

--- a/pkg/registry/genai-custom-models/delete_resolve.go
+++ b/pkg/registry/genai-custom-models/delete_resolve.go
@@ -1,0 +1,300 @@
+package genaicustommodels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/digitalocean/godo"
+)
+
+var customModelUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+const (
+	deleteModelIdentifierRequiredMsg = "either uuid or name is required: provide the exact custom model UUID or exact name the user typed or confirmed. Do not substitute values from a partial-match list."
+
+	deleteModelNameRequiredMsg = "name must be a non-empty string supplied by the user; do not use numbers or other types."
+
+	deleteModelUUIDNameMismatchMsg = "uuid and name refer to different models; provide the exact uuid and exact name for the same model, or pass only one identifier."
+
+	deleteModelNameTypeMsg = "name must be a string when provided."
+
+	deleteConsentRequiredMsg = "confirm_deletion must be true. Before deleting, identify the model (uuid and name), explain that deletion is permanent, and obtain explicit consent (yes) in this conversation. " +
+		"Consent is required for every delete. Only pass confirm_deletion: true after the user says yes."
+
+	genaiCustomModelsDeleteConfirmDescription = "Must be true only after the end user has explicitly confirmed deletion in conversation (yes/no in chat). " +
+		"Omitted or false is rejected. Not required when the tool only returns a name-match list (partial name with no exact match)."
+
+	genaiCustomModelsDeleteToolDescription = "Delete a custom model by exact UUID or exact name.\n\n" +
+		"EXACT IDENTIFIER REQUIRED: Provide uuid OR name (at least one). Only a full UUID (8-4-4-4-12 hex) or an exact model name deletes. " +
+		"Partial uuid or partial name returns candidates only — never deletes, even if only one match. " +
+		"Never substitute a name or uuid from a prior partial-match list.\n\n" +
+		"CONSENT REQUIRED (every delete): Do not call with confirm_deletion: true until the user has explicitly agreed to delete that model. " +
+		"Present name, uuid, and that deletion is permanent; ask for yes/no.\n\n" +
+		"If both uuid and name are set, they must refer to the same model."
+)
+
+// DeleteModelMatchCandidate is a custom model returned when delete-by-name needs disambiguation.
+type DeleteModelMatchCandidate struct {
+	UUID   string `json:"uuid"`
+	Name   string `json:"name"`
+	Status string `json:"status,omitempty"`
+}
+
+// DeleteModelUnresolvedOutput is returned when the identifier is not an exact match.
+type DeleteModelUnresolvedOutput struct {
+	Message                 string                      `json:"message"`
+	Query                   string                      `json:"query"`
+	QueryField              string                      `json:"query_field"`
+	Matches                 []DeleteModelMatchCandidate `json:"matches"`
+	RequiresExactMatch        bool                        `json:"requires_exact_match"`
+	DoNotSubstituteFromList bool                        `json:"do_not_substitute_name_or_uuid_from_matches"`
+}
+
+type deleteTarget struct {
+	UUID string
+	Name string
+}
+
+// listAllCustomModels fetches every custom model page from the API.
+func listAllCustomModels(ctx context.Context, client *godo.Client) ([]*CustomModel, error) {
+	const perPage = 100
+	var all []*CustomModel
+	page := 1
+
+	for {
+		q := url.Values{}
+		q.Set("page", fmt.Sprintf("%d", page))
+		q.Set("per_page", fmt.Sprintf("%d", perPage))
+		path := customModelsAPIPath + "?" + q.Encode()
+
+		apiReq, err := newRequestWithContext(ctx, client, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		var output ListCustomModelsOutput
+		resp, err := client.Do(ctx, apiReq, &output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list custom models: %w", err)
+		}
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("failed to list custom models: status %d", resp.StatusCode)
+		}
+
+		all = append(all, output.Models...)
+
+		if len(output.Models) == 0 {
+			break
+		}
+		if output.Meta != nil && output.Meta.Pages > 0 && page >= output.Meta.Pages {
+			break
+		}
+		if len(output.Models) < perPage {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
+// resolveCustomModelUUIDByName finds a single model by exact name, or partial name matches.
+func resolveCustomModelUUIDByName(name string, models []*CustomModel) (uuid string, unresolved *DeleteModelUnresolvedOutput, err error) {
+	active := filterNonDeletedCustomModels(models)
+
+	var exact []*CustomModel
+	for _, m := range active {
+		if m.Name == name {
+			exact = append(exact, m)
+		}
+	}
+
+	switch len(exact) {
+	case 1:
+		return exact[0].UUID, nil, nil
+	case 0:
+		queryLower := strings.ToLower(name)
+		var partial []*CustomModel
+		for _, m := range active {
+			if customModelNameMatchesQuery(m, queryLower) {
+				partial = append(partial, m)
+			}
+		}
+		return "", buildDeleteUnresolvedOutput(name, "name", partial), nil
+	default:
+		return "", nil, fmt.Errorf("multiple custom models named %q; provide uuid to delete one", name)
+	}
+}
+
+// resolveCustomModelUUIDByUUID finds a model by exact full UUID, or returns partial uuid matches (never auto-deletes on partial).
+func resolveCustomModelUUIDByUUID(uuid string, models []*CustomModel) (resolved string, unresolved *DeleteModelUnresolvedOutput, err error) {
+	active := filterNonDeletedCustomModels(models)
+
+	if isExactCustomModelUUID(uuid) {
+		var exact []*CustomModel
+		for _, m := range active {
+			if strings.EqualFold(m.UUID, uuid) {
+				exact = append(exact, m)
+			}
+		}
+		switch len(exact) {
+		case 1:
+			return exact[0].UUID, nil, nil
+		case 0:
+			return "", buildDeleteUnresolvedOutput(uuid, "uuid", nil), nil
+		default:
+			return "", nil, fmt.Errorf("multiple custom models with uuid %q", uuid)
+		}
+	}
+
+	queryLower := strings.ToLower(uuid)
+	var partial []*CustomModel
+	for _, m := range active {
+		if strings.Contains(strings.ToLower(m.UUID), queryLower) {
+			partial = append(partial, m)
+		}
+	}
+	return "", buildDeleteUnresolvedOutput(uuid, "uuid", partial), nil
+}
+
+func isExactCustomModelUUID(uuid string) bool {
+	return customModelUUIDPattern.MatchString(uuid)
+}
+
+// resolveDeleteTarget resolves an exact model from uuid and/or name. Partial identifiers never return a target.
+func resolveDeleteTarget(uuid, name string, models []*CustomModel) (*deleteTarget, *DeleteModelUnresolvedOutput, error) {
+	switch {
+	case uuid != "" && name != "":
+		nameUUID, nameUnresolved, err := resolveCustomModelUUIDByName(name, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if nameUnresolved != nil {
+			return nil, nameUnresolved, nil
+		}
+		uuidResolved, uuidUnresolved, err := resolveCustomModelUUIDByUUID(uuid, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if uuidUnresolved != nil {
+			return nil, uuidUnresolved, nil
+		}
+		if nameUUID != uuidResolved {
+			return nil, nil, fmt.Errorf("%s", deleteModelUUIDNameMismatchMsg)
+		}
+		return &deleteTarget{UUID: nameUUID, Name: name}, nil, nil
+
+	case uuid != "":
+		uuidResolved, uuidUnresolved, err := resolveCustomModelUUIDByUUID(uuid, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if uuidUnresolved != nil {
+			return nil, uuidUnresolved, nil
+		}
+		for _, m := range filterNonDeletedCustomModels(models) {
+			if strings.EqualFold(m.UUID, uuidResolved) {
+				return &deleteTarget{UUID: uuidResolved, Name: m.Name}, nil, nil
+			}
+		}
+		return nil, nil, fmt.Errorf("custom model %q not found", uuidResolved)
+
+	default:
+		nameUUID, nameUnresolved, err := resolveCustomModelUUIDByName(name, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if nameUnresolved != nil {
+			return nil, nameUnresolved, nil
+		}
+		return &deleteTarget{UUID: nameUUID, Name: name}, nil, nil
+	}
+}
+
+func filterNonDeletedCustomModels(models []*CustomModel) []*CustomModel {
+	out := make([]*CustomModel, 0, len(models))
+	for _, m := range models {
+		if m == nil || m.Status == CustomModelStatusDeleted {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func customModelNameMatchesQuery(cm *CustomModel, queryLower string) bool {
+	return strings.Contains(strings.ToLower(cm.Name), queryLower)
+}
+
+func buildDeleteUnresolvedOutput(query, queryField string, matches []*CustomModel) *DeleteModelUnresolvedOutput {
+	candidates := make([]DeleteModelMatchCandidate, 0, len(matches))
+	for _, m := range matches {
+		candidates = append(candidates, DeleteModelMatchCandidate{
+			UUID:   m.UUID,
+			Name:   m.Name,
+			Status: string(m.Status),
+		})
+	}
+
+	var msg string
+	switch queryField {
+	case "uuid":
+		msg = fmt.Sprintf("no custom model with exact uuid %q; ask the user to provide the full uuid from the matches below — do not delete from a partial uuid", query)
+		if len(candidates) == 0 {
+			msg = fmt.Sprintf("no custom model with exact uuid %q and no models whose uuids contain that string", query)
+		}
+		if len(candidates) == 1 {
+			msg = fmt.Sprintf("partial uuid %q — one model matched (%s / %q) but deletion requires the exact full uuid; ask the user to confirm the complete uuid", query, candidates[0].UUID, candidates[0].Name)
+		}
+	default:
+		msg = fmt.Sprintf("no custom model with exact name %q; ask the user to provide the exact name (character-for-character) from the matches below — do not substitute a similar name or pass uuid from this list", query)
+		if len(candidates) == 0 {
+			msg = fmt.Sprintf("no custom model with exact name %q and no models whose names contain that string", query)
+		}
+		if len(candidates) == 1 {
+			msg = fmt.Sprintf("no custom model with exact name %q; one similar model exists (%q) — ask the user to confirm that exact name before deleting; do not delete until they provide it verbatim", query, candidates[0].Name)
+		}
+	}
+
+	return &DeleteModelUnresolvedOutput{
+		Message:                 msg,
+		Query:                   query,
+		QueryField:              queryField,
+		Matches:                 candidates,
+		RequiresExactMatch:      true,
+		DoNotSubstituteFromList: true,
+	}
+}
+
+func getCustomModelByUUID(ctx context.Context, client *godo.Client, uuid string) (*CustomModel, error) {
+	apiReq, err := newRequestWithContext(ctx, client, http.MethodGet, customModelsAPIPath+"/"+uuid, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var output GetCustomModelOutput
+	resp, err := client.Do(ctx, apiReq, &output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom model: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed to get custom model: status %d", resp.StatusCode)
+	}
+	if output.Model == nil {
+		return nil, fmt.Errorf("custom model %q not found", uuid)
+	}
+	return output.Model, nil
+}
+
+func marshalDeleteUnresolvedResult(out *DeleteModelUnresolvedOutput) (string, error) {
+	jsonData, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal error: %w", err)
+	}
+	return string(jsonData), nil
+}

--- a/pkg/registry/genai-custom-models/delete_resolve.go
+++ b/pkg/registry/genai-custom-models/delete_resolve.go
@@ -51,7 +51,7 @@ type DeleteModelUnresolvedOutput struct {
 	Query                   string                      `json:"query"`
 	QueryField              string                      `json:"query_field"`
 	Matches                 []DeleteModelMatchCandidate `json:"matches"`
-	RequiresExactMatch        bool                        `json:"requires_exact_match"`
+	RequiresExactMatch      bool                        `json:"requires_exact_match"`
 	DoNotSubstituteFromList bool                        `json:"do_not_substitute_name_or_uuid_from_matches"`
 }
 

--- a/testing/e2e_custom_models_test.go
+++ b/testing/e2e_custom_models_test.go
@@ -164,7 +164,9 @@ func TestCustomModelsImportHuggingFaceResolvesCommitSHA(t *testing.T) {
 
 	t.Cleanup(func() {
 		callTool[map[string]any](t, "genai-custom-models-delete", map[string]any{
-			"uuid": out.Model.UUID,
+			"name":               out.Model.Name,
+			"uuid":               out.Model.UUID,
+			"confirm_deletion": true,
 		})
 	})
 }

--- a/testing/e2e_custom_models_test.go
+++ b/testing/e2e_custom_models_test.go
@@ -164,8 +164,8 @@ func TestCustomModelsImportHuggingFaceResolvesCommitSHA(t *testing.T) {
 
 	t.Cleanup(func() {
 		callTool[map[string]any](t, "genai-custom-models-delete", map[string]any{
-			"name":               out.Model.Name,
-			"uuid":               out.Model.UUID,
+			"name":             out.Model.Name,
+			"uuid":             out.Model.UUID,
 			"confirm_deletion": true,
 		})
 	})


### PR DESCRIPTION
## Summary

- **Delete (`genai-custom-models-delete`)**: Accept exact `uuid` or exact `name`; partial identifiers list candidates and never delete (even on a single match). Require `confirm_deletion: true` after explicit user consent. New `delete_resolve.go` lists models and resolves targets.
- **Import (`genai-custom-models-import`)**: Validate non-empty `name` (string, trimmed) before Hugging Face `commit_sha` resolution, consent checks, or API calls.
- **Docs & tests**: README workflow/consent guidance, unit tests for resolution and consent, e2e cleanup uses `confirm_deletion`.

## Test plan

- [x] `go test ./pkg/registry/genai-custom-models/...`
- [x] E2E: `go test -tags=e2e ./testing/... -run TestCustomModels` (with DO token)

