### PR TITLE
MS-525: Improve model evaluation MCP tools (dataset, resolve, consent)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module mcp-digitalocean
 go 1.25.3
 
 require (
-	github.com/digitalocean/godo v1.187.0
+	github.com/digitalocean/godo v1.192.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/invopop/jsonschema v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.187.0 h1:Ga+pkJdebdhnzWmIjusyehDzm+WZ/joLiXM00tPOXVs=
 github.com/digitalocean/godo v1.187.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.192.0 h1:It3AcVa123/Eh/Ol+F9CXXBBlTsWyUIYe8yZhhFZ9Q4=
+github.com/digitalocean/godo v1.192.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=

--- a/pkg/registry/genai-custom-models/README.md
+++ b/pkg/registry/genai-custom-models/README.md
@@ -41,12 +41,10 @@ List custom models with optional status filter and pagination.
 ### `genai-custom-models-import`
 Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.
 
-**Model name (validated first):** Do not call this tool until the user has provided a non-empty model name (`name` must be a string; whitespace-only is rejected). The server checks `name` before any other import logic—for example it does **not** resolve Hugging Face `commit_sha`, validate consent arguments, or call the DigitalOcean API until `name` is valid.
-
-**Consent (required every import):** After you have a name, present import terms and obtain explicit consent (yes). Set `accept_terms_and_conditions` to `true` only after the user agrees. This applies to every import, including re-imports of the same model. The tool rejects omitted or `false` values.
+**Consent (required every import):** Present import terms and obtain explicit consent (yes) before calling. Set `accept_terms_and_conditions` to `true` only after the user agrees. Consent is validated before Hugging Face `commit_sha` resolution or the DigitalOcean API. This applies to every import, including re-imports of the same model. The tool rejects omitted or `false` values.
 
 **Arguments:**
-- `name` (string, required): Non-empty display name from the user (leading/trailing spaces are trimmed and must leave a non-empty value)
+- `name` (string, optional): Display name (leading/trailing spaces are trimmed when provided)
 - `source_type` (string, required): `SOURCE_TYPE_HUGGINGFACE`, `SOURCE_TYPE_SPACES_BUCKET`, `SOURCE_TYPE_SDK_UPLOAD`, `SOURCE_TYPE_FINE_TUNING`
 - `source_ref` (object, required): Source reference with `repo_id`, `commit_sha` (optional for HuggingFace; if omitted, fetched from Hugging Face Hub before the import API is called), `access_type`, `hf_token` (for private/gated)
 - `accept_terms_and_conditions` (boolean, required): Must be `true` after explicit user consent in chat
@@ -137,30 +135,28 @@ Delete a custom model by exact UUID or exact name.
 ## Workflow Example
 
 ```
-1. Ask the user for the custom model name. Do not import until they provide a non-empty name.
+1. Ask the user to accept import terms (storage cost, license, source). Wait for explicit yes.
 
-2. Ask the user to accept import terms (storage cost, license, source). Wait for explicit yes.
-
-3. Import a model from HuggingFace:
+2. Import a model from HuggingFace:
    genai-custom-models-import
      name: "my-mistral-7b"
      source_type: "SOURCE_TYPE_HUGGINGFACE"
      source_ref: { "repo_id": "mistralai/Mistral-7B-v0.1", "access_type": "ACCESS_TYPE_PUBLIC" }
      accept_terms_and_conditions: true
 
-4. Check import status by listing models:
+3. Check import status by listing models:
    genai-custom-models-list
      status: "STATUS_IMPORTING"
 
-5. Once ready, update metadata:
+4. Once ready, update metadata:
    genai-custom-models-update-metadata
-     uuid: "<uuid from step 3>"
+     uuid: "<uuid from step 2>"
      description: "Production model for customer support"
      tags: { "tags": ["production", "v1"] }
 
-6. Confirm deletion with the user (permanent removal). Wait for explicit yes.
+5. Confirm deletion with the user (permanent removal). Wait for explicit yes.
 
-7. Delete using the exact name or uuid the user confirmed:
+6. Delete using the exact name or uuid the user confirmed:
    genai-custom-models-delete
      name: "my-mistral-7b"
      confirm_deletion: true

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -16,15 +16,11 @@ import (
 const customModelsAPIPath = "v2/gen-ai/custom_models"
 
 const (
-	importModelNameRequiredMsg = "name is required: ask the user for a non-empty model name before importing or calling this tool. Name is validated first; source checks (such as resolving Hugging Face commit_sha) and the API request do not run until name is valid."
-
-	importModelNameTypeMsg = "name must be a non-empty string supplied by the user; do not use numbers or other types."
-
 	importConsentRequiredMsg = "accept_terms_and_conditions must be true. Before importing, present the import terms to the user and obtain explicit consent (yes) in this conversation. Consent is required for every import, including re-imports of the same model."
 
 	genaiCustomModelsImportToolDescription = "Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.\n\n" +
-		"MODEL NAME REQUIRED: Do not call this tool until the user has supplied a non-empty model name string. Name is checked before anything else — no Hugging Face resolution, consent validation of other arguments, or API calls occur until name is valid.\n\n" +
 		"CONSENT REQUIRED (every import): Do not call this tool until the user has explicitly agreed to the import terms in the current conversation. " +
+		"Consent is checked before any Hugging Face resolution or API calls. " +
 		"Present the terms (storage cost, license, source) and ask for yes/no. This applies to every import request, even if the same model was imported before. " +
 		"Only pass accept_terms_and_conditions: true after the user says yes."
 
@@ -121,17 +117,16 @@ func (cmt *CustomModelsTool) listModels(ctx context.Context, req mcp.CallToolReq
 func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
-	nameRaw, hasName := args["name"]
-	if !hasName || nameRaw == nil {
-		return mcp.NewToolResultError(importModelNameRequiredMsg), nil
+	acceptTerms, _ := args["accept_terms_and_conditions"].(bool)
+	if !acceptTerms {
+		return mcp.NewToolResultError(importConsentRequiredMsg), nil
 	}
-	name, ok := nameRaw.(string)
-	if !ok {
-		return mcp.NewToolResultError(importModelNameTypeMsg), nil
-	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return mcp.NewToolResultError(importModelNameRequiredMsg), nil
+
+	var name string
+	if nameRaw, ok := args["name"]; ok && nameRaw != nil {
+		if s, ok := nameRaw.(string); ok {
+			name = strings.TrimSpace(s)
+		}
 	}
 
 	sourceType, _ := args["source_type"].(string)
@@ -165,11 +160,6 @@ func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRe
 	}
 	if v, ok := sourceRefRaw["prefix"].(string); ok {
 		sourceRef.Prefix = v
-	}
-
-	acceptTerms, _ := args["accept_terms_and_conditions"].(bool)
-	if !acceptTerms {
-		return mcp.NewToolResultError(importConsentRequiredMsg), nil
 	}
 
 	if CustomModelSourceType(sourceType) == CustomModelSourceTypeHuggingFace {
@@ -423,7 +413,7 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-custom-models-import",
 				mcp.WithDescription(genaiCustomModelsImportToolDescription),
-				mcp.WithString("name", mcp.Required(), mcp.Description("Non-empty name for the custom model (leading/trailing whitespace is rejected). Obtain this from the user before calling — it is validated before any import checks.")),
+				mcp.WithString("name", mcp.Description("Optional display name for the custom model (leading/trailing whitespace is trimmed when provided).")),
 				mcp.WithString("source_type", mcp.Required(), mcp.Description("Source type: SOURCE_TYPE_HUGGINGFACE, SOURCE_TYPE_SPACES_BUCKET, SOURCE_TYPE_SDK_UPLOAD, SOURCE_TYPE_FINE_TUNING")),
 				mcp.WithObject("source_ref", mcp.Required(), mcp.Description("Source reference. For HuggingFace: repo_id (string, required), commit_sha (string, optional; if omitted, resolved from Hugging Face Hub before import), access_type (ACCESS_TYPE_PUBLIC, ACCESS_TYPE_PRIVATE, ACCESS_TYPE_GATED), hf_token (string, for private/gated models). For Spaces Bucket: bucket (string, required), region (string, optional), prefix (string, optional)")),
 				mcp.WithBoolean("accept_terms_and_conditions", mcp.Required(), mcp.Description(genaiCustomModelsImportAcceptTermsDescription)),

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
-
-const customModelsAPIPath = "v2/gen-ai/custom_models"
 
 const (
 	importConsentRequiredMsg = "accept_terms_and_conditions must be true. Before importing, present the import terms to the user and obtain explicit consent (yes) in this conversation. Consent is required for every import, including re-imports of the same model."
@@ -38,26 +34,6 @@ func NewCustomModelsTool(client func(ctx context.Context) (*godo.Client, error))
 	return &CustomModelsTool{client: client}
 }
 
-// newRequestWithContext builds an authenticated HTTP request via the godo client.
-func newRequestWithContext(ctx context.Context, client *godo.Client, method, urlPath string, body interface{}) (*http.Request, error) {
-	req0, err := client.NewRequest(ctx, method, urlPath, body)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, req0.Method, req0.URL.String(), req0.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Header = req0.Header.Clone()
-	if req0.ContentLength > 0 {
-		req.ContentLength = req0.ContentLength
-	}
-	if req0.GetBody != nil {
-		req.GetBody = req0.GetBody
-	}
-	return req, nil
-}
-
 // listModels lists custom models with optional filters. Returns one markdown table with
 // every model on its own row (including STATUS_FAILED with UUID). For catalog + custom
 // together, use genai-models-unified-search.
@@ -77,37 +53,26 @@ func (cmt *CustomModelsTool) listModels(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultText(formatCustomModelsList("", rows)), nil
 	}
 
-	q := url.Values{}
 	statusFilter := ""
+	opt := &godo.CustomModelListOptions{}
 	if status, ok := args["status"].(string); ok && status != "" {
 		statusFilter = status
-		q.Set("status", status)
+		opt.Status = godo.CustomModelStatus(status)
 	}
-	if page, ok := args["page"].(float64); ok {
-		q.Set("page", fmt.Sprintf("%d", int(page)))
+	if page, ok := args["page"].(float64); ok && int(page) > 0 {
+		opt.Page = int(page)
 	}
-	if perPage, ok := args["per_page"].(float64); ok {
-		q.Set("per_page", fmt.Sprintf("%d", int(perPage)))
-	}
-
-	path := customModelsAPIPath
-	if enc := q.Encode(); enc != "" {
-		path += "?" + enc
+	if perPage, ok := args["per_page"].(float64); ok && int(perPage) > 0 {
+		opt.PerPage = int(perPage)
 	}
 
-	apiReq, err := newRequestWithContext(ctx, client, "GET", path, nil)
+	models, _, err := listCustomModels(ctx, client, opt)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
-	}
-
-	var output ListCustomModelsOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
 		return mcp.NewToolResultErrorFromErr("failed to list custom models", err), nil
 	}
 
-	rows := make([]CustomSearchRow, 0, len(output.Models))
-	for _, cm := range output.Models {
+	rows := make([]CustomSearchRow, 0, len(models))
+	for _, cm := range models {
 		rows = append(rows, toCustomSearchRow(cm))
 	}
 
@@ -207,23 +172,21 @@ func (cmt *CustomModelsTool) importModel(ctx context.Context, req mcp.CallToolRe
 		}
 	}
 
+	if input.Name == "" && input.SourceRef.RepoID != "" {
+		input.Name = input.SourceRef.RepoID
+	}
+
 	client, err := cmt.client(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
-	apiReq, err := newRequestWithContext(ctx, client, "POST", customModelsAPIPath+"/import", input)
+	out, _, err := client.GradientAI.ImportCustomModel(ctx, importRequestToGodo(input))
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
-	}
-
-	var output ImportCustomModelOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
 		return mcp.NewToolResultErrorFromErr("failed to import custom model", err), nil
 	}
 
-	jsonData, err := json.MarshalIndent(output, "", "  ")
+	jsonData, err := json.MarshalIndent(importResponseFromGodo(out), "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -273,18 +236,12 @@ func (cmt *CustomModelsTool) updateMetadata(ctx context.Context, req mcp.CallToo
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
-	apiReq, err := newRequestWithContext(ctx, client, "PATCH", customModelsAPIPath+"/"+uuid+"/metadata", input)
+	model, _, err := client.GradientAI.UpdateCustomModelMetadata(ctx, uuid, metadataUpdateToGodo(input))
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
-	}
-
-	var output UpdateCustomModelMetadataOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
 		return mcp.NewToolResultErrorFromErr("failed to update custom model metadata", err), nil
 	}
 
-	jsonData, err := json.MarshalIndent(output.Model, "", "  ")
+	jsonData, err := json.MarshalIndent(customModelFromGodo(model), "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -304,18 +261,12 @@ func (cmt *CustomModelsTool) getModel(ctx context.Context, req mcp.CallToolReque
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
-	apiReq, err := newRequestWithContext(ctx, client, "GET", customModelsAPIPath+"/"+uuid, nil)
+	model, err := getCustomModelByUUID(ctx, client, uuid)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
-	}
-
-	var output GetCustomModelOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
 		return mcp.NewToolResultErrorFromErr("failed to get custom model", err), nil
 	}
 
-	jsonData, err := json.MarshalIndent(output.Model, "", "  ")
+	jsonData, err := json.MarshalIndent(model, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -382,23 +333,14 @@ func (cmt *CustomModelsTool) deleteModel(ctx context.Context, req mcp.CallToolRe
 }
 
 func (cmt *CustomModelsTool) deleteModelByUUID(ctx context.Context, client *godo.Client, uuid, name string) (*mcp.CallToolResult, error) {
-	apiReq, err := newRequestWithContext(ctx, client, "DELETE", customModelsAPIPath+"/"+uuid, nil)
+	output, resp, err := deleteCustomModelByUUID(ctx, client, uuid)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create request", err), nil
-	}
-
-	var output DeleteCustomModelOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if isNotFoundResponse(resp) {
 			return mcp.NewToolResultError(fmt.Sprintf(
 				"DELETE returned 404 for model %q (%s) but the model still exists. Deletion may be blocked (for example active deployments) or the delete API may be unavailable in this environment — verify in the control panel or remove deployments first.",
 				name, uuid)), nil
 		}
 		return mcp.NewToolResultErrorFromErr("failed to delete custom model", err), nil
-	}
-	if resp.StatusCode >= 400 {
-		return mcp.NewToolResultErrorFromErr("failed to delete custom model", fmt.Errorf("status %d", resp.StatusCode)), nil
 	}
 
 	jsonData, err := json.MarshalIndent(output, "", "  ")

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -20,7 +20,7 @@ const (
 
 	genaiCustomModelsImportToolDescription = "Import a custom model from an external source (e.g. HuggingFace). Starts an async import job.\n\n" +
 		"CONSENT REQUIRED (every import): Do not call this tool until the user has explicitly agreed to the import terms in the current conversation. " +
-		"Consent is checked before any Hugging Face resolution or API calls. " +
+		"Consent is checked before any import related API calls " +
 		"Present the terms (storage cost, license, source) and ask for yes/no. This applies to every import request, even if the same model was imported before. " +
 		"Only pass accept_terms_and_conditions: true after the user says yes."
 

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -58,16 +58,29 @@ func newRequestWithContext(ctx context.Context, client *godo.Client, method, url
 	return req, nil
 }
 
-// listModels lists custom models with optional filters.
+// listModels lists custom models with optional filters. Returns one markdown table with
+// every model on its own row (including STATUS_FAILED with UUID). For catalog + custom
+// together, use genai-models-unified-search.
 func (cmt *CustomModelsTool) listModels(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
 	client, err := cmt.client(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
-	args := req.GetArguments()
+	if !listModelsHasFilters(args) {
+		rows, err := fetchCustomModels(ctx, client, "")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("failed to list custom models", err), nil
+		}
+		return mcp.NewToolResultText(formatCustomModelsList("", rows)), nil
+	}
+
 	q := url.Values{}
+	statusFilter := ""
 	if status, ok := args["status"].(string); ok && status != "" {
+		statusFilter = status
 		q.Set("status", status)
 	}
 	if page, ok := args["page"].(float64); ok {
@@ -93,24 +106,25 @@ func (cmt *CustomModelsTool) listModels(ctx context.Context, req mcp.CallToolReq
 		return mcp.NewToolResultErrorFromErr("failed to list custom models", err), nil
 	}
 
-	type ListResponse struct {
-		Models       []*CustomModel `json:"models"`
-		Count        int            `json:"count"`
-		MaxThreshold int            `json:"max_threshold,omitempty"`
+	rows := make([]CustomSearchRow, 0, len(output.Models))
+	for _, cm := range output.Models {
+		rows = append(rows, toCustomSearchRow(cm))
 	}
 
-	response := ListResponse{
-		Models:       output.Models,
-		Count:        len(output.Models),
-		MaxThreshold: output.MaxThreshold,
-	}
+	return mcp.NewToolResultText(formatCustomModelsList(statusFilter, rows)), nil
+}
 
-	jsonData, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal error: %w", err)
+func listModelsHasFilters(args map[string]any) bool {
+	if status, ok := args["status"].(string); ok && strings.TrimSpace(status) != "" {
+		return true
 	}
-
-	return mcp.NewToolResultText(string(jsonData)), nil
+	if page, ok := args["page"].(float64); ok && int(page) > 0 {
+		return true
+	}
+	if perPage, ok := args["per_page"].(float64); ok && int(perPage) > 0 {
+		return true
+	}
+	return false
 }
 
 // importModel imports a custom model from an external source.
@@ -399,10 +413,18 @@ func (cmt *CustomModelsTool) deleteModelByUUID(ctx context.Context, client *godo
 func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
+			Handler: cmt.unifiedSearch,
+			Tool: mcp.NewTool(
+				"genai-models-unified-search",
+				mcp.WithDescription("PRIMARY tool for listing or searching models. Use when the user asks to list all models, show available models, or search by partial name. Returns two markdown tables (Model Catalog and Custom Models) with one row per model: custom columns are UUID, Name, Source, Status, Architecture, Input Modalities, Output Modalities; catalog columns include Provider, Type, Context Window, Capabilities, and modalities. Empty query lists everything; partial query returns nearest matches."),
+				mcp.WithString("query", mcp.Description("Partial model name or search string (optional). Empty returns all models in both tables.")),
+			),
+		},
+		{
 			Handler: cmt.listModels,
 			Tool: mcp.NewTool(
 				"genai-custom-models-list",
-				mcp.WithDescription("List custom models with optional status filter and pagination."),
+				mcp.WithDescription("List all custom models in one markdown table (one row per model, every UUID shown including STATUS_FAILED). Columns: UUID, Name, Source, Status, Architecture, Input Modalities, Output Modalities. Do not summarize the table in the response. For catalog + custom together use genai-models-unified-search. Optional status/page/per_page filters."),
 				mcp.WithString("status", mcp.Description("Filter by status: STATUS_IMPORTING, STATUS_READY, STATUS_FAILED, STATUS_DELETED")),
 				mcp.WithNumber("page", mcp.Description("Page number for pagination (default: 1)")),
 				mcp.WithNumber("per_page", mcp.Description("Results per page (default: 20)")),
@@ -449,14 +471,6 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 				mcp.WithString("name", mcp.Description("Exact custom model name the user provided or confirmed (character-for-character, whitespace trimmed). Use this OR uuid. Partial names return candidates only.")),
 				mcp.WithString("uuid", mcp.Description("Exact full custom model UUID (8-4-4-4-12 hex). Use this OR name. Partial uuids return candidates only; never delete on a partial uuid even if one match.")),
 				mcp.WithBoolean("confirm_deletion", mcp.Description(genaiCustomModelsDeleteConfirmDescription)),
-			),
-		},
-		{
-			Handler: cmt.unifiedSearch,
-			Tool: mcp.NewTool(
-				"genai-models-unified-search",
-				mcp.WithDescription("Search across both the DigitalOcean model catalog and your custom models in a single call. Returns a merged list of models with a 'source' field indicating whether each result is from the 'catalog' or 'custom' models. When a query is provided, catalog models are searched server-side and custom models are filtered client-side by name, description, architecture, and tags. An empty query returns all models from both sources."),
-				mcp.WithString("query", mcp.Description("Search query string to find models (optional; empty or omitted returns all models from both sources)")),
 			),
 		},
 	}

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -436,59 +436,6 @@ func TestCustomModelsTool_unifiedSearch_emptyQuery_clientError(t *testing.T) {
 	require.Error(t, err, "empty query should still attempt API call and fail on client error")
 }
 
-func TestCustomModelMatchesQuery(t *testing.T) {
-	tests := []struct {
-		name     string
-		model    *CustomModel
-		query    string
-		expected bool
-	}{
-		{
-			name:     "match by name",
-			model:    &CustomModel{Name: "my-llama-model"},
-			query:    "llama",
-			expected: true,
-		},
-		{
-			name:     "match by description",
-			model:    &CustomModel{Name: "some-model", Description: "A fine-tuned Llama variant"},
-			query:    "llama",
-			expected: true,
-		},
-		{
-			name:     "match by tag",
-			model:    &CustomModel{Name: "some-model", Tags: &CustomModelTags{Tags: []string{"llm", "llama"}}},
-			query:    "llama",
-			expected: true,
-		},
-		{
-			name:     "match by architecture",
-			model:    &CustomModel{Name: "some-model", Architecture: "LlamaForCausalLM"},
-			query:    "llama",
-			expected: true,
-		},
-		{
-			name:     "no match",
-			model:    &CustomModel{Name: "my-gpt-model", Description: "A GPT variant"},
-			query:    "llama",
-			expected: false,
-		},
-		{
-			name:     "case insensitive",
-			model:    &CustomModel{Name: "My-LLAMA-Model"},
-			query:    "llama",
-			expected: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := customModelMatchesQuery(tc.model, tc.query)
-			require.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 func setupCustomModelsToolWithTestServer(t *testing.T, models []*CustomModel) *CustomModelsTool {
 	t.Helper()
 

--- a/pkg/registry/genai-custom-models/custom_models_tools_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools_test.go
@@ -65,10 +65,6 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 		name string
 		args map[string]any
 	}{
-		{name: "missing name", args: map[string]any{
-			"source_type": "SOURCE_TYPE_HUGGINGFACE",
-			"source_ref":  map[string]interface{}{"repo_id": "test/model"},
-		}},
 		{name: "missing source_type", args: map[string]any{
 			"name":       "my-model",
 			"source_ref": map[string]interface{}{"repo_id": "test/model"},
@@ -88,17 +84,6 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
 			"accept_terms_and_conditions": false,
 		}},
-		{name: "name whitespace only", args: map[string]any{
-			"name":        " \t ",
-			"source_type": "SOURCE_TYPE_HUGGINGFACE",
-			"source_ref":  map[string]interface{}{"repo_id": "test/model"},
-		}},
-		{name: "name wrong type", args: map[string]any{
-			"name":                        float64(42),
-			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
-			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
-			"accept_terms_and_conditions": true,
-		}},
 	}
 
 	for _, tc := range tests {
@@ -112,43 +97,25 @@ func TestCustomModelsTool_importModel_validation(t *testing.T) {
 	}
 }
 
-func TestImportModel_invalidNameDoesNotResolveHuggingFace(t *testing.T) {
+func TestImportModel_missingConsentDoesNotResolveHuggingFace(t *testing.T) {
 	oldFetch := fetchHuggingFaceCommitSHA
 	hfCalled := false
 	fetchHuggingFaceCommitSHA = func(ctx context.Context, repoID, hfToken string) (string, error) {
 		hfCalled = true
-		return "", errors.New("Hugging Face resolution should not run without a valid name")
+		return "", errors.New("Hugging Face resolution should not run without consent")
 	}
 	t.Cleanup(func() { fetchHuggingFaceCommitSHA = oldFetch })
 
 	tool := setupCustomModelsToolWithFailingClient()
 
-	t.Run("missing name", func(t *testing.T) {
-		hfCalled = false
-		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
-			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
-			"accept_terms_and_conditions": true,
-		}}}
-		resp, err := tool.importModel(context.Background(), req)
-		require.NoError(t, err)
-		require.True(t, resp.IsError)
-		require.False(t, hfCalled)
-	})
-
-	t.Run("whitespace name", func(t *testing.T) {
-		hfCalled = false
-		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-			"name":                        " ",
-			"source_type":                 "SOURCE_TYPE_HUGGINGFACE",
-			"source_ref":                  map[string]interface{}{"repo_id": "test/model"},
-			"accept_terms_and_conditions": true,
-		}}}
-		resp, err := tool.importModel(context.Background(), req)
-		require.NoError(t, err)
-		require.True(t, resp.IsError)
-		require.False(t, hfCalled)
-	})
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"source_type": "SOURCE_TYPE_HUGGINGFACE",
+		"source_ref":  map[string]interface{}{"repo_id": "test/model"},
+	}}}
+	resp, err := tool.importModel(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.False(t, hfCalled)
 }
 
 func TestCustomModelsTool_importModel_spacesSourceRef(t *testing.T) {

--- a/pkg/registry/genai-custom-models/delete_resolve.go
+++ b/pkg/registry/genai-custom-models/delete_resolve.go
@@ -1,15 +1,10 @@
 package genaicustommodels
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
-
-	"github.com/digitalocean/godo"
 )
 
 var customModelUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
@@ -58,49 +53,6 @@ type DeleteModelUnresolvedOutput struct {
 type deleteTarget struct {
 	UUID string
 	Name string
-}
-
-// listAllCustomModels fetches every custom model page from the API.
-func listAllCustomModels(ctx context.Context, client *godo.Client) ([]*CustomModel, error) {
-	const perPage = 100
-	var all []*CustomModel
-	page := 1
-
-	for {
-		q := url.Values{}
-		q.Set("page", fmt.Sprintf("%d", page))
-		q.Set("per_page", fmt.Sprintf("%d", perPage))
-		path := customModelsAPIPath + "?" + q.Encode()
-
-		apiReq, err := newRequestWithContext(ctx, client, http.MethodGet, path, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-
-		var output ListCustomModelsOutput
-		resp, err := client.Do(ctx, apiReq, &output)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list custom models: %w", err)
-		}
-		if resp.StatusCode >= 400 {
-			return nil, fmt.Errorf("failed to list custom models: status %d", resp.StatusCode)
-		}
-
-		all = append(all, output.Models...)
-
-		if len(output.Models) == 0 {
-			break
-		}
-		if output.Meta != nil && output.Meta.Pages > 0 && page >= output.Meta.Pages {
-			break
-		}
-		if len(output.Models) < perPage {
-			break
-		}
-		page++
-	}
-
-	return all, nil
 }
 
 // resolveCustomModelUUIDByName finds a single model by exact name, or partial name matches.
@@ -269,26 +221,6 @@ func buildDeleteUnresolvedOutput(query, queryField string, matches []*CustomMode
 		RequiresExactMatch:      true,
 		DoNotSubstituteFromList: true,
 	}
-}
-
-func getCustomModelByUUID(ctx context.Context, client *godo.Client, uuid string) (*CustomModel, error) {
-	apiReq, err := newRequestWithContext(ctx, client, http.MethodGet, customModelsAPIPath+"/"+uuid, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	var output GetCustomModelOutput
-	resp, err := client.Do(ctx, apiReq, &output)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get custom model: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("failed to get custom model: status %d", resp.StatusCode)
-	}
-	if output.Model == nil {
-		return nil, fmt.Errorf("custom model %q not found", uuid)
-	}
-	return output.Model, nil
 }
 
 func marshalDeleteUnresolvedResult(out *DeleteModelUnresolvedOutput) (string, error) {

--- a/pkg/registry/genai-custom-models/generate.go
+++ b/pkg/registry/genai-custom-models/generate.go
@@ -1,5 +1,4 @@
 package genaicustommodels
 
-// godo does not yet have a CustomModelsService interface, so mock generation
-// is not available. Once godo adds support, update this directive:
-// //go:generate mockgen -destination=./mocks.go -package genaicustommodels github.com/digitalocean/godo CustomModelsService
+// Custom model APIs are provided by godo.GradientAIService (ListCustomModels, GetCustomModel,
+// ImportCustomModel, DeleteCustomModel, UpdateCustomModelMetadata).

--- a/pkg/registry/genai-custom-models/godo_client.go
+++ b/pkg/registry/genai-custom-models/godo_client.go
@@ -1,0 +1,90 @@
+package genaicustommodels
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/digitalocean/godo"
+)
+
+func listCustomModels(ctx context.Context, client *godo.Client, opt *godo.CustomModelListOptions) ([]*CustomModel, *godo.Meta, error) {
+	out, resp, err := client.GradientAI.ListCustomModels(ctx, opt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list custom models: %w", err)
+	}
+	if resp != nil && resp.StatusCode >= 400 {
+		return nil, nil, fmt.Errorf("failed to list custom models: status %d", resp.StatusCode)
+	}
+	var meta *godo.Meta
+	if out != nil && out.Meta != nil {
+		meta = out.Meta
+	} else if resp != nil && resp.Meta != nil {
+		meta = resp.Meta
+	}
+	var models []*godo.CustomModel
+	if out != nil {
+		models = out.Models
+	}
+	return customModelsFromGodo(models), meta, nil
+}
+
+// listAllCustomModels fetches every custom model page from the API.
+func listAllCustomModels(ctx context.Context, client *godo.Client) ([]*CustomModel, error) {
+	const perPage = 100
+	var all []*CustomModel
+	page := 1
+
+	for {
+		models, meta, err := listCustomModels(ctx, client, &godo.CustomModelListOptions{
+			ListOptions: godo.ListOptions{Page: page, PerPage: perPage},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, models...)
+
+		if len(models) == 0 {
+			break
+		}
+		if meta != nil && meta.Pages > 0 && page >= meta.Pages {
+			break
+		}
+		if len(models) < perPage {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
+func getCustomModelByUUID(ctx context.Context, client *godo.Client, uuid string) (*CustomModel, error) {
+	model, resp, err := client.GradientAI.GetCustomModel(ctx, uuid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get custom model: %w", err)
+	}
+	if resp != nil && resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed to get custom model: status %d", resp.StatusCode)
+	}
+	if model == nil {
+		return nil, fmt.Errorf("custom model %q not found", uuid)
+	}
+	return customModelFromGodo(model), nil
+}
+
+func deleteCustomModelByUUID(ctx context.Context, client *godo.Client, uuid string) (*DeleteCustomModelOutput, *godo.Response, error) {
+	out, resp, err := client.GradientAI.DeleteCustomModel(ctx, uuid)
+	if err != nil {
+		return nil, resp, err
+	}
+	if resp != nil && resp.StatusCode >= 400 {
+		return nil, resp, fmt.Errorf("failed to delete custom model: status %d", resp.StatusCode)
+	}
+	return deleteResponseFromGodo(out), resp, nil
+}
+
+func isNotFoundResponse(resp *godo.Response) bool {
+	return resp != nil && resp.Response != nil && resp.StatusCode == http.StatusNotFound
+}

--- a/pkg/registry/genai-custom-models/godo_convert.go
+++ b/pkg/registry/genai-custom-models/godo_convert.go
@@ -1,0 +1,184 @@
+package genaicustommodels
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+func customModelFromGodo(m *godo.CustomModel) *CustomModel {
+	if m == nil {
+		return nil
+	}
+	out := &CustomModel{
+		UUID:                 m.Uuid,
+		Name:                 m.Name,
+		Description:          m.Description,
+		Status:               CustomModelStatus(m.Status),
+		Architecture:         m.Architecture,
+		SourceType:           CustomModelSourceType(m.SourceType),
+		TotalSizeBytes:       jsonNumberFromString(m.TotalSizeBytes),
+		FileCount:            jsonNumberFromInt(m.FileCount),
+		License:              m.License,
+		CreatedAt:            timestampToTime(m.CreatedAt),
+		UpdatedAt:            timestampToTime(m.UpdatedAt),
+		ContextLength:        jsonNumberFromInt(m.ContextLength),
+		CostEstimatePerMonth: jsonNumberFromInt(m.CostEstimatePerMonth),
+		InputModalities:      append([]string(nil), m.InputModalities...),
+		OutputModalities:     append([]string(nil), m.OutputModalities...),
+		Parameters:           jsonNumberFromString(m.Parameters),
+		TeamID:               jsonNumberFromString(m.TeamId),
+		ConfigJSON:           m.ConfigJson,
+		StorageRegion:        m.StorageRegion,
+	}
+	if m.SourceRef != nil {
+		out.SourceRef = &CustomModelSourceRef{
+			RepoID:     m.SourceRef.RepoId,
+			CommitSHA:  m.SourceRef.CommitSha,
+			AccessType: CustomModelAccessType(m.SourceRef.AccessType),
+			HFToken:    m.SourceRef.HfToken,
+			Bucket:     m.SourceRef.Bucket,
+			Region:     m.SourceRef.Region,
+			Prefix:     m.SourceRef.Prefix,
+		}
+	}
+	if m.Tags != nil {
+		out.Tags = &CustomModelTags{Tags: append([]string(nil), m.Tags.Tags...)}
+	}
+	if len(m.ActiveDeployments) > 0 {
+		out.ActiveDeployments = make([]*CustomModelActiveDeployment, 0, len(m.ActiveDeployments))
+		for _, d := range m.ActiveDeployments {
+			if d == nil {
+				continue
+			}
+			dep := &CustomModelActiveDeployment{
+				ID:         d.Id,
+				Name:       d.Name,
+				RegionSlug: d.RegionSlug,
+				State:      d.State,
+			}
+			if d.Endpoints != nil {
+				dep.Endpoints = &CustomModelDeploymentEndpoints{
+					PublicEndpointFQDN:  d.Endpoints.PublicEndpointFqdn,
+					PrivateEndpointFQDN: d.Endpoints.PrivateEndpointFqdn,
+				}
+			}
+			out.ActiveDeployments = append(out.ActiveDeployments, dep)
+		}
+	}
+	return out
+}
+
+func customModelsFromGodo(models []*godo.CustomModel) []*CustomModel {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make([]*CustomModel, 0, len(models))
+	for _, m := range models {
+		out = append(out, customModelFromGodo(m))
+	}
+	return out
+}
+
+func importRequestToGodo(in *ImportCustomModelInput) *godo.CustomModelImportRequest {
+	req := &godo.CustomModelImportRequest{
+		Name:                     in.Name,
+		SourceType:               godo.CustomModelSourceType(in.SourceType),
+		Description:              in.Description,
+		PreferredGpuRegion:       in.PreferredGPURegion,
+		AcceptTermsAndConditions: in.AcceptTermsAndConditions,
+	}
+	req.SourceRef = &godo.CustomModelSourceRef{
+		RepoId:     in.SourceRef.RepoID,
+		CommitSha:  in.SourceRef.CommitSHA,
+		AccessType: godo.CustomModelSourceRefAccessType(in.SourceRef.AccessType),
+		HfToken:    in.SourceRef.HFToken,
+		Bucket:     in.SourceRef.Bucket,
+		Region:     in.SourceRef.Region,
+		Prefix:     in.SourceRef.Prefix,
+	}
+	if in.Tags != nil {
+		req.Tags = &godo.CustomModelTags{Tags: append([]string(nil), in.Tags.Tags...)}
+	}
+	return req
+}
+
+func importResponseFromGodo(out *godo.CustomModelImportResponse) *ImportCustomModelOutput {
+	if out == nil {
+		return nil
+	}
+	resp := &ImportCustomModelOutput{
+		Model: customModelFromGodo(out.Model),
+		Error: out.Error,
+	}
+	if out.ImportJob != nil {
+		resp.ImportJob = &ImportJob{
+			UUID:       out.ImportJob.Uuid,
+			Status:     out.ImportJob.Status,
+			FilesTotal: jsonNumberFromInt(out.ImportJob.FilesTotal),
+			FilesDone:  jsonNumberFromInt(out.ImportJob.FilesDone),
+			BytesTotal: jsonNumberFromString(out.ImportJob.BytesTotal),
+			BytesDone:  jsonNumberFromString(out.ImportJob.BytesDone),
+			CreatedAt:  timestampToTime(out.ImportJob.CreatedAt),
+		}
+	}
+	if len(out.ValidationSteps) > 0 {
+		resp.ValidationSteps = make([]*ValidationStep, 0, len(out.ValidationSteps))
+		for _, s := range out.ValidationSteps {
+			if s == nil {
+				continue
+			}
+			resp.ValidationSteps = append(resp.ValidationSteps, &ValidationStep{
+				Name:   s.Name,
+				Passed: s.Passed,
+				Error:  s.Error,
+			})
+		}
+	}
+	return resp
+}
+
+func metadataUpdateToGodo(in *UpdateCustomModelMetadataInput) *godo.CustomModelMetadataUpdateRequest {
+	req := &godo.CustomModelMetadataUpdateRequest{}
+	if in.Name != nil {
+		req.Name = *in.Name
+	}
+	if in.Description != nil {
+		req.Description = *in.Description
+	}
+	if in.Tags != nil {
+		req.Tags = &godo.CustomModelTags{Tags: append([]string(nil), in.Tags.Tags...)}
+	}
+	return req
+}
+
+func deleteResponseFromGodo(out *godo.CustomModelDeleteResponse) *DeleteCustomModelOutput {
+	if out == nil {
+		return &DeleteCustomModelOutput{}
+	}
+	return &DeleteCustomModelOutput{
+		Status: string(out.Status),
+		Error:  out.Error,
+	}
+}
+
+func timestampToTime(ts *godo.Timestamp) *time.Time {
+	if ts == nil {
+		return nil
+	}
+	t := ts.Time
+	return &t
+}
+
+func jsonNumberFromString(s string) json.Number {
+	if s == "" {
+		return ""
+	}
+	return json.Number(s)
+}
+
+func jsonNumberFromInt(i int) json.Number {
+	return json.Number(strconv.Itoa(i))
+}

--- a/pkg/registry/genai-custom-models/list_models_test.go
+++ b/pkg/registry/genai-custom-models/list_models_test.go
@@ -1,0 +1,56 @@
+package genaicustommodels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListModelsHasFilters(t *testing.T) {
+	require.False(t, listModelsHasFilters(map[string]any{}))
+	require.True(t, listModelsHasFilters(map[string]any{"status": "STATUS_READY"}))
+	require.True(t, listModelsHasFilters(map[string]any{"page": float64(2)}))
+	require.True(t, listModelsHasFilters(map[string]any{"per_page": float64(10)}))
+}
+
+func TestCustomModelsTool_listModels_unfilteredIncludesFailedUUID(t *testing.T) {
+	tool := setupCustomModelsToolWithTestServer(t, []*CustomModel{
+		{UUID: "ok-uuid", Name: "ready", Status: CustomModelStatusReady},
+		{UUID: "bad-uuid", Name: "failed-one", Status: CustomModelStatusFailed, Architecture: "LlamaForCausalLM"},
+	})
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	resp, err := tool.listModels(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+
+	text := resp.Content[0].(mcp.TextContent).Text
+	require.Contains(t, text, "| bad-uuid | failed-one | custom | STATUS_FAILED | LlamaForCausalLM |")
+	require.NotContains(t, text, "## Model Catalog")
+}
+
+func TestCustomModelsTool_listModels_filteredReturnsTable(t *testing.T) {
+	tool := setupCustomModelsToolWithTestServer(t, []*CustomModel{
+		{
+			UUID:         "uuid-1",
+			Name:         "ready-model",
+			Status:       CustomModelStatusReady,
+			Architecture: "LlamaForCausalLM",
+		},
+	})
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"status": "STATUS_READY",
+	}}}
+	resp, err := tool.listModels(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+
+	text := resp.Content[0].(mcp.TextContent).Text
+	require.Contains(t, text, "## Custom Models (1 models)")
+	require.Contains(t, text, "ready-model")
+	require.Contains(t, text, "STATUS_READY")
+	require.Contains(t, text, "LlamaForCausalLM")
+}

--- a/pkg/registry/genai-custom-models/models.go
+++ b/pkg/registry/genai-custom-models/models.go
@@ -186,30 +186,41 @@ type GetCustomModelOutput struct {
 	Model *CustomModel `json:"model"`
 }
 
-// UnifiedModel is a normalized representation that can hold either a catalog model
-// or a custom model, identified by the Source field.
-type UnifiedModel struct {
+// CatalogSearchRow is one catalog model row in unified search output.
+type CatalogSearchRow struct {
 	UUID             string   `json:"uuid"`
 	Name             string   `json:"name"`
-	Description      string   `json:"description,omitempty"`
 	Source           string   `json:"source"`
-	Status           string   `json:"status,omitempty"`
 	Provider         string   `json:"provider,omitempty"`
 	Type             string   `json:"type,omitempty"`
-	Architecture     string   `json:"architecture,omitempty"`
 	ContextWindow    string   `json:"context_window,omitempty"`
 	Capabilities     []string `json:"capabilities,omitempty"`
 	InputModalities  []string `json:"input_modalities,omitempty"`
 	OutputModalities []string `json:"output_modalities,omitempty"`
 }
 
+// CustomSearchRow is one custom model row in unified search output.
+type CustomSearchRow struct {
+	UUID             string   `json:"uuid"`
+	Name             string   `json:"name"`
+	Source           string   `json:"source"`
+	Status           string   `json:"status"`
+	Architecture     string   `json:"architecture,omitempty"`
+	InputModalities  []string `json:"input_modalities,omitempty"`
+	OutputModalities []string `json:"output_modalities,omitempty"`
+}
+
 // UnifiedSearchResponse is the response from the unified model search tool.
 type UnifiedSearchResponse struct {
-	Query   string          `json:"query"`
-	Results []*UnifiedModel `json:"results"`
-	Counts  struct {
-		Catalog int `json:"catalog"`
-		Custom  int `json:"custom"`
-		Total   int `json:"total"`
-	} `json:"counts"`
+	Query         string              `json:"query"`
+	CatalogModels []CatalogSearchRow  `json:"catalog_models"`
+	CustomModels  []CustomSearchRow   `json:"custom_models"`
+	Counts        UnifiedSearchCounts `json:"counts"`
+}
+
+// UnifiedSearchCounts holds per-source result counts.
+type UnifiedSearchCounts struct {
+	Catalog int `json:"catalog"`
+	Custom  int `json:"custom"`
+	Total   int `json:"total"`
 }

--- a/pkg/registry/genai-custom-models/unified_search_format.go
+++ b/pkg/registry/genai-custom-models/unified_search_format.go
@@ -1,0 +1,226 @@
+package genaicustommodels
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/digitalocean/godo"
+)
+
+// modelListDisplayInstruction tells clients to show every table row (including STATUS_FAILED).
+const modelListDisplayInstruction = "**Display requirement:** Show the complete markdown table below exactly as returned. " +
+	"Every model must appear on its own row with UUID. Do not group by status, omit failed models, or replace rows with a summary.\n\n"
+
+// formatUnifiedSearchTables renders catalog and custom models as two markdown tables.
+// Each model is exactly one table row; rows are never combined.
+func formatUnifiedSearchTables(query string, catalog []CatalogSearchRow, custom []CustomSearchRow) string {
+	if err := validateOneRowPerModel(catalog, custom); err != nil {
+		panic(fmt.Sprintf("unified search invariant violated: %v", err))
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# Unified Model Search\n\n")
+	if strings.TrimSpace(query) == "" {
+		sb.WriteString("**Query:** (all models)\n\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("**Query:** %s\n\n", query))
+	}
+
+	sb.WriteString(fmt.Sprintf("## Model Catalog (%d models)\n\n", len(catalog)))
+	sb.WriteString(renderCatalogTable(catalog))
+	sb.WriteString("\n")
+
+	sb.WriteString(fmt.Sprintf("## Custom Models (%d models)\n\n", len(custom)))
+	sb.WriteString(modelListDisplayInstruction)
+	sb.WriteString(renderCustomTable(sortCustomSearchRows(custom)))
+
+	return sb.String()
+}
+
+// formatCustomModelsList renders all custom models in a single table (one row per model).
+func formatCustomModelsList(statusFilter string, rows []CustomSearchRow) string {
+	if err := validateUniqueRows(rows, func(r CustomSearchRow) string { return r.UUID }); err != nil {
+		panic(fmt.Sprintf("custom models list invariant violated: %v", err))
+	}
+
+	rows = sortCustomSearchRows(rows)
+
+	var sb strings.Builder
+	sb.WriteString("# Custom Models\n\n")
+	if strings.TrimSpace(statusFilter) != "" {
+		sb.WriteString(fmt.Sprintf("**Status filter:** %s\n\n", statusFilter))
+	}
+	sb.WriteString(fmt.Sprintf("## Custom Models (%d models)\n\n", len(rows)))
+	sb.WriteString(modelListDisplayInstruction)
+	sb.WriteString(renderCustomTable(rows))
+	return sb.String()
+}
+
+func sortCustomSearchRows(rows []CustomSearchRow) []CustomSearchRow {
+	sorted := append([]CustomSearchRow(nil), rows...)
+	sort.Slice(sorted, func(i, j int) bool {
+		si, sj := customStatusSortKey(sorted[i].Status), customStatusSortKey(sorted[j].Status)
+		if si != sj {
+			return si < sj
+		}
+		return strings.ToLower(sorted[i].Name) < strings.ToLower(sorted[j].Name)
+	})
+	return sorted
+}
+
+func customStatusSortKey(status string) int {
+	switch status {
+	case string(CustomModelStatusReady):
+		return 0
+	case string(CustomModelStatusImporting):
+		return 1
+	case string(CustomModelStatusFailed):
+		return 2
+	case string(CustomModelStatusDeleted):
+		return 3
+	default:
+		return 4
+	}
+}
+
+func validateOneRowPerModel(catalog []CatalogSearchRow, custom []CustomSearchRow) error {
+	if err := validateUniqueRows(catalog, func(r CatalogSearchRow) string { return r.UUID }); err != nil {
+		return fmt.Errorf("catalog: %w", err)
+	}
+	if err := validateUniqueRows(custom, func(r CustomSearchRow) string { return r.UUID }); err != nil {
+		return fmt.Errorf("custom: %w", err)
+	}
+	return nil
+}
+
+func validateUniqueRows[T any](rows []T, uuid func(T) string) error {
+	seen := make(map[string]struct{}, len(rows))
+	for i, row := range rows {
+		id := strings.TrimSpace(uuid(row))
+		if id == "" {
+			return fmt.Errorf("row %d has empty uuid", i)
+		}
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("duplicate uuid %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
+}
+
+func renderCatalogTable(rows []CatalogSearchRow) string {
+	headers := []string{
+		"UUID", "Name", "Source", "Provider", "Type",
+		"Context Window", "Capabilities", "Input Modalities", "Output Modalities",
+	}
+	var sb strings.Builder
+	sb.WriteString(markdownTableHeader(headers))
+	if len(rows) == 0 {
+		return sb.String()
+	}
+	for _, r := range rows {
+		sb.WriteString(markdownTableRow([]string{
+			r.UUID,
+			r.Name,
+			r.Source,
+			r.Provider,
+			r.Type,
+			r.ContextWindow,
+			joinCSV(r.Capabilities),
+			joinCSV(r.InputModalities),
+			joinCSV(r.OutputModalities),
+		}))
+	}
+	return sb.String()
+}
+
+func renderCustomTable(rows []CustomSearchRow) string {
+	headers := []string{
+		"UUID", "Name", "Source", "Status", "Architecture",
+		"Input Modalities", "Output Modalities",
+	}
+	var sb strings.Builder
+	sb.WriteString(markdownTableHeader(headers))
+	if len(rows) == 0 {
+		return sb.String()
+	}
+	for _, r := range rows {
+		sb.WriteString(markdownTableRow([]string{
+			r.UUID,
+			r.Name,
+			r.Source,
+			r.Status,
+			r.Architecture,
+			joinCSV(r.InputModalities),
+			joinCSV(r.OutputModalities),
+		}))
+	}
+	return sb.String()
+}
+
+func markdownTableHeader(cols []string) string {
+	var sb strings.Builder
+	sb.WriteString("| ")
+	sb.WriteString(strings.Join(cols, " | "))
+	sb.WriteString(" |\n| ")
+	seps := make([]string, len(cols))
+	for i := range seps {
+		seps[i] = "---"
+	}
+	sb.WriteString(strings.Join(seps, " | "))
+	sb.WriteString(" |\n")
+	return sb.String()
+}
+
+func markdownTableRow(cells []string) string {
+	escaped := make([]string, len(cells))
+	for i, c := range cells {
+		escaped[i] = escapeMarkdownCell(c)
+	}
+	return "| " + strings.Join(escaped, " | ") + " |\n"
+}
+
+func escapeMarkdownCell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}
+
+func joinCSV(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	return strings.Join(items, ", ")
+}
+
+func toCustomSearchRow(cm *CustomModel) CustomSearchRow {
+	return CustomSearchRow{
+		UUID:             cm.UUID,
+		Name:             cm.Name,
+		Source:           sourceCustom,
+		Status:           string(cm.Status),
+		Architecture:     cm.Architecture,
+		InputModalities:  append([]string(nil), cm.InputModalities...),
+		OutputModalities: append([]string(nil), cm.OutputModalities...),
+	}
+}
+
+func toCatalogSearchRow(model *godo.Model) CatalogSearchRow {
+	var inputMod, outputMod []string
+	if model.Modalities != nil {
+		inputMod = append([]string(nil), model.Modalities.Input...)
+		outputMod = append([]string(nil), model.Modalities.Output...)
+	}
+	return CatalogSearchRow{
+		UUID:             model.Uuid,
+		Name:             model.Name,
+		Source:           sourceCatalog,
+		Provider:         model.Provider,
+		Type:             model.Type,
+		ContextWindow:    model.ContextWindow,
+		Capabilities:     append([]string(nil), model.Capabilities...),
+		InputModalities:  inputMod,
+		OutputModalities: outputMod,
+	}
+}

--- a/pkg/registry/genai-custom-models/unified_search_format_test.go
+++ b/pkg/registry/genai-custom-models/unified_search_format_test.go
@@ -1,0 +1,65 @@
+package genaicustommodels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatUnifiedSearchTables_OneRowPerModel(t *testing.T) {
+	catalog := []CatalogSearchRow{
+		{UUID: "uuid-a", Name: "Model A", Source: sourceCatalog, Type: "chat"},
+		{UUID: "uuid-b", Name: "Model B", Source: sourceCatalog, Type: "chat"},
+	}
+	custom := []CustomSearchRow{
+		{UUID: "uuid-c", Name: "Custom C", Source: sourceCustom, Status: "STATUS_READY", Architecture: "LlamaForCausalLM"},
+	}
+
+	out := formatUnifiedSearchTables("llama", catalog, custom)
+
+	require.Contains(t, out, "## Model Catalog (2 models)")
+	require.Contains(t, out, "## Custom Models (1 models)")
+	require.Equal(t, 1, strings.Count(out, "uuid-a"))
+	require.Equal(t, 1, strings.Count(out, "uuid-b"))
+	require.Equal(t, 1, strings.Count(out, "uuid-c"))
+	require.Equal(t, 3, countTableDataRows(out), "one markdown row per model across both tables")
+}
+
+func TestFormatUnifiedSearchTables_EmptySections(t *testing.T) {
+	out := formatUnifiedSearchTables("", nil, nil)
+	require.Contains(t, out, "## Model Catalog (0 models)")
+	require.Contains(t, out, "## Custom Models (0 models)")
+	require.Contains(t, out, "| UUID | Name | Source | Status |")
+}
+
+func countTableDataRows(markdown string) int {
+	count := 0
+	for _, line := range strings.Split(markdown, "\n") {
+		if strings.HasPrefix(line, "| ") && !strings.HasPrefix(line, "| ---") && !strings.Contains(line, "| UUID |") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestFormatCustomModelsList_IncludesFailedUUIDRow(t *testing.T) {
+	rows := []CustomSearchRow{
+		{UUID: "ready-uuid", Name: "ready", Source: sourceCustom, Status: "STATUS_READY"},
+		{UUID: "failed-uuid", Name: "failed-one", Source: sourceCustom, Status: "STATUS_FAILED", Architecture: "MistralForCausalLM"},
+	}
+	out := formatCustomModelsList("", rows)
+	require.Contains(t, out, modelListDisplayInstruction)
+	require.Contains(t, out, "| failed-uuid | failed-one | custom | STATUS_FAILED | MistralForCausalLM |")
+	require.Equal(t, 2, countTableDataRows(out))
+}
+
+func TestValidateOneRowPerModel_RejectsDuplicateUUID(t *testing.T) {
+	catalog := []CatalogSearchRow{
+		{UUID: "same", Name: "One", Source: sourceCatalog},
+		{UUID: "same", Name: "Two", Source: sourceCatalog},
+	}
+	require.Panics(t, func() {
+		formatUnifiedSearchTables("", catalog, nil)
+	})
+}

--- a/pkg/registry/genai-custom-models/unified_search_match.go
+++ b/pkg/registry/genai-custom-models/unified_search_match.go
@@ -1,0 +1,97 @@
+package genaicustommodels
+
+import (
+	"sort"
+	"strings"
+)
+
+// customModelMatchScore returns a relevance score for a partial query (higher is closer).
+// Returns 0 when the model does not match the query.
+func customModelMatchScore(cm *CustomModel, queryLower string) int {
+	if queryLower == "" {
+		return 1
+	}
+
+	score := 0
+	nameLower := strings.ToLower(cm.Name)
+
+	if nameLower == queryLower {
+		score += 1000
+	}
+	if strings.HasPrefix(nameLower, queryLower) {
+		score += 500
+	}
+	if strings.Contains(nameLower, queryLower) {
+		score += 200
+	}
+
+	descLower := strings.ToLower(cm.Description)
+	if strings.Contains(descLower, queryLower) {
+		score += 100
+	}
+
+	archLower := strings.ToLower(cm.Architecture)
+	if strings.Contains(archLower, queryLower) {
+		score += 80
+	}
+
+	if cm.Tags != nil {
+		for _, tag := range cm.Tags.Tags {
+			tagLower := strings.ToLower(tag)
+			if tagLower == queryLower {
+				score += 150
+			} else if strings.Contains(tagLower, queryLower) {
+				score += 60
+			}
+		}
+	}
+
+	uuidLower := strings.ToLower(cm.UUID)
+	if strings.Contains(uuidLower, queryLower) {
+		score += 50
+	}
+
+	return score
+}
+
+func customModelMatchesQuery(cm *CustomModel, queryLower string) bool {
+	return customModelMatchScore(cm, queryLower) > 0
+}
+
+type scoredCustomModel struct {
+	model *CustomModel
+	score int
+}
+
+// filterAndRankCustomModels returns custom models nearest to the query, best match first.
+// An empty query returns all models sorted by name.
+func filterAndRankCustomModels(models []*CustomModel, query string) []*CustomModel {
+	queryLower := strings.ToLower(strings.TrimSpace(query))
+	if queryLower == "" {
+		out := append([]*CustomModel(nil), models...)
+		sort.Slice(out, func(i, j int) bool {
+			return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+		})
+		return out
+	}
+
+	scored := make([]scoredCustomModel, 0, len(models))
+	for _, cm := range models {
+		if score := customModelMatchScore(cm, queryLower); score > 0 {
+			scored = append(scored, scoredCustomModel{model: cm, score: score})
+		}
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		return strings.ToLower(scored[i].model.Name) < strings.ToLower(scored[j].model.Name)
+	})
+
+	out := make([]*CustomModel, 0, len(scored))
+	for _, s := range scored {
+		out = append(out, s.model)
+	}
+	return out
+}

--- a/pkg/registry/genai-custom-models/unified_search_match_test.go
+++ b/pkg/registry/genai-custom-models/unified_search_match_test.go
@@ -1,0 +1,84 @@
+package genaicustommodels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomModelMatchesQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *CustomModel
+		query    string
+		expected bool
+	}{
+		{
+			name:     "match by name",
+			model:    &CustomModel{Name: "my-llama-model"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by description",
+			model:    &CustomModel{Name: "some-model", Description: "A fine-tuned Llama variant"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by tag",
+			model:    &CustomModel{Name: "some-model", Tags: &CustomModelTags{Tags: []string{"llm", "llama"}}},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "match by architecture",
+			model:    &CustomModel{Name: "some-model", Architecture: "LlamaForCausalLM"},
+			query:    "llama",
+			expected: true,
+		},
+		{
+			name:     "no match",
+			model:    &CustomModel{Name: "my-gpt-model", Description: "A GPT variant"},
+			query:    "llama",
+			expected: false,
+		},
+		{
+			name:     "case insensitive",
+			model:    &CustomModel{Name: "My-LLAMA-Model"},
+			query:    "llama",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := customModelMatchesQuery(tc.model, tc.query)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFilterAndRankCustomModels_PartialQueryOrdersByRelevance(t *testing.T) {
+	models := []*CustomModel{
+		{UUID: "1", Name: "alpha-llama-helper"},
+		{UUID: "2", Name: "llama"},
+		{UUID: "3", Name: "other"},
+	}
+
+	ranked := filterAndRankCustomModels(models, "llama")
+	require.Len(t, ranked, 2)
+	require.Equal(t, "2", ranked[0].UUID, "exact name match should rank first")
+	require.Equal(t, "1", ranked[1].UUID)
+}
+
+func TestFilterAndRankCustomModels_EmptyQueryReturnsAll(t *testing.T) {
+	models := []*CustomModel{
+		{UUID: "b", Name: "b-model"},
+		{UUID: "a", Name: "a-model"},
+	}
+	ranked := filterAndRankCustomModels(models, "")
+	require.Len(t, ranked, 2)
+	require.Equal(t, "a", ranked[0].UUID)
+	require.Equal(t, "b", ranked[1].UUID)
+}

--- a/pkg/registry/genai-custom-models/unified_search_tool.go
+++ b/pkg/registry/genai-custom-models/unified_search_tool.go
@@ -2,7 +2,6 @@ package genaicustommodels
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -17,10 +16,9 @@ const (
 	sourceCustom  = "custom"
 )
 
-// unifiedSearch searches both the model catalog and custom models, returning
-// a merged, normalized list. The catalog is searched via GradientAI.SearchModels
-// and custom models are fetched from the v2/gen-ai/custom_models endpoint with
-// client-side name/description/tag substring matching.
+// unifiedSearch searches the model catalog and custom models in parallel, then returns
+// two markdown tables (one row per model, never combined). Catalog matches use
+// GradientAI.SearchModels; custom matches are ranked client-side by relevance.
 func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	query, _ := req.GetArguments()["query"].(string)
 
@@ -30,11 +28,11 @@ func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallTool
 	}
 
 	type catalogResult struct {
-		models []*UnifiedModel
+		models []CatalogSearchRow
 		err    error
 	}
 	type customResult struct {
-		models []*UnifiedModel
+		models []CustomSearchRow
 		err    error
 	}
 
@@ -61,7 +59,8 @@ func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallTool
 	cr := <-catalogCh
 	cu := <-customCh
 
-	var catalogModels, customModels []*UnifiedModel
+	var catalogModels []CatalogSearchRow
+	var customModels []CustomSearchRow
 	var errors []string
 
 	if cr.err != nil {
@@ -69,7 +68,6 @@ func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallTool
 	} else {
 		catalogModels = cr.models
 	}
-
 	if cu.err != nil {
 		errors = append(errors, fmt.Sprintf("custom: %s", cu.err))
 	} else {
@@ -80,42 +78,31 @@ func (cmt *CustomModelsTool) unifiedSearch(ctx context.Context, req mcp.CallTool
 		return mcp.NewToolResultError(fmt.Sprintf("both sources failed: %s", strings.Join(errors, "; "))), nil
 	}
 
-	merged := make([]*UnifiedModel, 0, len(catalogModels)+len(customModels))
-	merged = append(merged, catalogModels...)
-	merged = append(merged, customModels...)
-
-	resp := UnifiedSearchResponse{
-		Query:   query,
-		Results: merged,
+	if catalogModels == nil {
+		catalogModels = []CatalogSearchRow{}
 	}
-	resp.Counts.Catalog = len(catalogModels)
-	resp.Counts.Custom = len(customModels)
-	resp.Counts.Total = len(merged)
-
-	jsonData, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("marshal error: %w", err)
+	if customModels == nil {
+		customModels = []CustomSearchRow{}
 	}
 
-	result := mcp.NewToolResultText(string(jsonData))
+	text := formatUnifiedSearchTables(query, catalogModels, customModels)
 	if len(errors) == 1 {
-		result = mcp.NewToolResultText(fmt.Sprintf("partial results (one source failed: %s)\n\n%s", errors[0], string(jsonData)))
+		text = fmt.Sprintf("partial results (one source failed: %s)\n\n%s", errors[0], text)
 	}
 
-	return result, nil
+	return mcp.NewToolResultText(text), nil
 }
 
-// fetchCatalogModels searches the model catalog and fetches metadata for each
-// matching UUID, converting results into UnifiedModel.
-func fetchCatalogModels(ctx context.Context, client *godo.Client, query string) ([]*UnifiedModel, error) {
+// fetchCatalogModels searches the catalog and returns one row per matching model UUID.
+func fetchCatalogModels(ctx context.Context, client *godo.Client, query string) ([]CatalogSearchRow, error) {
 	uuids, _, err := client.GradientAI.SearchModels(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search catalog: %w", err)
 	}
 
 	type result struct {
-		model *UnifiedModel
-		err   error
+		row CatalogSearchRow
+		ok  bool
 	}
 
 	const maxConcurrent = 20
@@ -132,44 +119,24 @@ func fetchCatalogModels(ctx context.Context, client *godo.Client, query string) 
 
 			model, _, getErr := client.GradientAI.GetModelByUUID(ctx, id)
 			if getErr != nil || model == nil {
-				results[idx] = result{err: getErr}
 				return
 			}
-
-			var inputMod, outputMod []string
-			if model.Modalities != nil {
-				inputMod = model.Modalities.Input
-				outputMod = model.Modalities.Output
-			}
-
-			results[idx] = result{model: &UnifiedModel{
-				UUID:             model.Uuid,
-				Name:             model.Name,
-				Description:      model.Description,
-				Source:           sourceCatalog,
-				Provider:         model.Provider,
-				Type:             model.Type,
-				ContextWindow:    model.ContextWindow,
-				Capabilities:     model.Capabilities,
-				InputModalities:  inputMod,
-				OutputModalities: outputMod,
-			}}
+			results[idx] = result{row: toCatalogSearchRow(model), ok: true}
 		}(i, uuid)
 	}
 	wg.Wait()
 
-	models := make([]*UnifiedModel, 0, len(results))
+	rows := make([]CatalogSearchRow, 0, len(uuids))
 	for _, r := range results {
-		if r.model != nil {
-			models = append(models, r.model)
+		if r.ok {
+			rows = append(rows, r.row)
 		}
 	}
-	return models, nil
+	return rows, nil
 }
 
-// fetchCustomModels lists all custom models and applies client-side substring
-// filtering on name, description, and tags when a query is provided.
-func fetchCustomModels(ctx context.Context, client *godo.Client, query string) ([]*UnifiedModel, error) {
+// fetchCustomModels lists custom models and returns one row per match, ranked by relevance.
+func fetchCustomModels(ctx context.Context, client *godo.Client, query string) ([]CustomSearchRow, error) {
 	apiReq, err := client.NewRequest(ctx, http.MethodGet, customModelsAPIPath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -187,42 +154,10 @@ func fetchCustomModels(ctx context.Context, client *godo.Client, query string) (
 		return nil, fmt.Errorf("failed to list custom models: %w", err)
 	}
 
-	queryLower := strings.ToLower(strings.TrimSpace(query))
-	models := make([]*UnifiedModel, 0, len(output.Models))
-	for _, cm := range output.Models {
-		if queryLower != "" && !customModelMatchesQuery(cm, queryLower) {
-			continue
-		}
-		models = append(models, &UnifiedModel{
-			UUID:             cm.UUID,
-			Name:             cm.Name,
-			Description:      cm.Description,
-			Source:           sourceCustom,
-			Status:           string(cm.Status),
-			Architecture:     cm.Architecture,
-			InputModalities:  cm.InputModalities,
-			OutputModalities: cm.OutputModalities,
-		})
+	matched := filterAndRankCustomModels(output.Models, query)
+	rows := make([]CustomSearchRow, 0, len(matched))
+	for _, cm := range matched {
+		rows = append(rows, toCustomSearchRow(cm))
 	}
-	return models, nil
-}
-
-func customModelMatchesQuery(cm *CustomModel, queryLower string) bool {
-	if strings.Contains(strings.ToLower(cm.Name), queryLower) {
-		return true
-	}
-	if strings.Contains(strings.ToLower(cm.Description), queryLower) {
-		return true
-	}
-	if cm.Tags != nil {
-		for _, tag := range cm.Tags.Tags {
-			if strings.Contains(strings.ToLower(tag), queryLower) {
-				return true
-			}
-		}
-	}
-	if strings.Contains(strings.ToLower(cm.Architecture), queryLower) {
-		return true
-	}
-	return false
+	return rows, nil
 }

--- a/pkg/registry/genai-custom-models/unified_search_tool.go
+++ b/pkg/registry/genai-custom-models/unified_search_tool.go
@@ -3,7 +3,6 @@ package genaicustommodels
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync"
 
@@ -137,24 +136,12 @@ func fetchCatalogModels(ctx context.Context, client *godo.Client, query string) 
 
 // fetchCustomModels lists custom models and returns one row per match, ranked by relevance.
 func fetchCustomModels(ctx context.Context, client *godo.Client, query string) ([]CustomSearchRow, error) {
-	apiReq, err := client.NewRequest(ctx, http.MethodGet, customModelsAPIPath, nil)
+	models, _, err := listCustomModels(ctx, client, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, apiReq.Method, apiReq.URL.String(), apiReq.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build http request: %w", err)
-	}
-	httpReq.Header = apiReq.Header.Clone()
-
-	var output ListCustomModelsOutput
-	resp, err := client.Do(ctx, httpReq, &output)
-	if err != nil || resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("failed to list custom models: %w", err)
-	}
-
-	matched := filterAndRankCustomModels(output.Models, query)
+	matched := filterAndRankCustomModels(models, query)
 	rows := make([]CustomSearchRow, 0, len(matched))
 	for _, cm := range matched {
 		rows = append(rows, toCustomSearchRow(cm))

--- a/pkg/registry/genai/README.md
+++ b/pkg/registry/genai/README.md
@@ -367,7 +367,7 @@ Upload and register a model evaluation dataset (presign → Spaces upload → da
 
 **Arguments:**
 - `name` (string, required): Name for the dataset
-- `file_path` (string, required): Path to the CSV file to upload (must include an `input` column; `ground_truth` is optional)
+- `file_path` (string, required): Path to a `.csv` or `.jsonl` file to upload. CSV must include an `input` column; JSONL must be one JSON object per line with an `input` field. `ground_truth` is optional in both formats.
 
 **Returns:** JSON object with the registered dataset UUID and upload metadata
 
@@ -452,7 +452,7 @@ Run a complete model evaluation workflow: upload dataset, create run, and poll f
 **User consent:** Same two-step chat confirmation as `genai-model-eval-create-run`.
 
 **Arguments:**
-- `dataset_file_path` (string, required): Path to the CSV evaluation dataset
+- `dataset_file_path` (string, required): Path to the `.csv` or `.jsonl` evaluation dataset
 - `name` (string, required): Name for the evaluation run
 - `candidate_model_name` (string, required): Exact candidate model name
 - `candidate_model_uuid` (string, optional): Exact full candidate UUID
@@ -479,6 +479,25 @@ Run a complete model evaluation workflow: upload dataset, create run, and poll f
   "duration_seconds": 45.3,
   "error_message": ""
 }
+```
+
+## Model Evaluation Dataset Format
+
+Model evaluation datasets accept **CSV** or **JSONL**:
+
+**CSV** — header row with `input` column (and optional `ground_truth`):
+
+```csv
+input,ground_truth
+What is 2+2?,4
+What is the capital of France?,Paris
+```
+
+**JSONL** — one JSON object per line with an `input` field (and optional `ground_truth`):
+
+```jsonl
+{"input":"What is 2+2?","ground_truth":"4"}
+{"input":"What is the capital of France?","ground_truth":"Paris"}
 ```
 
 ## Model Evaluation Workflow Examples

--- a/pkg/registry/genai/README.md
+++ b/pkg/registry/genai/README.md
@@ -363,16 +363,18 @@ List all available model evaluation metrics.
 ```
 
 #### `genai-model-eval-create-dataset`
-Upload a CSV file as a model evaluation dataset.
+Upload and register a model evaluation dataset (presign → Spaces upload → database record).
 
 **Arguments:**
 - `name` (string, required): Name for the dataset
-- `file_path` (string, required): Path to the CSV file to upload
+- `file_path` (string, required): Path to the CSV file to upload (must include an `input` column; `ground_truth` is optional)
 
-**Returns:** JSON object with the uploaded object key and metadata
+**Returns:** JSON object with the registered dataset UUID and upload metadata
 
 ```json
 {
+  "evaluation_dataset_uuid": "...",
+  "dataset_uuid": "...",
   "object_key": "...",
   "name": "my_dataset",
   "file_name": "queries.csv",
@@ -383,15 +385,20 @@ Upload a CSV file as a model evaluation dataset.
 #### `genai-model-eval-create-run`
 Create a model evaluation run.
 
+**User confirmation (chat, two steps):** (1) Call without `user_message` — returns a preview with `prompt_for_user`. Post that to the end user and wait for their chat reply. (2) Call again with `user_message` set to their verbatim reply (typically **yes**) and the same arguments. The run is not created until step 2.
+
 **Arguments:**
 - `name` (string, required): Name for the evaluation run
-- `candidate_model_uuid` (string, required): UUID of the candidate model
-- `candidate_model_name` (string, required): Display name of the candidate model
-- `dataset_uuid` (string, required): Dataset UUID
-- `judge_model_uuid` (string, required): Judge model UUID
+- `candidate_model_name` (string, required): Exact candidate model name (partial names return match list)
+- `candidate_model_uuid` (string, optional): Exact full candidate UUID (optional when name is exact)
+- `eval_preset_uuid` (string, optional): Preset UUID (dataset/judge/metrics from preset; judge name not required)
+- `dataset_uuid` (string, required without preset): Dataset UUID
+- `judge_model_name` (string, required without preset): Exact judge model name
+- `judge_model_uuid` (string, optional): Exact full judge UUID
 - `metric_uuids` (array of strings, optional): Metric UUIDs to evaluate
 - `star_metric` (object, optional): Primary success metric
 - `candidate_inference_config` (object, optional): Inference params (max_tokens, temperature, top_p)
+- `user_message` (string, optional): End user's verbatim chat reply after preview (second call; typically `yes`)
 
 **Returns:** JSON object with the evaluation run UUID
 
@@ -442,16 +449,20 @@ Get a presigned download URL for the full results of an evaluation run.
 #### `genai-model-eval-run-workflow`
 Run a complete model evaluation workflow: upload dataset, create run, and poll for results.
 
+**User consent:** Same two-step chat confirmation as `genai-model-eval-create-run`.
+
 **Arguments:**
 - `dataset_file_path` (string, required): Path to the CSV evaluation dataset
 - `name` (string, required): Name for the evaluation run
-- `candidate_model_uuid` (string, required): UUID of the candidate model
-- `candidate_model_name` (string, required): Display name of the candidate model
-- `judge_model_uuid` (string, required): UUID of the judge model
+- `candidate_model_name` (string, required): Exact candidate model name
+- `candidate_model_uuid` (string, optional): Exact full candidate UUID
+- `judge_model_name` (string, required): Exact judge model name
+- `judge_model_uuid` (string, optional): Exact full judge UUID
 - `metric_uuids` (array of strings, optional): Metric UUIDs (if empty, all available metrics are used)
 - `candidate_inference_config` (object, optional): Inference params
 - `timeout_seconds` (number, optional): Polling timeout (default: 300)
 - `poll_interval_seconds` (number, optional): Poll interval (default: 5)
+- `user_message` (string, optional): End user's verbatim chat reply after preview (second call; typically `yes`)
 
 **Returns:** JSON object with complete workflow results
 
@@ -483,16 +494,20 @@ Run a complete model evaluation workflow: upload dataset, create run, and poll f
 2. List metrics:
    genai-model-eval-list-metrics
 
-3. Create a run:
+3. Create run (first call — preview; post prompt_for_user and wait for user to type yes):
    genai-model-eval-create-run
      name: "eval_run_1"
-     candidate_model_uuid: "<candidate-uuid>"
      candidate_model_name: "Llama 3.3 70B"
-     dataset_uuid: "<object-key from step 1>"
-     judge_model_uuid: "<judge-model-uuid>"
+     judge_model_name: "GPT-4o"
+     dataset_uuid: "<evaluation_dataset_uuid from step 1>"
      metric_uuids: ["<metric-uuid-1>", "<metric-uuid-2>"]
 
-4. Poll for results:
+4. Create run (second call — after user types yes):
+   genai-model-eval-create-run
+     (same arguments as step 3)
+     user_message: "yes"
+
+5. Poll for results:
    genai-model-eval-get-run
      eval_run_uuid: "<uuid from step 3>"
 ```
@@ -500,12 +515,20 @@ Run a complete model evaluation workflow: upload dataset, create run, and poll f
 ### Using the Orchestrated Workflow (All-in-One)
 
 ```
+# First call — preview; post prompt_for_user and wait for yes in chat
 genai-model-eval-run-workflow
   dataset_file_path: "/path/to/queries.csv"
   name: "eval_llama_v1"
-  candidate_model_uuid: "<candidate-uuid>"
   candidate_model_name: "Llama 3.3 70B"
-  judge_model_uuid: "<judge-model-uuid>"
+  judge_model_name: "GPT-4o"
+
+# Second call — same args plus user_message (verbatim reply from end user)
+genai-model-eval-run-workflow
+  dataset_file_path: "/path/to/queries.csv"
+  name: "eval_llama_v1"
+  candidate_model_name: "Llama 3.3 70B"
+  judge_model_name: "GPT-4o"
+  user_message: "yes"
   timeout_seconds: 300
   poll_interval_seconds: 5
 ```

--- a/pkg/registry/genai/evaluation_tools.go
+++ b/pkg/registry/genai/evaluation_tools.go
@@ -1094,6 +1094,10 @@ func isCSVFile(path string) bool {
 	return len(path) > 4 && path[len(path)-4:] == ".csv"
 }
 
+func isJSONLFile(path string) bool {
+	return len(path) > 6 && path[len(path)-6:] == ".jsonl"
+}
+
 func getFileName(path string) string {
 	for i := len(path) - 1; i >= 0; i-- {
 		if path[i] == '/' || path[i] == '\\' {

--- a/pkg/registry/genai/model_evaluation_dataset.go
+++ b/pkg/registry/genai/model_evaluation_dataset.go
@@ -1,0 +1,165 @@
+package genai
+
+import (
+	"context"
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/digitalocean/godo"
+)
+
+// ModelEvalDatasetResult is returned after uploading and registering a model evaluation dataset.
+type ModelEvalDatasetResult struct {
+	EvaluationDatasetUUID string `json:"evaluation_dataset_uuid"`
+	DatasetUUID           string `json:"dataset_uuid"`
+	ObjectKey             string `json:"object_key"`
+	Name                  string `json:"name"`
+	FileName              string `json:"file_name"`
+	FileSize              int64  `json:"file_size"`
+}
+
+// validateModelEvaluationDataset checks that a CSV has the required input column for model evaluation.
+func validateModelEvaluationDataset(filePath string) error {
+	if !isCSVFile(filePath) {
+		return fmt.Errorf("file must have .csv extension")
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	header, err := reader.Read()
+	if err != nil {
+		return fmt.Errorf("failed to read CSV header: %w", err)
+	}
+
+	hasInput := false
+	for _, col := range header {
+		if col == "input" {
+			hasInput = true
+			break
+		}
+	}
+	if !hasInput {
+		return fmt.Errorf("CSV must contain an 'input' column")
+	}
+
+	rowNum := 1
+	for {
+		row, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read CSV row %d: %w", rowNum, err)
+		}
+		rowNum++
+		if len(row) == 0 {
+			return fmt.Errorf("row %d: empty row", rowNum)
+		}
+	}
+
+	return nil
+}
+
+// uploadAndRegisterModelEvaluationDataset presigns, uploads to Spaces, and registers the dataset record.
+func uploadAndRegisterModelEvaluationDataset(
+	ctx context.Context,
+	client *godo.Client,
+	name string,
+	fileData []byte,
+	fileName string,
+) (*ModelEvalDatasetResult, error) {
+	fileSize := int64(len(fileData))
+
+	presignedInput := &ModelEvalDatasetPresignedUrlsInput{
+		Files: []PresignedUrlFile{
+			{
+				FileName: fileName,
+				FileSize: fileSize,
+			},
+		},
+	}
+
+	presignedReq, err := newGodoRequestWithContext(ctx, client, "POST", modelEvalAPIPath+"/datasets/file_upload_presigned_urls", presignedInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create presigned URL request: %w", err)
+	}
+
+	var presignedOutput ModelEvalDatasetPresignedUrlsOutput
+	resp, err := client.Do(ctx, presignedReq, &presignedOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create presigned URL: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed to create presigned URL: status %d", resp.StatusCode)
+	}
+
+	if len(presignedOutput.Uploads) == 0 {
+		return nil, fmt.Errorf("no presigned URL returned")
+	}
+
+	upload := presignedOutput.Uploads[0]
+
+	uploadReq, err := http.NewRequestWithContext(ctx, "PUT", upload.PresignedURL, bytes.NewReader(fileData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create upload request: %w", err)
+	}
+	uploadReq.ContentLength = fileSize
+	uploadReq.Header.Set("Content-Type", "text/csv")
+
+	httpResp, err := presignedUploadHTTPClient.Do(uploadReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload file: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("file upload failed with status %d: %s", httpResp.StatusCode, string(bodyBytes))
+	}
+
+	datasetInput := &CreateEvaluationDatasetInput{
+		Name:        name,
+		DatasetType: EvaluationDatasetTypeModel,
+		FileUploadDataSource: FileUploadDataSource{
+			OriginalFileName: fileName,
+			StoredObjectKey:  upload.ObjectKey,
+			SizeInBytes:      fileSize,
+		},
+	}
+
+	datasetReq, err := newGodoRequestWithContext(ctx, client, "POST", genAIAPIPath+"/evaluation_datasets", datasetInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dataset request: %w", err)
+	}
+
+	var datasetOutput CreateEvaluationDatasetOutput
+	resp, err = client.Do(ctx, datasetReq, &datasetOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register evaluation dataset: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("failed to register evaluation dataset: status %d", resp.StatusCode)
+	}
+
+	if datasetOutput.EvaluationDatasetUUID == "" {
+		return nil, fmt.Errorf("evaluation dataset registration returned empty UUID")
+	}
+
+	return &ModelEvalDatasetResult{
+		EvaluationDatasetUUID: datasetOutput.EvaluationDatasetUUID,
+		DatasetUUID:           datasetOutput.EvaluationDatasetUUID,
+		ObjectKey:             upload.ObjectKey,
+		Name:                  name,
+		FileName:              fileName,
+		FileSize:              fileSize,
+	}, nil
+}

--- a/pkg/registry/genai/model_evaluation_dataset.go
+++ b/pkg/registry/genai/model_evaluation_dataset.go
@@ -1,13 +1,16 @@
 package genai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/digitalocean/godo"
 )
@@ -22,12 +25,19 @@ type ModelEvalDatasetResult struct {
 	FileSize              int64  `json:"file_size"`
 }
 
-// validateModelEvaluationDataset checks that a CSV has the required input column for model evaluation.
+// validateModelEvaluationDataset checks that a CSV or JSONL file has the required input field for model evaluation.
 func validateModelEvaluationDataset(filePath string) error {
-	if !isCSVFile(filePath) {
-		return fmt.Errorf("file must have .csv extension")
+	switch {
+	case isCSVFile(filePath):
+		return validateModelEvaluationDatasetCSV(filePath)
+	case isJSONLFile(filePath):
+		return validateModelEvaluationDatasetJSONL(filePath)
+	default:
+		return fmt.Errorf("file must have .csv or .jsonl extension")
 	}
+}
 
+func validateModelEvaluationDatasetCSV(filePath string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
@@ -67,6 +77,51 @@ func validateModelEvaluationDataset(filePath string) error {
 	}
 
 	return nil
+}
+
+func validateModelEvaluationDatasetJSONL(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	recordCount := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var record map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return fmt.Errorf("line %d: invalid JSON: %w", lineNum, err)
+		}
+		if _, ok := record["input"]; !ok {
+			return fmt.Errorf("line %d: JSON object must contain an 'input' field", lineNum)
+		}
+		recordCount++
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read JSONL file: %w", err)
+	}
+	if recordCount == 0 {
+		return fmt.Errorf("JSONL file must contain at least one record with an 'input' field")
+	}
+
+	return nil
+}
+
+func modelEvaluationDatasetContentType(fileName string) string {
+	if isJSONLFile(fileName) {
+		return "application/jsonl"
+	}
+	return "text/csv"
 }
 
 // uploadAndRegisterModelEvaluationDataset presigns, uploads to Spaces, and registers the dataset record.
@@ -113,7 +168,7 @@ func uploadAndRegisterModelEvaluationDataset(
 		return nil, fmt.Errorf("failed to create upload request: %w", err)
 	}
 	uploadReq.ContentLength = fileSize
-	uploadReq.Header.Set("Content-Type", "text/csv")
+	uploadReq.Header.Set("Content-Type", modelEvaluationDatasetContentType(fileName))
 
 	httpResp, err := presignedUploadHTTPClient.Do(uploadReq)
 	if err != nil {

--- a/pkg/registry/genai/model_evaluation_dataset.go
+++ b/pkg/registry/genai/model_evaluation_dataset.go
@@ -1,8 +1,8 @@
 package genai
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"

--- a/pkg/registry/genai/model_evaluation_dataset_test.go
+++ b/pkg/registry/genai/model_evaluation_dataset_test.go
@@ -1,0 +1,50 @@
+package genai
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateModelEvaluationDataset(t *testing.T) {
+	dir := t.TempDir()
+
+	validPath := filepath.Join(dir, "valid.csv")
+	require.NoError(t, os.WriteFile(validPath, []byte("input,ground_truth\nWhat is 2+2?,4\n"), 0o600))
+
+	noInputPath := filepath.Join(dir, "no_input.csv")
+	require.NoError(t, os.WriteFile(noInputPath, []byte("query,answer\nfoo,bar\n"), 0o600))
+
+	require.NoError(t, validateModelEvaluationDataset(validPath))
+
+	err := validateModelEvaluationDataset(noInputPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input")
+
+	err = validateModelEvaluationDataset(filepath.Join(dir, "missing.csv"))
+	require.Error(t, err)
+
+	err = validateModelEvaluationDataset(filepath.Join(dir, "bad.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), ".csv")
+}
+
+func TestCreateEvaluationDatasetInput_modelType(t *testing.T) {
+	input := CreateEvaluationDatasetInput{
+		Name:        "test",
+		DatasetType: EvaluationDatasetTypeModel,
+		FileUploadDataSource: FileUploadDataSource{
+			OriginalFileName: "data.csv",
+			StoredObjectKey:  "datasets/abc.csv",
+			SizeInBytes:      100,
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "EVALUATION_DATASET_TYPE_MODEL")
+	require.Contains(t, string(data), "file_upload_dataset")
+}

--- a/pkg/registry/genai/model_evaluation_dataset_test.go
+++ b/pkg/registry/genai/model_evaluation_dataset_test.go
@@ -18,9 +18,20 @@ func TestValidateModelEvaluationDataset(t *testing.T) {
 	noInputPath := filepath.Join(dir, "no_input.csv")
 	require.NoError(t, os.WriteFile(noInputPath, []byte("query,answer\nfoo,bar\n"), 0o600))
 
+	validJSONLPath := filepath.Join(dir, "valid.jsonl")
+	require.NoError(t, os.WriteFile(validJSONLPath, []byte(`{"input":"What is 2+2?","ground_truth":"4"}`+"\n"), 0o600))
+
+	noInputJSONLPath := filepath.Join(dir, "no_input.jsonl")
+	require.NoError(t, os.WriteFile(noInputJSONLPath, []byte(`{"ground_truth":"4"}`+"\n"), 0o600))
+
 	require.NoError(t, validateModelEvaluationDataset(validPath))
+	require.NoError(t, validateModelEvaluationDataset(validJSONLPath))
 
 	err := validateModelEvaluationDataset(noInputPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "input")
+
+	err = validateModelEvaluationDataset(noInputJSONLPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "input")
 
@@ -30,6 +41,12 @@ func TestValidateModelEvaluationDataset(t *testing.T) {
 	err = validateModelEvaluationDataset(filepath.Join(dir, "bad.json"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), ".csv")
+	require.Contains(t, err.Error(), ".jsonl")
+}
+
+func TestModelEvaluationDatasetContentType(t *testing.T) {
+	require.Equal(t, "text/csv", modelEvaluationDatasetContentType("queries.csv"))
+	require.Equal(t, "application/jsonl", modelEvaluationDatasetContentType("queries.jsonl"))
 }
 
 func TestCreateEvaluationDatasetInput_modelType(t *testing.T) {

--- a/pkg/registry/genai/model_evaluation_resolve.go
+++ b/pkg/registry/genai/model_evaluation_resolve.go
@@ -88,21 +88,21 @@ type ModelEvalModelsResolveOutput struct {
 
 // ModelEvalConsentPreviewOutput is returned before the user types yes in chat.
 type ModelEvalConsentPreviewOutput struct {
-	Status                string                   `json:"status"`
-	Message               string                   `json:"message"`
-	PromptForUser         string                   `json:"prompt_for_user"`
-	RunName               string                   `json:"run_name"`
-	DatasetUUID           string                   `json:"dataset_uuid,omitempty"`
-	DatasetFilePath       string                   `json:"dataset_file_path,omitempty"`
-	EvalPresetUUID        string                   `json:"eval_preset_uuid,omitempty"`
-	MetricUUIDs           []string                 `json:"metric_uuids,omitempty"`
-	StarMetric            *StarMetric              `json:"star_metric,omitempty"`
-	CandidateModel        ModelEvalMatchCandidate  `json:"candidate_model"`
-	JudgeModel            *ModelEvalMatchCandidate `json:"judge_model,omitempty"`
-	StopAndAskUser              bool   `json:"stop_and_ask_user"`
-	DoNotRetryUntilUserOK       bool   `json:"do_not_retry_until_user_confirms"`
-	RequireUserMessageFromChat  bool   `json:"require_user_message_from_chat"`
-	InstructionForAgent         string `json:"instruction_for_agent"`
+	Status                     string                   `json:"status"`
+	Message                    string                   `json:"message"`
+	PromptForUser              string                   `json:"prompt_for_user"`
+	RunName                    string                   `json:"run_name"`
+	DatasetUUID                string                   `json:"dataset_uuid,omitempty"`
+	DatasetFilePath            string                   `json:"dataset_file_path,omitempty"`
+	EvalPresetUUID             string                   `json:"eval_preset_uuid,omitempty"`
+	MetricUUIDs                []string                 `json:"metric_uuids,omitempty"`
+	StarMetric                 *StarMetric              `json:"star_metric,omitempty"`
+	CandidateModel             ModelEvalMatchCandidate  `json:"candidate_model"`
+	JudgeModel                 *ModelEvalMatchCandidate `json:"judge_model,omitempty"`
+	StopAndAskUser             bool                     `json:"stop_and_ask_user"`
+	DoNotRetryUntilUserOK      bool                     `json:"do_not_retry_until_user_confirms"`
+	RequireUserMessageFromChat bool                     `json:"require_user_message_from_chat"`
+	InstructionForAgent        string                   `json:"instruction_for_agent"`
 }
 
 // modelEvalRunConfig holds run parameters shown in the consent prompt.

--- a/pkg/registry/genai/model_evaluation_resolve.go
+++ b/pkg/registry/genai/model_evaluation_resolve.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -12,8 +11,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-
-const customModelsAPIPath = "v2/gen-ai/custom_models"
 
 var evalModelUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
@@ -127,16 +124,6 @@ type modelEvalRunModels struct {
 	Judge     *modelEvalResolvedModel
 }
 
-type evalCustomModelListItem struct {
-	UUID   string `json:"uuid"`
-	Name   string `json:"name"`
-	Status string `json:"status"`
-}
-
-type listEvalCustomModelsOutput struct {
-	Models []*evalCustomModelListItem `json:"models"`
-}
-
 // listAllEvalModels fetches catalog and custom models for evaluation run resolution.
 func listAllEvalModels(ctx context.Context, client *godo.Client) ([]*EvalCatalogModel, error) {
 	type catalogResult struct {
@@ -235,35 +222,46 @@ func fetchEvalCustomModels(ctx context.Context, client *godo.Client) ([]*EvalCat
 	page := 1
 
 	for {
-		path := fmt.Sprintf("%s?page=%d&per_page=%d", customModelsAPIPath, page, perPage)
-		apiReq, err := newGodoRequestWithContext(ctx, client, http.MethodGet, path, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-
-		var output listEvalCustomModelsOutput
-		resp, err := client.Do(ctx, apiReq, &output)
+		out, resp, err := client.GradientAI.ListCustomModels(ctx, &godo.CustomModelListOptions{
+			ListOptions: godo.ListOptions{Page: page, PerPage: perPage},
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list custom models: %w", err)
 		}
-		if resp.StatusCode >= 400 {
+		if resp != nil && resp.StatusCode >= 400 {
 			return nil, fmt.Errorf("failed to list custom models: status %d", resp.StatusCode)
 		}
 
-		for _, cm := range output.Models {
-			if cm == nil || cm.Status == "STATUS_DELETED" {
+		var models []*godo.CustomModel
+		var meta *godo.Meta
+		if out != nil {
+			models = out.Models
+			meta = out.Meta
+		}
+		if meta == nil && resp != nil {
+			meta = resp.Meta
+		}
+
+		for _, cm := range models {
+			if cm == nil || cm.Status == godo.CustomModelStatusDeleted {
 				continue
 			}
 			all = append(all, &EvalCatalogModel{
-				UUID:        cm.UUID,
+				UUID:        cm.Uuid,
 				APIName:     cm.Name,
 				DisplayName: cm.Name,
 				Source:      "custom",
-				Status:      cm.Status,
+				Status:      string(cm.Status),
 			})
 		}
 
-		if len(output.Models) == 0 || len(output.Models) < perPage {
+		if len(models) == 0 {
+			break
+		}
+		if meta != nil && meta.Pages > 0 && page >= meta.Pages {
+			break
+		}
+		if len(models) < perPage {
 			break
 		}
 		page++
@@ -696,27 +694,20 @@ func lookupEvalModelByUUID(ctx context.Context, client *godo.Client, uuid string
 		}, nil
 	}
 
-	apiReq, err := newGodoRequestWithContext(ctx, client, http.MethodGet, customModelsAPIPath+"/"+uuid, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create custom model request: %w", err)
-	}
-	var output struct {
-		Model *evalCustomModelListItem `json:"model"`
-	}
-	resp, err := client.Do(ctx, apiReq, &output)
+	customModel, _, err := client.GradientAI.GetCustomModel(ctx, uuid)
 	if err != nil {
 		return nil, fmt.Errorf("model %q not found in catalog or custom models: %w", uuid, err)
 	}
-	if resp.StatusCode >= 400 || output.Model == nil {
+	if customModel == nil {
 		return nil, fmt.Errorf("model %q not found in catalog or custom models", uuid)
 	}
-	if output.Model.Status == "STATUS_DELETED" {
+	if customModel.Status == godo.CustomModelStatusDeleted {
 		return nil, fmt.Errorf("model %q is deleted", uuid)
 	}
 	return &modelEvalResolvedModel{
 		UUID:        uuid,
-		APIName:     output.Model.Name,
-		DisplayName: output.Model.Name,
+		APIName:     customModel.Name,
+		DisplayName: customModel.Name,
 		Source:      "custom",
 	}, nil
 }

--- a/pkg/registry/genai/model_evaluation_resolve.go
+++ b/pkg/registry/genai/model_evaluation_resolve.go
@@ -1,0 +1,819 @@
+package genai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+const customModelsAPIPath = "v2/gen-ai/custom_models"
+
+var evalModelUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+const (
+	modelEvalCandidateNameRequiredMsg = "candidate_model_name is required: ask the user for the exact model name before creating an evaluation run."
+
+	modelEvalJudgeNameRequiredMsg = "judge_model_name is required when not using eval_preset_uuid (or pass eval_preset_uuid so the judge comes from the preset)."
+
+	modelEvalConsentStatus        = "consent_required"
+	modelEvalModelSelectionStatus = "model_selection_required"
+
+	modelEvalUserMessageRequiredMsg = "user_message is required to start the run: pass the end user's verbatim chat reply (e.g. yes) from after they saw prompt_for_user. " +
+		"First call: omit user_message — tool returns a preview. Post prompt_for_user to the end user and wait for their reply in chat. " +
+		"Second call: pass user_message set to that exact user reply (not assistant text). Never pass user_message on the first call."
+
+	modelEvalUserMessageNotYesMsg = "user_message is not yes — it must be the end user's verbatim chat reply (e.g. yes). Wait for the user to reply after prompt_for_user before retrying."
+
+	modelEvalUUIDNameMismatchMsg = "candidate uuid and candidate_model_name refer to different models; provide the exact uuid and exact name for the same model, or pass only one identifier."
+
+	modelEvalJudgeUUIDNameMismatchMsg = "judge_model_uuid and judge_model_name refer to different models; provide the exact uuid and exact name for the same model, or pass only one identifier."
+
+	genaiModelEvalUserMessageDescription = "The end user's verbatim chat message after they reviewed prompt_for_user (typically yes). " +
+		"Copy from the user's message only — never use assistant-generated text. Omit on the first call."
+
+	genaiModelEvalCreateRunToolDescription = "Create a model evaluation run. Provide either an eval_preset_uuid to use a preset, or provide dataset_uuid, judge_model_name, and metric_uuids for inline configuration.\n\n" +
+		"MODEL NAMES: candidate_model_name accepts display or API (inference) names. When candidate_model_uuid / judge_model_uuid are omitted, UUIDs are fetched from the catalog API and shown in the consent preview.\n\n" +
+		"USER CONFIRMATION (chat): (1) Call without user_message — returns prompt_for_user. Post it to the end user and wait for their chat reply. " +
+		"(2) Call again with user_message set to that exact reply and the same arguments. The run is not created until step 2."
+
+	genaiModelEvalWorkflowToolDescription = "Run a complete model evaluation workflow: upload dataset, create evaluation run, and poll for results.\n\n" +
+		"MODEL NAMES and USER CONSENT: same two-step chat confirmation as genai-model-eval-create-run."
+)
+
+// EvalCatalogModel is a catalog or custom model usable for model evaluation runs.
+type EvalCatalogModel struct {
+	UUID        string `json:"uuid"`
+	APIName     string `json:"api_name"`     // sent as candidate_model_name / judge_model_name to the evaluation API
+	DisplayName string `json:"display_name"` // human-readable catalog name
+	Source      string `json:"source,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// ModelEvalMatchCandidate is a model returned when name/uuid resolution needs disambiguation or consent.
+type ModelEvalMatchCandidate struct {
+	UUID        string `json:"uuid"`
+	DisplayName string `json:"display_name"`
+	APIName     string `json:"api_name"`
+	Source      string `json:"source,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// ModelEvalUnresolvedOutput is returned when a model identifier is not an exact match.
+type ModelEvalUnresolvedOutput struct {
+	Message                 string                    `json:"message"`
+	Role                    string                    `json:"role"`
+	Query                   string                    `json:"query"`
+	QueryField              string                    `json:"query_field"`
+	Matches                 []ModelEvalMatchCandidate `json:"matches"`
+	RequiresExactMatch      bool                      `json:"requires_exact_match"`
+	DoNotSubstituteFromList bool                      `json:"do_not_substitute_name_or_uuid_from_matches"`
+}
+
+// ModelEvalModelsResolveOutput is returned when candidate and/or judge models need disambiguation.
+type ModelEvalModelsResolveOutput struct {
+	Status                string                     `json:"status"`
+	Message               string                     `json:"message"`
+	Candidate             *ModelEvalUnresolvedOutput `json:"candidate,omitempty"`
+	Judge                 *ModelEvalUnresolvedOutput `json:"judge,omitempty"`
+	StopAndAskUser        bool                       `json:"stop_and_ask_user"`
+	DoNotRetryUntilUserOK bool                       `json:"do_not_retry_until_user_confirms"`
+}
+
+// ModelEvalConsentPreviewOutput is returned before the user types yes in chat.
+type ModelEvalConsentPreviewOutput struct {
+	Status                string                   `json:"status"`
+	Message               string                   `json:"message"`
+	PromptForUser         string                   `json:"prompt_for_user"`
+	RunName               string                   `json:"run_name"`
+	DatasetUUID           string                   `json:"dataset_uuid,omitempty"`
+	DatasetFilePath       string                   `json:"dataset_file_path,omitempty"`
+	EvalPresetUUID        string                   `json:"eval_preset_uuid,omitempty"`
+	MetricUUIDs           []string                 `json:"metric_uuids,omitempty"`
+	StarMetric            *StarMetric              `json:"star_metric,omitempty"`
+	CandidateModel        ModelEvalMatchCandidate  `json:"candidate_model"`
+	JudgeModel            *ModelEvalMatchCandidate `json:"judge_model,omitempty"`
+	StopAndAskUser              bool   `json:"stop_and_ask_user"`
+	DoNotRetryUntilUserOK       bool   `json:"do_not_retry_until_user_confirms"`
+	RequireUserMessageFromChat  bool   `json:"require_user_message_from_chat"`
+	InstructionForAgent         string `json:"instruction_for_agent"`
+}
+
+// modelEvalRunConfig holds run parameters shown in the consent prompt.
+type modelEvalRunConfig struct {
+	RunName         string
+	DatasetUUID     string
+	DatasetFilePath string
+	EvalPresetUUID  string
+	MetricUUIDs     []string
+	StarMetric      *StarMetric
+}
+
+type modelEvalResolvedModel struct {
+	UUID        string
+	APIName     string
+	DisplayName string
+	Source      string
+}
+
+type modelEvalRunModels struct {
+	Candidate modelEvalResolvedModel
+	Judge     *modelEvalResolvedModel
+}
+
+type evalCustomModelListItem struct {
+	UUID   string `json:"uuid"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type listEvalCustomModelsOutput struct {
+	Models []*evalCustomModelListItem `json:"models"`
+}
+
+// listAllEvalModels fetches catalog and custom models for evaluation run resolution.
+func listAllEvalModels(ctx context.Context, client *godo.Client) ([]*EvalCatalogModel, error) {
+	type catalogResult struct {
+		models []*EvalCatalogModel
+		err    error
+	}
+	type customResult struct {
+		models []*EvalCatalogModel
+		err    error
+	}
+
+	var wg sync.WaitGroup
+	catalogCh := make(chan catalogResult, 1)
+	customCh := make(chan customResult, 1)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		models, err := fetchEvalCatalogModels(ctx, client)
+		catalogCh <- catalogResult{models: models, err: err}
+	}()
+	go func() {
+		defer wg.Done()
+		models, err := fetchEvalCustomModels(ctx, client)
+		customCh <- customResult{models: models, err: err}
+	}()
+
+	wg.Wait()
+	close(catalogCh)
+	close(customCh)
+
+	cr := <-catalogCh
+	cu := <-customCh
+
+	if cr.err != nil && cu.err != nil {
+		return nil, fmt.Errorf("catalog: %w; custom: %w", cr.err, cu.err)
+	}
+
+	merged := make([]*EvalCatalogModel, 0, len(cr.models)+len(cu.models))
+	merged = append(merged, cr.models...)
+	merged = append(merged, cu.models...)
+	return merged, nil
+}
+
+func fetchEvalCatalogModels(ctx context.Context, client *godo.Client) ([]*EvalCatalogModel, error) {
+	uuids, _, err := client.GradientAI.SearchModels(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to search catalog: %w", err)
+	}
+
+	type result struct {
+		model *EvalCatalogModel
+		err   error
+	}
+
+	const maxConcurrent = 20
+	sem := make(chan struct{}, maxConcurrent)
+	results := make([]result, len(uuids))
+
+	var wg sync.WaitGroup
+	for i, uuid := range uuids {
+		wg.Add(1)
+		go func(idx int, id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			model, _, getErr := client.GradientAI.GetModelByUUID(ctx, id)
+			if getErr != nil || model == nil {
+				results[idx] = result{err: getErr}
+				return
+			}
+			apiName, displayName := catalogModelNames(model)
+			results[idx] = result{model: &EvalCatalogModel{
+				UUID:        model.Uuid,
+				APIName:     apiName,
+				DisplayName: displayName,
+				Source:      "catalog",
+			}}
+		}(i, uuid)
+	}
+	wg.Wait()
+
+	models := make([]*EvalCatalogModel, 0, len(results))
+	for _, r := range results {
+		if r.model != nil {
+			models = append(models, r.model)
+		}
+	}
+	return models, nil
+}
+
+func fetchEvalCustomModels(ctx context.Context, client *godo.Client) ([]*EvalCatalogModel, error) {
+	const perPage = 100
+	var all []*EvalCatalogModel
+	page := 1
+
+	for {
+		path := fmt.Sprintf("%s?page=%d&per_page=%d", customModelsAPIPath, page, perPage)
+		apiReq, err := newGodoRequestWithContext(ctx, client, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		var output listEvalCustomModelsOutput
+		resp, err := client.Do(ctx, apiReq, &output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list custom models: %w", err)
+		}
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("failed to list custom models: status %d", resp.StatusCode)
+		}
+
+		for _, cm := range output.Models {
+			if cm == nil || cm.Status == "STATUS_DELETED" {
+				continue
+			}
+			all = append(all, &EvalCatalogModel{
+				UUID:        cm.UUID,
+				APIName:     cm.Name,
+				DisplayName: cm.Name,
+				Source:      "custom",
+				Status:      cm.Status,
+			})
+		}
+
+		if len(output.Models) == 0 || len(output.Models) < perPage {
+			break
+		}
+		page++
+	}
+
+	return all, nil
+}
+
+func resolveEvalModelsForRun(
+	ctx context.Context,
+	client *godo.Client,
+	candidateUUID, candidateName string,
+	judgeUUID, judgeName string,
+	requireJudge bool,
+	models []*EvalCatalogModel,
+) (*modelEvalRunModels, *ModelEvalModelsResolveOutput, error) {
+	candidate, candidateUnresolved, err := resolveEvalModel(ctx, client, "candidate", candidateUUID, candidateName, models)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var judge *modelEvalResolvedModel
+	var judgeUnresolved *ModelEvalUnresolvedOutput
+
+	if requireJudge {
+		if strings.TrimSpace(judgeName) == "" && strings.TrimSpace(judgeUUID) == "" {
+			return nil, nil, fmt.Errorf("%s", modelEvalJudgeNameRequiredMsg)
+		}
+		judge, judgeUnresolved, err = resolveEvalModel(ctx, client, "judge", judgeUUID, judgeName, models)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if candidateUnresolved != nil || judgeUnresolved != nil {
+		return nil, buildModelEvalModelsResolveOutput(candidateUnresolved, judgeUnresolved), nil
+	}
+
+	out := &modelEvalRunModels{Candidate: *candidate}
+	if judge != nil {
+		out.Judge = judge
+	}
+	return out, nil, nil
+}
+
+func resolveEvalModel(ctx context.Context, client *godo.Client, role, uuid, name string, models []*EvalCatalogModel) (*modelEvalResolvedModel, *ModelEvalUnresolvedOutput, error) {
+	uuid = strings.TrimSpace(uuid)
+	name = strings.TrimSpace(name)
+
+	switch {
+	case uuid != "" && name != "":
+		uuidResolved, uuidUnresolved, err := resolveEvalModelByUUID(role, uuid, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if uuidUnresolved != nil {
+			return nil, uuidUnresolved, nil
+		}
+		if !evalModelNameMatchesExact(findEvalModelByUUID(models, uuidResolved.UUID), name) {
+			msg := modelEvalUUIDNameMismatchMsg
+			if role == "judge" {
+				msg = modelEvalJudgeUUIDNameMismatchMsg
+			}
+			return nil, nil, fmt.Errorf("%s", msg)
+		}
+		return uuidResolved, nil, nil
+
+	case uuid != "":
+		uuidResolved, uuidUnresolved, err := resolveEvalModelByUUID(role, uuid, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if uuidUnresolved != nil {
+			return nil, uuidUnresolved, nil
+		}
+		return uuidResolved, nil, nil
+
+	default:
+		nameResolved, nameUnresolved, err := resolveEvalModelByName(ctx, client, role, name, models)
+		if err != nil {
+			return nil, nil, err
+		}
+		if nameUnresolved != nil {
+			return nil, nameUnresolved, nil
+		}
+		return nameResolved, nil, nil
+	}
+}
+
+// lookupEvalCatalogModelByName searches the catalog API and returns the model when display or API name matches exactly.
+func lookupEvalCatalogModelByName(ctx context.Context, client *godo.Client, name string) (*modelEvalResolvedModel, error) {
+	if client == nil {
+		return nil, fmt.Errorf("catalog client required")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	uuids, _, err := client.GradientAI.SearchModels(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search catalog: %w", err)
+	}
+
+	var exact []*modelEvalResolvedModel
+	for _, id := range uuids {
+		model, _, getErr := client.GradientAI.GetModelByUUID(ctx, id)
+		if getErr != nil || model == nil || model.Uuid == "" {
+			continue
+		}
+		apiName, displayName := catalogModelNames(model)
+		if !evalModelNameMatchesExact(&EvalCatalogModel{DisplayName: displayName, APIName: apiName}, name) {
+			continue
+		}
+		exact = append(exact, &modelEvalResolvedModel{
+			UUID:        model.Uuid,
+			APIName:     apiName,
+			DisplayName: displayName,
+			Source:      "catalog",
+		})
+	}
+
+	switch len(exact) {
+	case 1:
+		return exact[0], nil
+	case 0:
+		return nil, fmt.Errorf("no catalog model with exact name %q", name)
+	default:
+		return nil, fmt.Errorf("multiple catalog models named %q; provide uuid to select one", name)
+	}
+}
+
+func catalogModelNames(model *godo.Model) (apiName, displayName string) {
+	displayName = model.Name
+	apiName = model.InferenceName
+	if apiName == "" && displayName != "" {
+		apiName = displayNameToInferenceSlug(displayName)
+	}
+	if apiName == "" {
+		apiName = displayName
+	}
+	if displayName == "" {
+		displayName = apiName
+	}
+	return apiName, displayName
+}
+
+// displayNameToInferenceSlug derives the evaluation API slug when InferenceName is unset.
+func displayNameToInferenceSlug(displayName string) string {
+	s := strings.ToLower(strings.TrimSpace(displayName))
+	return strings.ReplaceAll(s, " ", "-")
+}
+
+func evalModelNameMatchesExact(m *EvalCatalogModel, name string) bool {
+	if m == nil {
+		return false
+	}
+	return m.DisplayName == name || m.APIName == name
+}
+
+func findEvalModelByUUID(models []*EvalCatalogModel, uuid string) *EvalCatalogModel {
+	for _, m := range filterActiveEvalModels(models) {
+		if strings.EqualFold(m.UUID, uuid) {
+			return m
+		}
+	}
+	return nil
+}
+
+func evalModelNameMatchesPartial(m *EvalCatalogModel, queryLower string) bool {
+	return strings.Contains(strings.ToLower(m.DisplayName), queryLower) ||
+		strings.Contains(strings.ToLower(m.APIName), queryLower)
+}
+
+func resolveEvalModelByName(ctx context.Context, client *godo.Client, role, name string, models []*EvalCatalogModel) (*modelEvalResolvedModel, *ModelEvalUnresolvedOutput, error) {
+	active := filterActiveEvalModels(models)
+
+	var exact []*EvalCatalogModel
+	for _, m := range active {
+		if evalModelNameMatchesExact(m, name) {
+			exact = append(exact, m)
+		}
+	}
+
+	switch len(exact) {
+	case 1:
+		return evalModelToResolved(exact[0]), nil, nil
+	case 0:
+		if client != nil {
+			if catalogResolved, err := lookupEvalCatalogModelByName(ctx, client, name); err == nil {
+				return catalogResolved, nil, nil
+			}
+		}
+		queryLower := strings.ToLower(name)
+		var partial []*EvalCatalogModel
+		for _, m := range active {
+			if evalModelNameMatchesPartial(m, queryLower) {
+				partial = append(partial, m)
+			}
+		}
+		return nil, buildEvalUnresolvedOutput(role, name, "name", partial), nil
+	default:
+		return nil, nil, fmt.Errorf("multiple %s models named %q; provide uuid to select one", role, name)
+	}
+}
+
+func validateModelEvalResolvedUUIDs(resolved *modelEvalRunModels, requireJudge bool) error {
+	if resolved == nil {
+		return fmt.Errorf("no models resolved for evaluation run")
+	}
+	if strings.TrimSpace(resolved.Candidate.UUID) == "" {
+		return fmt.Errorf("candidate model uuid could not be fetched from catalog; provide candidate_model_uuid or an exact catalog model name")
+	}
+	if requireJudge {
+		if resolved.Judge == nil || strings.TrimSpace(resolved.Judge.UUID) == "" {
+			return fmt.Errorf("judge model uuid could not be fetched from catalog; provide judge_model_uuid or an exact catalog model name")
+		}
+	}
+	return nil
+}
+
+func resolveEvalModelByUUID(role, uuid string, models []*EvalCatalogModel) (*modelEvalResolvedModel, *ModelEvalUnresolvedOutput, error) {
+	active := filterActiveEvalModels(models)
+
+	if isExactEvalModelUUID(uuid) {
+		var exact []*EvalCatalogModel
+		for _, m := range active {
+			if strings.EqualFold(m.UUID, uuid) {
+				exact = append(exact, m)
+			}
+		}
+		switch len(exact) {
+		case 1:
+			return evalModelToResolved(exact[0]), nil, nil
+		case 0:
+			return nil, buildEvalUnresolvedOutput(role, uuid, "uuid", nil), nil
+		default:
+			return nil, nil, fmt.Errorf("multiple %s models with uuid %q", role, uuid)
+		}
+	}
+
+	queryLower := strings.ToLower(uuid)
+	var partial []*EvalCatalogModel
+	for _, m := range active {
+		if strings.Contains(strings.ToLower(m.UUID), queryLower) {
+			partial = append(partial, m)
+		}
+	}
+	return nil, buildEvalUnresolvedOutput(role, uuid, "uuid", partial), nil
+}
+
+func filterActiveEvalModels(models []*EvalCatalogModel) []*EvalCatalogModel {
+	out := make([]*EvalCatalogModel, 0, len(models))
+	for _, m := range models {
+		if m == nil || m.Status == "STATUS_DELETED" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func evalModelToResolved(m *EvalCatalogModel) *modelEvalResolvedModel {
+	return &modelEvalResolvedModel{
+		UUID:        m.UUID,
+		APIName:     m.APIName,
+		DisplayName: m.DisplayName,
+		Source:      m.Source,
+	}
+}
+
+func evalModelToMatchCandidate(m *EvalCatalogModel) ModelEvalMatchCandidate {
+	return ModelEvalMatchCandidate{
+		UUID:        m.UUID,
+		DisplayName: m.DisplayName,
+		APIName:     m.APIName,
+		Source:      m.Source,
+		Status:      m.Status,
+	}
+}
+
+func isModelEvalUserMessageYes(userMessage string) bool {
+	return strings.EqualFold(strings.TrimSpace(userMessage), "yes")
+}
+
+// checkModelEvalUserMessage returns a tool result when the end user's confirmation is missing or invalid.
+// ok is true only when user_message is the user's yes reply (case-insensitive).
+func checkModelEvalUserMessage(args map[string]any, resolved *modelEvalRunModels, cfg *modelEvalRunConfig) (*mcp.CallToolResult, bool) {
+	userMessage := strings.TrimSpace(stringArg(args, "user_message"))
+	if isModelEvalUserMessageYes(userMessage) {
+		return nil, true
+	}
+	if userMessage != "" {
+		return mcp.NewToolResultError(modelEvalUserMessageNotYesMsg), false
+	}
+	result, err := modelEvalUserActionResult(buildModelEvalConsentPreview(resolved, cfg))
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), false
+	}
+	return result, false
+}
+
+func parseMetricUUIDsFromArgs(args map[string]any) []string {
+	metricUUIDsRaw, ok := args["metric_uuids"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(metricUUIDsRaw))
+	for _, m := range metricUUIDsRaw {
+		if s, ok := m.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func parseModelEvalRunConfig(args map[string]any, requireJudge bool) (*modelEvalRunConfig, error) {
+	runName, _ := args["name"].(string)
+	runName = strings.TrimSpace(runName)
+	if runName == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	cfg := &modelEvalRunConfig{
+		RunName:        runName,
+		EvalPresetUUID: strings.TrimSpace(stringArg(args, "eval_preset_uuid")),
+		DatasetUUID:    strings.TrimSpace(stringArg(args, "dataset_uuid")),
+		MetricUUIDs:    parseMetricUUIDsFromArgs(args),
+		StarMetric:     parseStarMetricArg(args),
+	}
+	if cfg.StarMetric == nil && len(cfg.MetricUUIDs) > 0 {
+		cfg.StarMetric = defaultStarMetric(cfg.MetricUUIDs)
+	}
+
+	if cfg.EvalPresetUUID == "" {
+		if cfg.DatasetUUID == "" {
+			return nil, fmt.Errorf("dataset_uuid is required when not using eval_preset_uuid")
+		}
+		if requireJudge && len(cfg.MetricUUIDs) == 0 {
+			return nil, fmt.Errorf("metric_uuids is required when not using eval_preset_uuid")
+		}
+	}
+	return cfg, nil
+}
+
+func stringArg(args map[string]any, key string) string {
+	v, _ := args[key].(string)
+	return v
+}
+
+func buildModelEvalPromptForUser(resolved *modelEvalRunModels, cfg *modelEvalRunConfig) string {
+	var b strings.Builder
+	b.WriteString("Please confirm this model evaluation run.\n")
+	b.WriteString("Catalog UUIDs below were resolved from model names (use these exact values on the confirmed run).\n\n")
+	fmt.Fprintf(&b, "Candidate model\n  display_name: %s\n  api_name: %s\n  uuid: %s\n\n",
+		resolved.Candidate.DisplayName, resolved.Candidate.APIName, resolved.Candidate.UUID)
+	if resolved.Judge != nil {
+		fmt.Fprintf(&b, "Judge model\n  display_name: %s\n  api_name: %s\n  uuid: %s\n\n",
+			resolved.Judge.DisplayName, resolved.Judge.APIName, resolved.Judge.UUID)
+	}
+	if cfg.EvalPresetUUID != "" {
+		fmt.Fprintf(&b, "Eval preset UUID: %s\n", cfg.EvalPresetUUID)
+	}
+	if cfg.DatasetUUID != "" {
+		fmt.Fprintf(&b, "Dataset UUID: %s\n", cfg.DatasetUUID)
+	}
+	if cfg.DatasetFilePath != "" {
+		fmt.Fprintf(&b, "Dataset file: %s\n", cfg.DatasetFilePath)
+	}
+	if len(cfg.MetricUUIDs) > 0 {
+		b.WriteString("Metric UUIDs:\n")
+		for _, id := range cfg.MetricUUIDs {
+			fmt.Fprintf(&b, "  - %s\n", id)
+		}
+	}
+	if cfg.StarMetric != nil && cfg.StarMetric.MetricUUID != "" {
+		fmt.Fprintf(&b, "Star metric UUID: %s\n", cfg.StarMetric.MetricUUID)
+		if cfg.StarMetric.SuccessThresholdPct != nil {
+			fmt.Fprintf(&b, "Star metric success_threshold_pct: %g\n", *cfg.StarMetric.SuccessThresholdPct)
+		}
+	}
+	fmt.Fprintf(&b, "\nRun name: %s\n\nIf this looks correct, reply **yes** in this chat to start the evaluation run.", cfg.RunName)
+	return b.String()
+}
+
+func buildModelEvalConsentPreview(resolved *modelEvalRunModels, cfg *modelEvalRunConfig) *ModelEvalConsentPreviewOutput {
+	out := &ModelEvalConsentPreviewOutput{
+		Status:                     modelEvalConsentStatus,
+		Message:                    modelEvalUserMessageRequiredMsg,
+		PromptForUser:              buildModelEvalPromptForUser(resolved, cfg),
+		RunName:                    cfg.RunName,
+		DatasetUUID:                cfg.DatasetUUID,
+		DatasetFilePath:            cfg.DatasetFilePath,
+		EvalPresetUUID:             cfg.EvalPresetUUID,
+		MetricUUIDs:                append([]string(nil), cfg.MetricUUIDs...),
+		StarMetric:                 cfg.StarMetric,
+		CandidateModel:             evalModelToMatchCandidateFromResolved(resolved.Candidate),
+		StopAndAskUser:             true,
+		DoNotRetryUntilUserOK:      true,
+		RequireUserMessageFromChat: true,
+		InstructionForAgent: "Post prompt_for_user to the end user and wait for their chat reply. " +
+			"On the next call, pass user_message set to that verbatim reply (typically yes). Do not pass user_message until the user has replied.",
+	}
+	if resolved.Judge != nil {
+		judge := evalModelToMatchCandidateFromResolved(*resolved.Judge)
+		out.JudgeModel = &judge
+	}
+	return out
+}
+
+func evalModelToMatchCandidateFromResolved(m modelEvalResolvedModel) ModelEvalMatchCandidate {
+	return ModelEvalMatchCandidate{
+		UUID:        m.UUID,
+		DisplayName: m.DisplayName,
+		APIName:     m.APIName,
+		Source:      m.Source,
+	}
+}
+
+// lookupEvalModelByUUID loads the canonical api_name (inference slug) and display_name for a model UUID.
+func lookupEvalModelByUUID(ctx context.Context, client *godo.Client, uuid string) (*modelEvalResolvedModel, error) {
+	model, _, err := client.GradientAI.GetModelByUUID(ctx, uuid)
+	if err == nil && model != nil {
+		apiName, displayName := catalogModelNames(model)
+		return &modelEvalResolvedModel{
+			UUID:        uuid,
+			APIName:     apiName,
+			DisplayName: displayName,
+			Source:      "catalog",
+		}, nil
+	}
+
+	apiReq, err := newGodoRequestWithContext(ctx, client, http.MethodGet, customModelsAPIPath+"/"+uuid, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create custom model request: %w", err)
+	}
+	var output struct {
+		Model *evalCustomModelListItem `json:"model"`
+	}
+	resp, err := client.Do(ctx, apiReq, &output)
+	if err != nil {
+		return nil, fmt.Errorf("model %q not found in catalog or custom models: %w", uuid, err)
+	}
+	if resp.StatusCode >= 400 || output.Model == nil {
+		return nil, fmt.Errorf("model %q not found in catalog or custom models", uuid)
+	}
+	if output.Model.Status == "STATUS_DELETED" {
+		return nil, fmt.Errorf("model %q is deleted", uuid)
+	}
+	return &modelEvalResolvedModel{
+		UUID:        uuid,
+		APIName:     output.Model.Name,
+		DisplayName: output.Model.Name,
+		Source:      "custom",
+	}, nil
+}
+
+// hydrateResolvedEvalModelsFromAPI re-fetches api_name values from the API so consent tokens cannot supply display names.
+func hydrateResolvedEvalModelsFromAPI(ctx context.Context, client *godo.Client, resolved *modelEvalRunModels) (*modelEvalRunModels, error) {
+	if resolved == nil {
+		return nil, fmt.Errorf("no models to hydrate")
+	}
+	candidate, err := lookupEvalModelByUUID(ctx, client, resolved.Candidate.UUID)
+	if err != nil {
+		return nil, err
+	}
+	out := &modelEvalRunModels{Candidate: *candidate}
+	if resolved.Judge != nil {
+		judge, err := lookupEvalModelByUUID(ctx, client, resolved.Judge.UUID)
+		if err != nil {
+			return nil, err
+		}
+		out.Judge = judge
+	}
+	return out, nil
+}
+
+func isExactEvalModelUUID(uuid string) bool {
+	return evalModelUUIDPattern.MatchString(uuid)
+}
+
+func buildEvalUnresolvedOutput(role, query, queryField string, matches []*EvalCatalogModel) *ModelEvalUnresolvedOutput {
+	candidates := make([]ModelEvalMatchCandidate, 0, len(matches))
+	for _, m := range matches {
+		candidates = append(candidates, evalModelToMatchCandidate(m))
+	}
+
+	var msg string
+	switch queryField {
+	case "uuid":
+		msg = fmt.Sprintf("no %s model with exact uuid %q; ask the user to provide the full uuid from the matches below — do not substitute a partial uuid", role, query)
+		if len(candidates) == 0 {
+			msg = fmt.Sprintf("no %s model with exact uuid %q and no models whose uuids contain that string", role, query)
+		}
+		if len(candidates) == 1 {
+			msg = fmt.Sprintf("partial %s uuid %q — one model matched (%s / display %q, api %q) but the run requires the exact full uuid; ask the user to confirm the complete uuid", role, query, candidates[0].UUID, candidates[0].DisplayName, candidates[0].APIName)
+		}
+	default:
+		msg = fmt.Sprintf("no %s model with exact name %q; ask the user to choose display_name or api_name from the matches below — do not substitute from this list", role, query)
+		if len(candidates) == 0 {
+			msg = fmt.Sprintf("no %s model with exact name %q and no models whose display or api names contain that string", role, query)
+		}
+		if len(candidates) == 1 {
+			msg = fmt.Sprintf("no %s model with exact name %q; one similar model exists (display %q, api %q) — ask the user to confirm before proceeding", role, query, candidates[0].DisplayName, candidates[0].APIName)
+		}
+	}
+
+	return &ModelEvalUnresolvedOutput{
+		Message:                 msg,
+		Role:                    role,
+		Query:                   query,
+		QueryField:              queryField,
+		Matches:                 candidates,
+		RequiresExactMatch:      true,
+		DoNotSubstituteFromList: true,
+	}
+}
+
+func buildModelEvalModelsResolveOutput(candidate, judge *ModelEvalUnresolvedOutput) *ModelEvalModelsResolveOutput {
+	msg := "resolve candidate and judge models before creating the evaluation run"
+	switch {
+	case candidate != nil && judge != nil:
+		msg = "candidate and judge model names or uuids are not exact matches; ask the user to pick exact identifiers from the match lists"
+	case candidate != nil:
+		msg = "candidate model name or uuid is not an exact match; ask the user to pick the exact candidate from the match list"
+	case judge != nil:
+		msg = "judge model name or uuid is not an exact match; ask the user to pick the exact judge from the match list"
+	}
+	return &ModelEvalModelsResolveOutput{
+		Status:                modelEvalModelSelectionStatus,
+		Message:               msg,
+		Candidate:             candidate,
+		Judge:                 judge,
+		StopAndAskUser:        true,
+		DoNotRetryUntilUserOK: true,
+	}
+}
+
+func marshalModelEvalResolveResult(v any) (string, error) {
+	jsonData, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal error: %w", err)
+	}
+	return string(jsonData), nil
+}
+
+func modelEvalUserActionResult(v any) (*mcp.CallToolResult, error) {
+	text, err := marshalModelEvalResolveResult(v)
+	if err != nil {
+		return nil, err
+	}
+	return mcp.NewToolResultText(text), nil
+}

--- a/pkg/registry/genai/model_evaluation_resolve_test.go
+++ b/pkg/registry/genai/model_evaluation_resolve_test.go
@@ -1,0 +1,94 @@
+package genai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEvalModelByName(t *testing.T) {
+	models := []*EvalCatalogModel{
+		{UUID: "uuid-1", DisplayName: "DeepSeek R1 Distill Llama 70B", APIName: "deepseek-r1-distill-llama-70b", Source: "catalog"},
+		{UUID: "uuid-2", DisplayName: "OpenAI GPT-4o", APIName: "openai-gpt-4o", Source: "catalog"},
+	}
+
+	resolved, unresolved, err := resolveEvalModelByName(context.Background(), nil, "candidate", "DeepSeek R1 Distill Llama 70B", models)
+	require.NoError(t, err)
+	require.Nil(t, unresolved)
+	require.Equal(t, "deepseek-r1-distill-llama-70b", resolved.APIName)
+}
+
+func TestCatalogModelNames(t *testing.T) {
+	api, display := catalogModelNames(&godo.Model{
+		Name:          "DeepSeek R1 Distill Llama 70B",
+		InferenceName: "deepseek-r1-distill-llama-70b",
+	})
+	require.Equal(t, "deepseek-r1-distill-llama-70b", api)
+	require.Equal(t, "DeepSeek R1 Distill Llama 70B", display)
+}
+
+func TestIsModelEvalUserMessageYes(t *testing.T) {
+	require.True(t, isModelEvalUserMessageYes("yes"))
+	require.True(t, isModelEvalUserMessageYes(" YES "))
+	require.False(t, isModelEvalUserMessageYes(""))
+	require.False(t, isModelEvalUserMessageYes("no"))
+}
+
+func TestBuildModelEvalConsentPreview(t *testing.T) {
+	resolved := &modelEvalRunModels{
+		Candidate: modelEvalResolvedModel{
+			UUID: "c-uuid", DisplayName: "Candidate", APIName: "candidate-slug", Source: "catalog",
+		},
+		Judge: &modelEvalResolvedModel{
+			UUID: "j-uuid", DisplayName: "Judge", APIName: "judge-slug", Source: "catalog",
+		},
+	}
+	cfg := &modelEvalRunConfig{
+		RunName:     "my-run",
+		DatasetUUID: "ds-uuid",
+		MetricUUIDs: []string{"m1"},
+	}
+	preview := buildModelEvalConsentPreview(resolved, cfg)
+	require.Equal(t, modelEvalConsentStatus, preview.Status)
+	require.True(t, preview.StopAndAskUser)
+	require.Contains(t, preview.PromptForUser, "reply **yes**")
+	require.Contains(t, preview.InstructionForAgent, "user_message")
+	require.Equal(t, "candidate-slug", preview.CandidateModel.APIName)
+	require.NotNil(t, preview.JudgeModel)
+}
+
+func TestValidateModelEvalResolvedUUIDs(t *testing.T) {
+	resolved := &modelEvalRunModels{
+		Candidate: modelEvalResolvedModel{UUID: "c-uuid", APIName: "c"},
+		Judge:     &modelEvalResolvedModel{UUID: "j-uuid", APIName: "j"},
+	}
+	require.NoError(t, validateModelEvalResolvedUUIDs(resolved, true))
+
+	require.Error(t, validateModelEvalResolvedUUIDs(&modelEvalRunModels{
+		Candidate: modelEvalResolvedModel{UUID: ""},
+		Judge:     &modelEvalResolvedModel{UUID: "j"},
+	}, true))
+}
+
+func TestCheckModelEvalUserMessage(t *testing.T) {
+	resolved := &modelEvalRunModels{
+		Candidate: modelEvalResolvedModel{UUID: "c", APIName: "c-slug", DisplayName: "C"},
+	}
+	cfg := &modelEvalRunConfig{RunName: "run"}
+
+	result, ok := checkModelEvalUserMessage(map[string]any{"user_message": "yes"}, resolved, cfg)
+	require.True(t, ok)
+	require.Nil(t, result)
+
+	result, ok = checkModelEvalUserMessage(map[string]any{}, resolved, cfg)
+	require.False(t, ok)
+	require.NotNil(t, result)
+	require.False(t, result.IsError)
+	require.True(t, buildModelEvalConsentPreview(resolved, cfg).RequireUserMessageFromChat)
+
+	result, ok = checkModelEvalUserMessage(map[string]any{"user_message": "no"}, resolved, cfg)
+	require.False(t, ok)
+	require.True(t, result.IsError)
+}

--- a/pkg/registry/genai/model_evaluation_tools.go
+++ b/pkg/registry/genai/model_evaluation_tools.go
@@ -134,7 +134,7 @@ func (met *ModelEvaluationTool) getPreset(ctx context.Context, req mcp.CallToolR
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
-// createDataset uploads a CSV to Spaces and registers it as a model evaluation dataset.
+// createDataset uploads a CSV or JSONL file to Spaces and registers it as a model evaluation dataset.
 func (met *ModelEvaluationTool) createDataset(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
@@ -729,9 +729,9 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.createDataset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-create-dataset",
-				mcp.WithDescription("Upload and register a model evaluation dataset (presign → Spaces upload → database record). CSV must include an 'input' column; 'ground_truth' is optional. Returns evaluation_dataset_uuid for use with genai-model-eval-create-run."),
+				mcp.WithDescription("Upload and register a model evaluation dataset (presign → Spaces upload → database record). Accepts .csv (with 'input' column) or .jsonl (one JSON object per line with 'input' field); 'ground_truth' is optional. Returns evaluation_dataset_uuid for use with genai-model-eval-create-run."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the dataset")),
-				mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the CSV file to upload")),
+				mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the .csv or .jsonl dataset file to upload")),
 			),
 		},
 		{
@@ -790,7 +790,7 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-model-eval-run-workflow",
 				mcp.WithDescription(genaiModelEvalWorkflowToolDescription),
-				mcp.WithString("dataset_file_path", mcp.Required(), mcp.Description("Path to the CSV evaluation dataset")),
+				mcp.WithString("dataset_file_path", mcp.Required(), mcp.Description("Path to the .csv or .jsonl evaluation dataset")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the evaluation run")),
 				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Exact candidate model name. Partial names return nearest matches only.")),
 				mcp.WithString("candidate_model_uuid", mcp.Description("Exact full candidate model UUID. Optional if name is exact.")),

--- a/pkg/registry/genai/model_evaluation_tools.go
+++ b/pkg/registry/genai/model_evaluation_tools.go
@@ -1,14 +1,12 @@
 package genai
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -136,7 +134,7 @@ func (met *ModelEvaluationTool) getPreset(ctx context.Context, req mcp.CallToolR
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
-// createDataset uploads a CSV file and returns presigned URL info for model evaluation.
+// createDataset uploads a CSV to Spaces and registers it as a model evaluation dataset.
 func (met *ModelEvaluationTool) createDataset(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
@@ -150,8 +148,8 @@ func (met *ModelEvaluationTool) createDataset(ctx context.Context, req mcp.CallT
 		return mcp.NewToolResultError("file_path is required"), nil
 	}
 
-	if !isCSVFile(filePath) {
-		return mcp.NewToolResultError("file must have .csv extension"), nil
+	if err := validateModelEvaluationDataset(filePath); err != nil {
+		return mcp.NewToolResultErrorFromErr("dataset validation failed", err), nil
 	}
 
 	fileData, err := os.ReadFile(filePath)
@@ -164,68 +162,12 @@ func (met *ModelEvaluationTool) createDataset(ctx context.Context, req mcp.CallT
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
-	fileSize := int64(len(fileData))
-	fileName := getFileName(filePath)
-
-	presignedInput := &ModelEvalDatasetPresignedUrlsInput{
-		Files: []PresignedUrlFile{
-			{
-				FileName: fileName,
-				FileSize: fileSize,
-			},
-		},
-	}
-
-	presignedReq, err := newGodoRequestWithContext(ctx, client, "POST", modelEvalAPIPath+"/datasets/file_upload_presigned_urls", presignedInput)
+	result, err := uploadAndRegisterModelEvaluationDataset(ctx, client, name, fileData, getFileName(filePath))
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create presigned URL request", err), nil
+		return mcp.NewToolResultErrorFromErr("failed to create model evaluation dataset", err), nil
 	}
 
-	var presignedOutput ModelEvalDatasetPresignedUrlsOutput
-	resp, err := client.Do(ctx, presignedReq, &presignedOutput)
-	if err != nil || resp.StatusCode >= 400 {
-		return mcp.NewToolResultErrorFromErr("failed to create presigned URL", err), nil
-	}
-
-	if len(presignedOutput.Uploads) == 0 {
-		return mcp.NewToolResultError("no presigned URL returned"), nil
-	}
-
-	upload := presignedOutput.Uploads[0]
-
-	uploadReq, err := http.NewRequestWithContext(ctx, "PUT", upload.PresignedURL, bytes.NewReader(fileData))
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to create upload request", err), nil
-	}
-	uploadReq.ContentLength = fileSize
-	uploadReq.Header.Set("Content-Type", "text/csv")
-
-	httpResp, err := presignedUploadHTTPClient.Do(uploadReq)
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("failed to upload file", err), nil
-	}
-	defer httpResp.Body.Close()
-
-	if httpResp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(httpResp.Body)
-		return mcp.NewToolResultError(fmt.Sprintf("file upload failed with status %d: %s", httpResp.StatusCode, string(bodyBytes))), nil
-	}
-
-	type DatasetUploadResponse struct {
-		ObjectKey string `json:"object_key"`
-		Name      string `json:"name"`
-		FileName  string `json:"file_name"`
-		FileSize  int64  `json:"file_size"`
-	}
-
-	response := DatasetUploadResponse{
-		ObjectKey: upload.ObjectKey,
-		Name:      name,
-		FileName:  fileName,
-		FileSize:  fileSize,
-	}
-
-	jsonData, err := json.MarshalIndent(response, "", "  ")
+	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal error: %w", err)
 	}
@@ -233,31 +175,93 @@ func (met *ModelEvaluationTool) createDataset(ctx context.Context, req mcp.CallT
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
+// resolveEvalModelsOnly resolves candidate and judge models before chat-based user consent.
+func (met *ModelEvaluationTool) resolveEvalModelsOnly(
+	ctx context.Context,
+	args map[string]any,
+	requireJudge bool,
+) (*modelEvalRunModels, *mcp.CallToolResult, error) {
+	candidateModelName := strings.TrimSpace(stringArg(args, "candidate_model_name"))
+	if candidateModelName == "" {
+		return nil, mcp.NewToolResultError(modelEvalCandidateNameRequiredMsg), nil
+	}
+
+	client, err := met.client(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	models, err := listAllEvalModels(ctx, client)
+	if err != nil {
+		return nil, mcp.NewToolResultErrorFromErr("failed to list models for evaluation run resolution", err), nil
+	}
+
+	resolved, unresolved, err := resolveEvalModelsForRun(
+		ctx,
+		client,
+		strings.TrimSpace(stringArg(args, "candidate_model_uuid")),
+		candidateModelName,
+		strings.TrimSpace(stringArg(args, "judge_model_uuid")),
+		strings.TrimSpace(stringArg(args, "judge_model_name")),
+		requireJudge,
+		models,
+	)
+	if err != nil {
+		return nil, mcp.NewToolResultError(err.Error()), nil
+	}
+	if unresolved != nil {
+		result, err := modelEvalUserActionResult(unresolved)
+		return nil, result, err
+	}
+
+	hydrated, err := hydrateResolvedEvalModelsFromAPI(ctx, client, resolved)
+	if err != nil {
+		return nil, mcp.NewToolResultErrorFromErr("failed to fetch catalog UUIDs for candidate/judge models", err), nil
+	}
+	if err := validateModelEvalResolvedUUIDs(hydrated, requireJudge); err != nil {
+		return nil, mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return hydrated, nil, nil
+}
+
 // createRun creates a new model evaluation run.
 func (met *ModelEvaluationTool) createRun(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 
 	name, _ := args["name"].(string)
-	candidateModelUUID, _ := args["candidate_model_uuid"].(string)
-	candidateModelName, _ := args["candidate_model_name"].(string)
-
 	if name == "" {
 		return mcp.NewToolResultError("name is required"), nil
 	}
-	if candidateModelUUID == "" {
-		return mcp.NewToolResultError("candidate_model_uuid is required"), nil
+	presetUUID, _ := args["eval_preset_uuid"].(string)
+	requireJudge := presetUUID == ""
+
+	runCfg, err := parseModelEvalRunConfig(args, requireJudge)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
 	}
-	if candidateModelName == "" {
-		return mcp.NewToolResultError("candidate_model_name is required"), nil
+
+	resolved, selectionResult, err := met.resolveEvalModelsOnly(ctx, args, requireJudge)
+	if selectionResult != nil || err != nil {
+		return selectionResult, err
+	}
+
+	if consentResult, ok := checkModelEvalUserMessage(args, resolved, runCfg); !ok {
+		return consentResult, nil
+	}
+
+	client, err := met.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
 	input := &CreateModelEvalRunInput{
 		Name:               name,
-		CandidateModelUUID: candidateModelUUID,
-		CandidateModelName: candidateModelName,
+		CandidateModelUUID: resolved.Candidate.UUID,
+		CandidateModelName: resolved.Candidate.APIName,
 	}
 
-	if presetUUID, ok := args["eval_preset_uuid"].(string); ok && presetUUID != "" {
+	if presetUUID != "" {
 		input.EvalPresetUUID = &presetUUID
 	}
 
@@ -265,8 +269,8 @@ func (met *ModelEvaluationTool) createRun(ctx context.Context, req mcp.CallToolR
 		input.DatasetUUID = datasetUUID
 	}
 
-	if judgeModelUUID, ok := args["judge_model_uuid"].(string); ok && judgeModelUUID != "" {
-		input.JudgeModelUUID = judgeModelUUID
+	if resolved.Judge != nil {
+		input.JudgeModelUUID = resolved.Judge.UUID
 	}
 
 	if metricUUIDsRaw, ok := args["metric_uuids"].([]interface{}); ok {
@@ -308,11 +312,6 @@ func (met *ModelEvaluationTool) createRun(ctx context.Context, req mcp.CallToolR
 			config.TopP = &topP
 		}
 		input.CandidateInferenceConfig = config
-	}
-
-	client, err := met.client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
 	}
 
 	apiReq, err := newGodoRequestWithContext(ctx, client, "POST", modelEvalRunsAPIPath, input)
@@ -497,12 +496,15 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 
 	datasetFilePath, _ := args["dataset_file_path"].(string)
 	runName, _ := args["name"].(string)
-	candidateModelUUID, _ := args["candidate_model_uuid"].(string)
-	candidateModelName, _ := args["candidate_model_name"].(string)
-	judgeModelUUID, _ := args["judge_model_uuid"].(string)
 
-	if datasetFilePath == "" || runName == "" || candidateModelUUID == "" || candidateModelName == "" || judgeModelUUID == "" {
-		return mcp.NewToolResultError("dataset_file_path, name, candidate_model_uuid, candidate_model_name, and judge_model_uuid are required"), nil
+	if datasetFilePath == "" || runName == "" {
+		return mcp.NewToolResultError("dataset_file_path and name are required"), nil
+	}
+	if strings.TrimSpace(stringArg(args, "candidate_model_name")) == "" {
+		return mcp.NewToolResultError(modelEvalCandidateNameRequiredMsg), nil
+	}
+	if strings.TrimSpace(stringArg(args, "judge_model_name")) == "" {
+		return mcp.NewToolResultError(modelEvalJudgeNameRequiredMsg), nil
 	}
 
 	timeoutSec := int64(300)
@@ -524,6 +526,25 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 		}
 	}
 
+	resolved, selectionResult, err := met.resolveEvalModelsOnly(ctx, args, true)
+	if selectionResult != nil || err != nil {
+		return selectionResult, err
+	}
+
+	workflowCfg := &modelEvalRunConfig{
+		RunName:         runName,
+		DatasetFilePath: datasetFilePath,
+		MetricUUIDs:     append([]string(nil), metricUUIDs...),
+		StarMetric:      parseStarMetricArg(args),
+	}
+	if workflowCfg.StarMetric == nil && len(metricUUIDs) > 0 {
+		workflowCfg.StarMetric = defaultStarMetric(metricUUIDs)
+	}
+
+	if consentResult, ok := checkModelEvalUserMessage(args, resolved, workflowCfg); !ok {
+		return consentResult, nil
+	}
+
 	client, err := met.client(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
@@ -531,9 +552,8 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 
 	startTime := time.Now()
 
-	// Step 1: Validate dataset
-	if !isCSVFile(datasetFilePath) {
-		return mcp.NewToolResultError("step 1: file must have .csv extension"), nil
+	if err := validateModelEvaluationDataset(datasetFilePath); err != nil {
+		return mcp.NewToolResultErrorFromErr("step 1: dataset validation failed", err), nil
 	}
 
 	fileData, err := os.ReadFile(datasetFilePath)
@@ -541,65 +561,26 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 		return mcp.NewToolResultErrorFromErr("step 1: failed to read dataset file", err), nil
 	}
 
-	fileSize := int64(len(fileData))
 	fileName := getFileName(datasetFilePath)
+	datasetName := runName + "-dataset"
 
-	// Step 2: Get presigned URL and upload dataset
-	presignedInput := &ModelEvalDatasetPresignedUrlsInput{
-		Files: []PresignedUrlFile{
-			{
-				FileName: fileName,
-				FileSize: fileSize,
-			},
-		},
-	}
-
-	presignedReq, err := newGodoRequestWithContext(ctx, client, "POST", modelEvalAPIPath+"/datasets/file_upload_presigned_urls", presignedInput)
+	// Steps 2–4: presign, upload to Spaces, register dataset record.
+	datasetResult, err := uploadAndRegisterModelEvaluationDataset(ctx, client, datasetName, fileData, fileName)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("step 2: failed to create presigned URL request", err), nil
+		return mcp.NewToolResultErrorFromErr("step 2: failed to upload and register dataset", err), nil
 	}
 
-	var presignedOutput ModelEvalDatasetPresignedUrlsOutput
-	resp, err := client.Do(ctx, presignedReq, &presignedOutput)
-	if err != nil || resp.StatusCode >= 400 {
-		return mcp.NewToolResultErrorFromErr("step 2: failed to create presigned URL", err), nil
-	}
-
-	if len(presignedOutput.Uploads) == 0 {
-		return mcp.NewToolResultError("step 2: no presigned URL returned"), nil
-	}
-
-	upload := presignedOutput.Uploads[0]
-
-	uploadReq, err := http.NewRequestWithContext(ctx, "PUT", upload.PresignedURL, bytes.NewReader(fileData))
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("step 2: failed to create upload request", err), nil
-	}
-	uploadReq.ContentLength = fileSize
-	uploadReq.Header.Set("Content-Type", "text/csv")
-
-	httpResp, err := presignedUploadHTTPClient.Do(uploadReq)
-	if err != nil {
-		return mcp.NewToolResultErrorFromErr("step 2: failed to upload file", err), nil
-	}
-	defer httpResp.Body.Close()
-
-	if httpResp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(httpResp.Body)
-		return mcp.NewToolResultError(fmt.Sprintf("step 2: file upload failed with status %d: %s", httpResp.StatusCode, string(bodyBytes))), nil
-	}
-
-	// Step 3: List metrics if none provided
+	// Step 5: List metrics if none provided
 	if len(metricUUIDs) == 0 {
 		metricsReq, err := newGodoRequestWithContext(ctx, client, "GET", modelEvalMetricsAPIPath, nil)
 		if err != nil {
-			return mcp.NewToolResultErrorFromErr("step 3: failed to create request", err), nil
+			return mcp.NewToolResultErrorFromErr("step 5: failed to create request", err), nil
 		}
 
 		var metricsOutput ListModelEvaluationMetricsOutput
-		resp, err = client.Do(ctx, metricsReq, &metricsOutput)
+		resp, err := client.Do(ctx, metricsReq, &metricsOutput)
 		if err != nil || resp.StatusCode >= 400 {
-			return mcp.NewToolResultErrorFromErr("step 3: failed to list metrics", err), nil
+			return mcp.NewToolResultErrorFromErr("step 5: failed to list metrics", err), nil
 		}
 
 		for _, m := range metricsOutput.Metrics {
@@ -607,13 +588,13 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 		}
 	}
 
-	// Step 4: Create evaluation run
+	// Step 6: Create evaluation run
 	runInput := &CreateModelEvalRunInput{
 		Name:               runName,
-		CandidateModelUUID: candidateModelUUID,
-		CandidateModelName: candidateModelName,
-		DatasetUUID:        upload.ObjectKey,
-		JudgeModelUUID:     judgeModelUUID,
+		CandidateModelUUID: resolved.Candidate.UUID,
+		CandidateModelName: resolved.Candidate.APIName,
+		DatasetUUID:        datasetResult.EvaluationDatasetUUID,
+		JudgeModelUUID:     resolved.Judge.UUID,
 		MetricUUIDs:        metricUUIDs,
 		StarMetric:         defaultStarMetric(metricUUIDs),
 		Source:             "mcp",
@@ -636,18 +617,18 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 
 	runReq, err := newGodoRequestWithContext(ctx, client, "POST", modelEvalRunsAPIPath, runInput)
 	if err != nil {
-		return mcp.NewToolResultErrorFromErr("step 4: failed to create request", err), nil
+		return mcp.NewToolResultErrorFromErr("step 6: failed to create request", err), nil
 	}
 
 	var runOutput CreateModelEvalRunOutput
-	resp, err = client.Do(ctx, runReq, &runOutput)
+	resp, err := client.Do(ctx, runReq, &runOutput)
 	if err != nil || resp.StatusCode >= 400 {
-		return mcp.NewToolResultErrorFromErr("step 4: failed to create model evaluation run", err), nil
+		return mcp.NewToolResultErrorFromErr("step 6: failed to create model evaluation run", err), nil
 	}
 
 	evalRunUUID := runOutput.EvalRunUUID
 
-	// Step 5: Poll for completion
+	// Step 7: Poll for completion
 	timeout := time.Duration(timeoutSec) * time.Second
 	pollInterval := time.Duration(pollIntervalSec) * time.Second
 	deadline := time.Now().Add(timeout)
@@ -655,23 +636,23 @@ func (met *ModelEvaluationTool) runWorkflow(ctx context.Context, req mcp.CallToo
 	var finalRun *ModelEvaluationRunDetail
 	for {
 		if time.Now().After(deadline) {
-			return mcp.NewToolResultError("step 5: evaluation polling timed out"), nil
+			return mcp.NewToolResultError("step 7: evaluation polling timed out"), nil
 		}
 
 		getReq, err := newGodoRequestWithContext(ctx, client, "GET", modelEvalRunsAPIPath+"/"+evalRunUUID, nil)
 		if err != nil {
-			return mcp.NewToolResultErrorFromErr("step 5: failed to create request", err), nil
+			return mcp.NewToolResultErrorFromErr("step 7: failed to create request", err), nil
 		}
 
 		var output GetModelEvaluationRunOutput
 		resp, err = client.Do(ctx, getReq, &output)
 		if err != nil || resp.StatusCode >= 400 {
-			return mcp.NewToolResultErrorFromErr("step 5: failed to poll evaluation run", err), nil
+			return mcp.NewToolResultErrorFromErr("step 7: failed to poll evaluation run", err), nil
 		}
 
 		finalRun = output.Run
 		if finalRun == nil {
-			return mcp.NewToolResultError("step 5: evaluation run missing from API response"), nil
+			return mcp.NewToolResultError("step 7: evaluation run missing from API response"), nil
 		}
 
 		if isModelEvalTerminalStatus(finalRun.Status) {
@@ -748,7 +729,7 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.createDataset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-create-dataset",
-				mcp.WithDescription("Upload a CSV file as a model evaluation dataset. Returns the uploaded object key for use when creating evaluation runs."),
+				mcp.WithDescription("Upload and register a model evaluation dataset (presign → Spaces upload → database record). CSV must include an 'input' column; 'ground_truth' is optional. Returns evaluation_dataset_uuid for use with genai-model-eval-create-run."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the dataset")),
 				mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the CSV file to upload")),
 			),
@@ -757,13 +738,14 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.createRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-create-run",
-				mcp.WithDescription("Create a model evaluation run. Provide either an eval_preset_uuid to use a preset, or provide dataset_uuid, judge_model_uuid, and metric_uuids for inline configuration."),
+				mcp.WithDescription(genaiModelEvalCreateRunToolDescription),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for this evaluation run")),
-				mcp.WithString("candidate_model_uuid", mcp.Required(), mcp.Description("UUID of the candidate model to evaluate")),
-				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Display name of the candidate model")),
+				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Exact candidate model name the user provided or confirmed (character-for-character, whitespace trimmed). Partial names return nearest matches only.")),
+				mcp.WithString("candidate_model_uuid", mcp.Description("Exact full candidate model UUID (8-4-4-4-12 hex). Optional if name is exact; partial uuids return matches only.")),
 				mcp.WithString("eval_preset_uuid", mcp.Description("UUID of a preset to use (optional; if provided, dataset/judge/metrics come from the preset)")),
-				mcp.WithString("dataset_uuid", mcp.Description("UUID of the evaluation dataset (required if not using a preset)")),
-				mcp.WithString("judge_model_uuid", mcp.Description("UUID of the judge model that scores responses (required if not using a preset)")),
+				mcp.WithString("dataset_uuid", mcp.Description("evaluation_dataset_uuid from genai-model-eval-create-dataset (required if not using a preset)")),
+				mcp.WithString("judge_model_name", mcp.Description("Exact judge model name (required for inline configuration without a preset). Partial names return nearest matches only.")),
+				mcp.WithString("judge_model_uuid", mcp.Description("Exact full judge model UUID. Optional if judge_model_name is exact; partial uuids return matches only.")),
 				mcp.WithObject("metric_uuids", mcp.Description("Array of metric UUIDs to evaluate (required if not using a preset)")),
 				mcp.WithObject("star_metric", mcp.Description("Primary success metric: metric_uuid and optional success_threshold_pct")),
 				mcp.WithObject("candidate_inference_config", mcp.Description("Inference parameters: max_tokens (int), temperature (float), top_p (float)")),
@@ -771,6 +753,7 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 				mcp.WithBoolean("save_as_preset", mcp.Description("Whether to save this configuration as a new preset")),
 				mcp.WithString("preset_name", mcp.Description("Name for the new preset (required if save_as_preset is true)")),
 				mcp.WithString("candidate_model_source", mcp.Description("Source of the candidate model")),
+				mcp.WithString("user_message", mcp.Description(genaiModelEvalUserMessageDescription)),
 			),
 		},
 		{
@@ -806,16 +789,18 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.runWorkflow,
 			Tool: mcp.NewTool(
 				"genai-model-eval-run-workflow",
-				mcp.WithDescription("Run a complete model evaluation workflow: upload dataset, create evaluation run, and poll for results. This is a convenience tool that handles all steps automatically."),
+				mcp.WithDescription(genaiModelEvalWorkflowToolDescription),
 				mcp.WithString("dataset_file_path", mcp.Required(), mcp.Description("Path to the CSV evaluation dataset")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the evaluation run")),
-				mcp.WithString("candidate_model_uuid", mcp.Required(), mcp.Description("UUID of the candidate model to evaluate")),
-				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Display name of the candidate model")),
-				mcp.WithString("judge_model_uuid", mcp.Required(), mcp.Description("UUID of the judge model that scores responses")),
+				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Exact candidate model name. Partial names return nearest matches only.")),
+				mcp.WithString("candidate_model_uuid", mcp.Description("Exact full candidate model UUID. Optional if name is exact.")),
+				mcp.WithString("judge_model_name", mcp.Required(), mcp.Description("Exact judge model name. Partial names return nearest matches only.")),
+				mcp.WithString("judge_model_uuid", mcp.Description("Exact full judge model UUID. Optional if judge_model_name is exact.")),
 				mcp.WithObject("metric_uuids", mcp.Description("Array of metric UUIDs to evaluate (if empty, all available metrics are used)")),
 				mcp.WithObject("candidate_inference_config", mcp.Description("Inference parameters: max_tokens (int), temperature (float), top_p (float)")),
 				mcp.WithNumber("timeout_seconds", mcp.Description("Timeout for polling evaluation results in seconds (default: 300)")),
 				mcp.WithNumber("poll_interval_seconds", mcp.Description("Interval between status polls in seconds (default: 5)")),
+				mcp.WithString("user_message", mcp.Description(genaiModelEvalUserMessageDescription)),
 			),
 		},
 	}

--- a/pkg/registry/genai/model_evaluation_tools_test.go
+++ b/pkg/registry/genai/model_evaluation_tools_test.go
@@ -148,7 +148,6 @@ func TestModelEvaluationTool_createRun_validation(t *testing.T) {
 	}
 }
 
-
 func TestModelEvaluationTool_listRuns_clientError(t *testing.T) {
 	tool := setupModelEvalToolWithFailingClient()
 	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
@@ -227,11 +226,11 @@ func TestModelEvaluationTool_runWorkflow_validation(t *testing.T) {
 	}{
 		{name: "missing all required", args: map[string]any{}},
 		{name: "missing dataset_file_path", args: map[string]any{
-			"name": "run1",
+			"name":                 "run1",
 			"candidate_model_name": "model", "judge_model_name": "judge",
 		}},
 		{name: "missing name", args: map[string]any{
-			"dataset_file_path": "/tmp/test.csv",
+			"dataset_file_path":    "/tmp/test.csv",
 			"candidate_model_name": "model", "judge_model_name": "judge",
 		}},
 		{name: "missing candidate_model_name", args: map[string]any{

--- a/pkg/registry/genai/model_evaluation_tools_test.go
+++ b/pkg/registry/genai/model_evaluation_tools_test.go
@@ -126,16 +126,14 @@ func TestModelEvaluationTool_createRun_validation(t *testing.T) {
 		args map[string]any
 	}{
 		{name: "missing name", args: map[string]any{
-			"candidate_model_uuid": "uuid",
-			"candidate_model_name": "model",
-		}},
-		{name: "missing candidate_model_uuid", args: map[string]any{
-			"name":                 "run1",
 			"candidate_model_name": "model",
 		}},
 		{name: "missing candidate_model_name", args: map[string]any{
+			"name": "run1",
+		}},
+		{name: "empty candidate_model_name", args: map[string]any{
 			"name":                 "run1",
-			"candidate_model_uuid": "uuid",
+			"candidate_model_name": "",
 		}},
 	}
 
@@ -150,16 +148,6 @@ func TestModelEvaluationTool_createRun_validation(t *testing.T) {
 	}
 }
 
-func TestModelEvaluationTool_createRun_clientError(t *testing.T) {
-	tool := setupModelEvalToolWithFailingClient()
-	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
-		"name":                 "run1",
-		"candidate_model_uuid": "uuid",
-		"candidate_model_name": "model",
-	}}}
-	_, err := tool.createRun(context.Background(), req)
-	require.Error(t, err)
-}
 
 func TestModelEvaluationTool_listRuns_clientError(t *testing.T) {
 	tool := setupModelEvalToolWithFailingClient()
@@ -239,20 +227,16 @@ func TestModelEvaluationTool_runWorkflow_validation(t *testing.T) {
 	}{
 		{name: "missing all required", args: map[string]any{}},
 		{name: "missing dataset_file_path", args: map[string]any{
-			"name": "run1", "candidate_model_uuid": "uuid",
-			"candidate_model_name": "model", "judge_model_uuid": "judge",
+			"name": "run1",
+			"candidate_model_name": "model", "judge_model_name": "judge",
 		}},
 		{name: "missing name", args: map[string]any{
-			"dataset_file_path": "/tmp/test.csv", "candidate_model_uuid": "uuid",
-			"candidate_model_name": "model", "judge_model_uuid": "judge",
+			"dataset_file_path": "/tmp/test.csv",
+			"candidate_model_name": "model", "judge_model_name": "judge",
 		}},
-		{name: "missing candidate_model_uuid", args: map[string]any{
+		{name: "missing candidate_model_name", args: map[string]any{
 			"dataset_file_path": "/tmp/test.csv", "name": "run1",
-			"candidate_model_name": "model", "judge_model_uuid": "judge",
-		}},
-		{name: "missing judge_model_uuid", args: map[string]any{
-			"dataset_file_path": "/tmp/test.csv", "name": "run1",
-			"candidate_model_uuid": "uuid", "candidate_model_name": "model",
+			"judge_model_name": "judge",
 		}},
 	}
 

--- a/pkg/registry/genai/model_evaluation_tools_test.go
+++ b/pkg/registry/genai/model_evaluation_tools_test.go
@@ -104,7 +104,7 @@ func TestModelEvaluationTool_createDataset_validation(t *testing.T) {
 		{name: "empty name", args: map[string]any{"name": "", "file_path": "/tmp/test.csv"}},
 		{name: "missing file_path", args: map[string]any{"name": "test"}},
 		{name: "empty file_path", args: map[string]any{"name": "test", "file_path": ""}},
-		{name: "non-csv file", args: map[string]any{"name": "test", "file_path": "/tmp/test.json"}},
+		{name: "unsupported file format", args: map[string]any{"name": "test", "file_path": "/tmp/test.json"}},
 	}
 
 	for _, tc := range tests {

--- a/pkg/registry/genai/models.go
+++ b/pkg/registry/genai/models.go
@@ -105,9 +105,15 @@ type FileUploadDataSource struct {
 	SizeInBytes      int64  `json:"size_in_bytes"`
 }
 
+// Evaluation dataset types for POST /evaluation_datasets.
+const (
+	EvaluationDatasetTypeModel = "EVALUATION_DATASET_TYPE_MODEL"
+)
+
 // CreateEvaluationDatasetInput input for creating a dataset
 type CreateEvaluationDatasetInput struct {
 	Name                 string               `json:"name"`
+	DatasetType          string               `json:"dataset_type,omitempty"`
 	FileUploadDataSource FileUploadDataSource `json:"file_upload_dataset"`
 }
 

--- a/testing/e2e_custom_models_test.go
+++ b/testing/e2e_custom_models_test.go
@@ -16,76 +16,69 @@ import (
 const e2eHFRepoID = "Qwen/Qwen2.5-0.5B"
 
 // TestCustomModelsListModels calls genai-custom-models-list against the live GenAI API.
+// Unfiltered list returns one custom-models table with every UUID (including STATUS_FAILED).
 func TestCustomModelsListModels(t *testing.T) {
 	t.Parallel()
 
-	type customModel struct {
-		UUID   string `json:"uuid"`
-		Name   string `json:"name"`
-		Status string `json:"status"`
-	}
-	type listResponse struct {
-		Models       []customModel `json:"models"`
-		Count        int           `json:"count"`
-		MaxThreshold int           `json:"max_threshold"`
-	}
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "genai-custom-models-list", Arguments: map[string]any{}},
+	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
 
-	out := callTool[listResponse](t, "genai-custom-models-list", map[string]any{})
-
-	require.GreaterOrEqual(t, out.Count, 0)
-	require.Len(t, out.Models, out.Count)
-	t.Logf("listed %d custom model(s)", out.Count)
+	text := callToolResultText(resp)
+	require.Contains(t, text, "## Custom Models")
+	require.Contains(t, text, "| UUID | Name | Source | Status | Architecture |")
+	require.Contains(t, text, "STATUS_FAILED")
+	require.NotContains(t, text, "## Model Catalog")
+	require.Greater(t, strings.Count(text, "STATUS_FAILED"), 1, "failed models should appear as table rows, not only in a summary")
+	t.Logf("unfiltered custom list returned table (%d bytes)", len(text))
 }
 
 // TestCustomModelsListModelsWithPagination tests pagination on custom models list.
 func TestCustomModelsListModelsWithPagination(t *testing.T) {
 	t.Parallel()
 
-	type customModel struct {
-		UUID   string `json:"uuid"`
-		Name   string `json:"name"`
-		Status string `json:"status"`
-	}
-	type listResponse struct {
-		Models []customModel `json:"models"`
-		Count  int           `json:"count"`
-	}
-
-	out := callTool[listResponse](t, "genai-custom-models-list", map[string]any{
-		"page":     float64(1),
-		"per_page": float64(5),
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "genai-custom-models-list",
+			Arguments: map[string]any{
+				"page":     float64(1),
+				"per_page": float64(5),
+			},
+		},
 	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
 
-	require.GreaterOrEqual(t, out.Count, 0)
-	require.LessOrEqual(t, out.Count, 5, "per_page=5 should return at most 5 models")
-	require.Len(t, out.Models, out.Count)
-	t.Logf("listed %d custom model(s) with pagination", out.Count)
+	text := callToolResultText(resp)
+	require.Contains(t, text, "## Custom Models")
+	require.Contains(t, text, "| UUID | Name | Source | Status | Architecture |")
+	require.NotContains(t, text, "## Model Catalog")
+	t.Logf("paginated list returned custom table (%d bytes)", len(text))
 }
 
 // TestCustomModelsListModelsWithStatusFilter tests status filtering on custom models list.
 func TestCustomModelsListModelsWithStatusFilter(t *testing.T) {
 	t.Parallel()
 
-	type customModel struct {
-		UUID   string `json:"uuid"`
-		Name   string `json:"name"`
-		Status string `json:"status"`
-	}
-	type listResponse struct {
-		Models []customModel `json:"models"`
-		Count  int           `json:"count"`
-	}
-
-	out := callTool[listResponse](t, "genai-custom-models-list", map[string]any{
-		"status": "STATUS_READY",
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-custom-models-list",
+			Arguments: map[string]any{"status": "STATUS_READY"},
+		},
 	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
 
-	require.GreaterOrEqual(t, out.Count, 0)
-	require.Len(t, out.Models, out.Count)
-	for _, m := range out.Models {
-		require.Equal(t, "STATUS_READY", m.Status, "all models should have STATUS_READY")
-	}
-	t.Logf("listed %d custom model(s) with STATUS_READY filter", out.Count)
+	text := callToolResultText(resp)
+	require.Contains(t, text, "## Custom Models")
+	require.Contains(t, text, "STATUS_READY")
+	require.NotContains(t, text, "## Model Catalog")
+	t.Logf("status-filtered list returned custom table (%d bytes)", len(text))
 }
 
 // TestCustomModelsImportHuggingFaceResolvesCommitSHA imports without commit_sha and


### PR DESCRIPTION
## Summary

- Register evaluation datasets end-to-end (presign → Spaces upload → API registration) and return `evaluation_dataset_uuid` from `genai-model-eval-create-dataset`.
- Add model resolution for create-run and workflow tools: resolve candidate/judge by display or API name, optional UUIDs, preset support, and match hints when names are partial.
- Require two-step chat user consent before starting evaluation runs or workflows; document updated tool arguments in the GenAI README.
- Restore optional `name` on `genai-custom-models-import` and validate import consent before Hugging Face `commit_sha` resolution (avoids Hub calls when consent is missing).

