### PR TITLE
feat(droplet): add ImageSlug support to droplet-create tool

### DIFF
--- a/pkg/registry/droplet/README.md
+++ b/pkg/registry/droplet/README.md
@@ -9,14 +9,17 @@ This directory contains tools for managing DigitalOcean Droplets, Images, and Si
 ### Droplet Tools
 
 - **droplet-create**  
-  Create a new Droplet.  
+  Create a new Droplet. Supports standard distribution images via `ImageID` and 1-click marketplace app images via `ImageSlug`. Exactly one of `ImageID` or `ImageSlug` must be provided.  
   **Arguments:**  
   - `Name` (string, required): Name of the Droplet  
   - `Size` (string, required): Slug of the Droplet size (e.g., `s-1vcpu-1gb`)  
-  - `ImageID` (number, required): ID of the image to use  
+  - `ImageID` (number, optional): Numeric ID of the image to use. Mutually exclusive with `ImageSlug`.  
+  - `ImageSlug` (string, optional): Slug of the image to use (e.g., `ubuntu-22-04-x64`, `wordpress-20-04`). Use this for 1-click marketplace app images; slugs can be discovered via the `1-click-list` tool. Mutually exclusive with `ImageID`.  
   - `Region` (string, required): Slug of the region (e.g., `nyc3`)  
   - `Backup` (boolean, optional, default: false): Enable backups  
-  - `Monitoring` (boolean, optional, default: false): Enable monitoring
+  - `Monitoring` (boolean, optional, default: false): Enable monitoring  
+  - `SSHKeys` (array of strings, optional): SSH key IDs (numbers) or fingerprints to add to the droplet  
+  - `Tags` (array of strings, optional): Tag names to apply to the droplet
 
 - **droplet-delete**  
   Delete a Droplet.  

--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -27,10 +27,29 @@ func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest
 	args := req.GetArguments()
 	dropletName := args["Name"].(string)
 	size := args["Size"].(string)
-	imageID := args["ImageID"].(float64)
 	region := args["Region"].(string)
 	backup, _ := args["Backup"].(bool)         // Defaults to false
 	monitoring, _ := args["Monitoring"].(bool) // Defaults to false
+
+	imageID, hasID := args["ImageID"].(float64)
+	imageSlug, hasSlug := args["ImageSlug"].(string)
+	if hasSlug {
+		hasSlug = imageSlug != ""
+	}
+
+	if !hasID && !hasSlug {
+		return mcp.NewToolResultError("exactly one of ImageID or ImageSlug must be provided"), nil
+	}
+	if hasID && hasSlug {
+		return mcp.NewToolResultError("exactly one of ImageID or ImageSlug must be provided, not both"), nil
+	}
+
+	var image godo.DropletCreateImage
+	if hasSlug {
+		image = godo.DropletCreateImage{Slug: imageSlug}
+	} else {
+		image = godo.DropletCreateImage{ID: int(imageID)}
+	}
 
 	// Handle SSH keys if provided
 	var sshKeys []godo.DropletCreateSSHKey
@@ -61,7 +80,7 @@ func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest
 	dropletCreateRequest := &godo.DropletCreateRequest{
 		Name:       dropletName,
 		Size:       size,
-		Image:      godo.DropletCreateImage{ID: int(imageID)},
+		Image:      image,
 		Region:     region,
 		Backups:    backup,
 		Monitoring: monitoring,
@@ -312,10 +331,11 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.createDroplet,
 			Tool: mcp.NewTool("droplet-create",
-				mcp.WithDescription("Create a new droplet"),
+				mcp.WithDescription("Create a new droplet. Supports standard distribution images via ImageID and 1-click marketplace app images via ImageSlug. Exactly one of ImageID or ImageSlug must be provided."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the droplet size (e.g., s-1vcpu-1gb)")),
-				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image to use")),
+				mcp.WithNumber("ImageID", mcp.Description("Numeric ID of the image to use. Mutually exclusive with ImageSlug.")),
+				mcp.WithString("ImageSlug", mcp.Description("Slug of the image to use (e.g., ubuntu-22-04-x64, wordpress-20-04). Use this for 1-click marketplace app images; slugs can be discovered via the 1-click-list tool. Mutually exclusive with ImageID.")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Slug of the region (e.g., nyc3)")),
 				mcp.WithBoolean("Backup", mcp.DefaultBool(false), mcp.Description("Whether to enable backups")),
 				mcp.WithBoolean("Monitoring", mcp.DefaultBool(false), mcp.Description("Whether to enable monitoring")),

--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -33,9 +33,7 @@ func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest
 
 	imageID, hasID := args["ImageID"].(float64)
 	imageSlug, hasSlug := args["ImageSlug"].(string)
-	if hasSlug {
-		hasSlug = imageSlug != ""
-	}
+	hasSlug = hasSlug && imageSlug != ""
 
 	if !hasID && !hasSlug {
 		return mcp.NewToolResultError("exactly one of ImageID or ImageSlug must be provided"), nil

--- a/pkg/registry/droplet/droplet_tools_test.go
+++ b/pkg/registry/droplet/droplet_tools_test.go
@@ -85,6 +85,52 @@ func TestDropletTool_createDroplet(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "Successful create with ImageSlug (1-click marketplace image)",
+			args: map[string]any{
+				"Name":       "marketplace-droplet",
+				"Size":       "s-1vcpu-1gb",
+				"ImageSlug":  "wordpress-20-04",
+				"Region":     "nyc1",
+				"Backup":     false,
+				"Monitoring": false,
+			},
+			mockSetup: func(m *MockDropletsService) {
+				m.EXPECT().
+					Create(gomock.Any(), &godo.DropletCreateRequest{
+						Name:       "marketplace-droplet",
+						Region:     "nyc1",
+						Size:       "s-1vcpu-1gb",
+						Image:      godo.DropletCreateImage{Slug: "wordpress-20-04"},
+						Backups:    false,
+						Monitoring: false,
+					}).
+					Return(testDroplet, nil, nil).
+					Times(1)
+			},
+		},
+		{
+			name: "Error when neither ImageID nor ImageSlug provided",
+			args: map[string]any{
+				"Name":   "no-image-droplet",
+				"Size":   "s-1vcpu-1gb",
+				"Region": "nyc1",
+			},
+			mockSetup:   func(m *MockDropletsService) {},
+			expectError: true,
+		},
+		{
+			name: "Error when both ImageID and ImageSlug provided",
+			args: map[string]any{
+				"Name":      "both-image-droplet",
+				"Size":      "s-1vcpu-1gb",
+				"ImageID":   float64(456),
+				"ImageSlug": "wordpress-20-04",
+				"Region":    "nyc1",
+			},
+			mockSetup:   func(m *MockDropletsService) {},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Allow droplets to be created using an image slug (e.g. marketplace 1-click app slugs like wordpress-20-04) in addition to a numeric ImageID. Exactly one of ImageID or ImageSlug must be provided. Updates tool schema, handler logic, unit tests, and README documentation.