### PR TITLE
Add inference router mcp tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The easiest way to get started is to use DigitalOcean's hosted MCP services. Eac
 | docr                     | https://docr.mcp.digitalocean.com/mcp                       | Manage DigitalOcean Container Registry repositories, tags, manifests, and garbage collection. |
 | genai-batchinference     | https://genai-batchinference.mcp.digitalocean.com/mcp       | Create, manage, and monitor batch inference jobs for asynchronous bulk AI processing. |
 | genai-custom-models      | https://genai-custom-models.mcp.digitalocean.com/mcp        | Import, list, update, and delete custom (bring-your-own) models on DigitalOcean's GenAI platform. |
+| genai-inferencerouter    | https://genai-inferencerouter.mcp.digitalocean.com/mcp      | Create, list, get, and delete GenAI model routers. |
 | dedicated-inference      | https://dedicated-inference.mcp.digitalocean.com/mcp        | Manage Dedicated Inference instances for GPU-accelerated model serving. |
 | inference-modelcatalog   | https://inference-modelcatalog.mcp.digitalocean.com/mcp     | Browse the DigitalOcean Inference model catalog, search for models, and get model cards. |
 | insights                 | https://insights.mcp.digitalocean.com/mcp                   | Monitors your resources, endpoints and alert you when they're slow, unavailable, or SSL certificates are expiring. |
@@ -609,6 +610,7 @@ Each service provides a detailed README describing all available tools, resource
 - [GenAI evaluation](pkg/registry/genai/README.md)
 - [GenAI Batch Inference Service](pkg/registry/genai-batchinference/README.md)
 - [GenAI Custom Models Service](pkg/registry/genai-custom-models/README.md)
+- [GenAI Inference Router](pkg/registry/genai-inferencerouter/README.md)
 - [NFS Service](pkg/registry/nfs/README.md)
 - [Volumes Service](pkg/registry/volumes/README.md)
 

--- a/pkg/registry/genai-inferencerouter/README.md
+++ b/pkg/registry/genai-inferencerouter/README.md
@@ -1,0 +1,160 @@
+# GenAI Inference Router MCP Tools
+
+## What is a model router?
+
+A **model router** (sometimes called an inference router) is a **named GenAI configuration** in your DigitalOcean account. It does not run inference by itself; it defines **how your app or agent should choose models** for different kinds of work. Concretely, a router has:
+
+- **Policies** — Each policy ties a **task** to an **ordered list of model ids** and a **selection policy** (for example, prefer the fastest or cheapest model among the candidates for that task). A task is either a **built-in** `task_slug` (e.g. code generation, summarization) or a **custom task** you describe with a name and short `description`.
+- **Fallback models** — A **required** ordered list the API can use when primary model choices in a policy are not available, so traffic still has a path to complete.
+
+### Use cases and how routing fits together (for agents)
+
+From DigitalOcean’s product documentation, an **Inference Router** is meant for **production routing** over [serverless inference](https://docs.digitalocean.com/products/inference/how-to/use-serverless-inference/) and [dedicated inference](https://docs.digitalocean.com/products/inference/how-to/use-dedicated-inference/). Instead of hard-coding one model per call, you define **tasks** (preset routes tuned by DigitalOcean or **custom** routes you name and describe), attach **model pools** and a **selection policy** (cost vs latency tradeoffs; the control panel also describes “optimal” presets and manual ordering for custom tasks), and **fallback models** so unmatched or degraded traffic still completes. The router evaluates each request against those tasks and policies. This MCP’s create/update/list/get/delete and preset-list tools map to the **account-level router configuration** (`/v2/gen-ai/models/routers` and related endpoints) that backs that behavior. After a router exists, client applications typically invoke it as a **drop-in model target** (for example `model` set to `router:<your-router-name>` in Chat Completions or Responses against the inference runtime—see the official how-to for exact URLs, headers such as model affinity, and response details like which route was selected).
+
+**Further reading**
+
+- [How to Use Inference Router](https://docs.digitalocean.com/products/inference/how-to/use-inference-router/) — end-to-end: concepts, control panel vs API (`POST /v2/gen-ai/models/routers`), preset vs custom tasks, fallbacks, calling the router from inference APIs, playground and metrics.
+- [DigitalOcean Inference Engine](https://www.digitalocean.com/products/inference-engine) — where Inference Router sits alongside serverless, batch, and dedicated inference, evaluations, and the broader “single control plane” story.
+
+When you use these MCP tools, you are managing that **routing configuration** through the typed **`godo.GradientAI`** client (same auth, base URL, and transport as the rest of this MCP server). Responses are formatted JSON aligned with the API (`tasks` for presets, `model_routers` / `model_router`, and `config` on get/create/update).
+
+## godo surface
+
+Calls map to:
+
+- `GradientAI.CreateInferenceRouter` — create (`POST /v2/gen-ai/models/routers`)
+- `GradientAI.ListInferenceRouters` — list (`GET …` with `page`, `per_page`)
+- `GradientAI.GetInferenceRouter` — get by UUID
+- `GradientAI.UpdateInferenceRouter` — update (`PUT …/{uuid}`)
+- `GradientAI.DeleteInferenceRouter` — delete by UUID
+- `GradientAI.ListInferenceRouterTaskPresets` — list preset tasks (`GET /v2/gen-ai/models/routers/tasks/presets` with `page`, `per_page`)
+
+## Built-in `task_slug` values (how to choose)
+
+**Prefer the live catalog** — Call **`genai-inference-router-task-presets`** (wraps `ListInferenceRouterTaskPresets`) for current `task_slug` values, display names, suggested models, and pagination metadata. The API remains authoritative if a slug is unavailable in your account or region.
+
+**Practical ways to pick a slug:**
+
+1. **`genai-inference-router-task-presets`** — Returns each preset’s `task_slug` and related fields.
+2. **Copy from an existing router** — Call `genai-inference-router-list` or `genai-inference-router-get` and read `task_slug` under `model_router.config.policies`.
+3. **Avoid slugs for one-off work** — Use a **`custom_task`** policy with `name` and `description` instead of `task_slug` (the [e2e test](../../../testing/e2e_genai_inferencerouter_test.go) does this so tests do not depend on a specific catalog in every environment).
+
+**Static reference** (snapshot for quick scanning; may drift—use **`genai-inference-router-task-presets`** or the docs above for current values):
+
+- **General:** `brainstorming-ideation`, `classification-labeling`, `opinion-advice-recommendation`, `planning-task-decomposition`, `summarization`, `text-extraction-structured-output`, `translation`
+- **Writing:** `creative-writing`, `email-professional-communication-drafting`, `long-form-article-blog-writing`, `rewriting-editing`, `social-media-short-form-content`
+- **Software engineering:** `bug-fixing`, `code-completion-inline`, `code-generation`, `code-performance-optimization`, `test-writing-code-verification`
+- **Knowledge base & document intelligence:** `knowledge-base-customer-support`, `long-context-retrieval-aggregation`, `long-document-qa`, `rag-system-quality-evaluation`, `retrieval-quality-cross-domain-ir`, `text-and-table-grounded-reasoning`
+
+## Tools
+
+### `genai-inference-router-create`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `Name` | string | yes | Router name |
+| `PoliciesJson` | string | no | JSON array of policies (omit or `[]` if the API allows); see below |
+| `FallbackModels` | string[] | **yes** | At least one model id, sent as `fallback_models` (required by the API) |
+
+**Create request body (via godo):** `name`, optional **`policies`**, and required non-empty **`fallback_models`**. Each policy must define a **task**:
+
+- **Built-in task:** set **`task_slug`** (e.g. `code-generation`, `summarization`, `bug-fixing`) and **`models`** (ordered model id strings). Include **`selection_policy`** with **`prefer`** set to `fastest` or `cheapest`.
+- **Custom task:** use **`custom_task`** with **`name`** and **`description`** instead of `task_slug`, and still set **`models`** and **`selection_policy`** as needed.
+
+Policies that only set `model` plus `usecase_class` (with no task) are rejected by the API with an error like `policy 0 task is required`.
+
+**Example** (equivalent JSON body sent by godo; `PoliciesJson` is only the `policies` array):
+
+```json
+{
+  "name": "my-router",
+  "policies": [
+    {
+      "task_slug": "code-generation",
+      "models": ["openai-gpt-5", "anthropic-claude-4.6-sonnet"],
+      "selection_policy": { "prefer": "fastest" }
+    }
+  ],
+  "fallback_models": ["openai-gpt-oss-120b"]
+}
+```
+
+**Custom task** policy example:
+
+```json
+{
+  "custom_task": {
+    "name": "Code reviewer",
+    "description": "Review patches for correctness and style."
+  },
+  "models": ["openai-gpt-5.2"],
+  "selection_policy": { "prefer": "cheapest" }
+}
+```
+
+Pass the contents of `policies` (a JSON array) as the `PoliciesJson` string. **List** and **get** return `model_router.config.policies` in the same general shape (`task_slug` or `custom_task`, `models`, `selection_policy`). List summaries and full router payloads may include **`regions`** when the API returns them; that field is not set by this MCP on create (see current `godo.InferenceRouterCreateRequest`).
+
+### `genai-inference-router-list`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `Page` | number | no | Page (default 1) |
+| `PerPage` | number | no | Page size (default 1000, max 1000) |
+
+### `genai-inference-router-get`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `UUID` | string | yes | Model router UUID |
+
+### `genai-inference-router-delete`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `UUID` | string | yes | Model router UUID to delete |
+
+Returns formatted JSON (typically `{"uuid":"..."}`). If the API responds with an empty body on success, the tool still returns a JSON object containing the requested UUID.
+
+### `genai-inference-router-task-presets`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `Page` | number | no | Page (default 1) |
+| `PerPage` | number | no | Page size (default 1000, max 1000) |
+
+Returns JSON with a `tasks` array (preset `task_slug`, names, categories, suggested models, etc.) plus optional `meta` and `links`. Use this when choosing built-in slugs for `PoliciesJson` on create/update.
+
+### `genai-inference-router-update`
+
+**Arguments**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `UUID` | string | yes | Model router UUID |
+| `Name` | string | no | New name (omit if unchanged) |
+| `Description` | string | no | New description (omit if unchanged) |
+| `PoliciesJson` | string | no | JSON array of policies (omit if unchanged); must decode as a JSON array when non-empty |
+| `FallbackModels` | string[] | no | New ordered fallbacks; pass this argument only when updating fallbacks |
+
+At least one of `Name`, `Description`, non-empty `PoliciesJson`, or `FallbackModels` must be provided (matches `godo` validation).
+
+## Enabling the service
+
+Register with `--services genai-inferencerouter` (or include it in `SERVICES`). A valid `DIGITALOCEAN_API_TOKEN` is required.
+
+## Notes
+
+- The GenAI model router API **requires** at least one `fallback_models` entry on create, so the MCP enforces a non-empty `FallbackModels` list for create (mirroring `godo` client validation).
+- Preview / unreleased APIs may only work on specific API hosts or accounts.
+- Response bodies are returned as formatted JSON text.
+- **Integration tests / tokens:** If `DELETE …/v2/gen-ai/models/routers/{uuid}` returns **403** (“not authorized”), your Personal Access Token can list or create routers but **cannot delete** them—use a token with **write** (not read-only) access to the account’s Inference / GenAI resources, or delete the router in the [control panel](https://cloud.digitalocean.com/) under **INFERENCE → Inference Router**.

--- a/pkg/registry/genai-inferencerouter/router_tools.go
+++ b/pkg/registry/genai-inferencerouter/router_tools.go
@@ -1,0 +1,386 @@
+package genaiinferencerouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RouterTool exposes GenAI inference router operations via godo.GradientAI.
+type RouterTool struct {
+	client func(ctx context.Context) (*godo.Client, error)
+}
+
+// NewRouterTool builds a RouterTool that uses the shared godo client.
+func NewRouterTool(client func(ctx context.Context) (*godo.Client, error)) *RouterTool {
+	return &RouterTool{client: client}
+}
+
+// validatePoliciesJSON ensures PoliciesJson decodes to a JSON array (empty allowed; API permits no policies).
+func validatePoliciesJSON(raw json.RawMessage) error {
+	var policies []json.RawMessage
+	if err := json.Unmarshal(raw, &policies); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *RouterTool) create(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	name, _ := args["Name"].(string)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return mcp.NewToolResultError("Name is required"), nil
+	}
+	policiesJSON, _ := args["PoliciesJson"].(string)
+	policiesJSON = strings.TrimSpace(policiesJSON)
+
+	fallbacks := stringSliceArg(args["FallbackModels"])
+	if len(fallbacks) == 0 {
+		return mcp.NewToolResultError("FallbackModels is required: provide at least one fallback model id (the API requires fallbacks for inference routers)"), nil
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	create := &godo.InferenceRouterCreateRequest{
+		Name:           name,
+		FallbackModels: fallbacks,
+	}
+	if policiesJSON != "" {
+		raw := json.RawMessage(policiesJSON)
+		if err := validatePoliciesJSON(raw); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid PoliciesJson: %v", err)), nil
+		}
+		create.Policies = raw
+	}
+
+	router, _, err := c.GradientAI.CreateInferenceRouter(ctx, create)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("CreateInferenceRouter failed", err), nil
+	}
+
+	return encodeJSON(map[string]any{"model_router": router})
+}
+
+func (t *RouterTool) list(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	page := intFromArg(req.GetArguments()["Page"], 1)
+	perPage := intFromArg(req.GetArguments()["PerPage"], 1000)
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+	if perPage > 1000 {
+		perPage = 1000
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	routers, apiResp, err := c.GradientAI.ListInferenceRouters(ctx, &godo.ListOptions{Page: page, PerPage: perPage})
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("ListInferenceRouters failed", err), nil
+	}
+	if routers == nil {
+		routers = []*godo.InferenceRouterSummary{}
+	}
+
+	type metaView struct {
+		Page  int `json:"page"`
+		Pages int `json:"pages"`
+		Total int `json:"total"`
+	}
+	payload := struct {
+		ModelRouters []*godo.InferenceRouterSummary `json:"model_routers"`
+		Meta         *metaView                      `json:"meta,omitempty"`
+		Links        *godo.Links                    `json:"links,omitempty"`
+	}{
+		ModelRouters: routers,
+	}
+	if apiResp != nil {
+		if apiResp.Meta != nil {
+			payload.Meta = &metaView{
+				Page:  apiResp.Meta.Page,
+				Pages: apiResp.Meta.Pages,
+				Total: apiResp.Meta.Total,
+			}
+		}
+		if apiResp.Links != nil {
+			payload.Links = apiResp.Links
+		}
+	}
+
+	return encodeJSON(payload)
+}
+
+func (t *RouterTool) listTaskPresets(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	page := intFromArg(req.GetArguments()["Page"], 1)
+	perPage := intFromArg(req.GetArguments()["PerPage"], 1000)
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 {
+		perPage = 20
+	}
+	if perPage > 1000 {
+		perPage = 1000
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	tasks, apiResp, err := c.GradientAI.ListInferenceRouterTaskPresets(ctx, &godo.ListOptions{Page: page, PerPage: perPage})
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("ListInferenceRouterTaskPresets failed", err), nil
+	}
+	if tasks == nil {
+		tasks = []*godo.InferenceRouterTaskPreset{}
+	}
+
+	type metaView struct {
+		Page  int `json:"page"`
+		Pages int `json:"pages"`
+		Total int `json:"total"`
+	}
+	payload := struct {
+		Tasks []*godo.InferenceRouterTaskPreset `json:"tasks"`
+		Meta  *metaView                         `json:"meta,omitempty"`
+		Links *godo.Links                       `json:"links,omitempty"`
+	}{
+		Tasks: tasks,
+	}
+	if apiResp != nil {
+		if apiResp.Meta != nil {
+			payload.Meta = &metaView{
+				Page:  apiResp.Meta.Page,
+				Pages: apiResp.Meta.Pages,
+				Total: apiResp.Meta.Total,
+			}
+		}
+		if apiResp.Links != nil {
+			payload.Links = apiResp.Links
+		}
+	}
+
+	return encodeJSON(payload)
+}
+
+func (t *RouterTool) update(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	uuid, _ := args["UUID"].(string)
+	uuid = strings.TrimSpace(uuid)
+	if uuid == "" {
+		return mcp.NewToolResultError("UUID is required"), nil
+	}
+
+	update := &godo.InferenceRouterUpdateRequest{}
+	if name, _ := args["Name"].(string); strings.TrimSpace(name) != "" {
+		update.Name = strings.TrimSpace(name)
+	}
+	if desc, _ := args["Description"].(string); strings.TrimSpace(desc) != "" {
+		update.Description = strings.TrimSpace(desc)
+	}
+
+	if policiesJSON, ok := args["PoliciesJson"].(string); ok {
+		policiesJSON = strings.TrimSpace(policiesJSON)
+		if policiesJSON != "" {
+			raw := json.RawMessage(policiesJSON)
+			if err := validatePoliciesJSON(raw); err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("invalid PoliciesJson: %v", err)), nil
+			}
+			update.Policies = &raw
+		}
+	}
+
+	if _, hasFallbacks := args["FallbackModels"]; hasFallbacks {
+		update.FallbackModels = stringSliceArg(args["FallbackModels"])
+	}
+
+	if update.Name == "" && update.Description == "" && update.Policies == nil && len(update.FallbackModels) == 0 {
+		return mcp.NewToolResultError("at least one of Name, Description, PoliciesJson (non-empty JSON array), or FallbackModels must be provided (matches godo UpdateInferenceRouter validation)"), nil
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	router, _, err := c.GradientAI.UpdateInferenceRouter(ctx, uuid, update)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("UpdateInferenceRouter failed", err), nil
+	}
+
+	return encodeJSON(map[string]any{"model_router": router})
+}
+
+func (t *RouterTool) get(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	uuid, _ := req.GetArguments()["UUID"].(string)
+	uuid = strings.TrimSpace(uuid)
+	if uuid == "" {
+		return mcp.NewToolResultError("UUID is required"), nil
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	router, _, err := c.GradientAI.GetInferenceRouter(ctx, uuid)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("GetInferenceRouter failed", err), nil
+	}
+
+	return encodeJSON(map[string]any{"model_router": router})
+}
+
+func (t *RouterTool) delete(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	uuid, _ := req.GetArguments()["UUID"].(string)
+	uuid = strings.TrimSpace(uuid)
+	if uuid == "" {
+		return mcp.NewToolResultError("UUID is required"), nil
+	}
+
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+
+	out, _, err := c.GradientAI.DeleteInferenceRouter(ctx, uuid)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("DeleteInferenceRouter failed", err), nil
+	}
+
+	if out == nil {
+		b, _ := json.MarshalIndent(map[string]string{"uuid": uuid}, "", "  ")
+		return mcp.NewToolResultText(string(b)), nil
+	}
+
+	return encodeJSON(out)
+}
+
+func encodeJSON(v any) (*mcp.CallToolResult, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal response: %w", err)
+	}
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func intFromArg(v any, def int) int {
+	switch x := v.(type) {
+	case nil:
+		return def
+	case float64:
+		if x >= 1 {
+			return int(x)
+		}
+		return def
+	case int:
+		if x >= 1 {
+			return x
+		}
+		return def
+	case string:
+		if n, err := strconv.Atoi(x); err == nil && n >= 1 {
+			return n
+		}
+		return def
+	default:
+		return def
+	}
+}
+
+func stringSliceArg(v any) []string {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		return x
+	case []any:
+		var out []string
+		for _, el := range x {
+			if s, ok := el.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// Tools registers MCP tools for model routers.
+func (t *RouterTool) Tools() []server.ServerTool {
+	return []server.ServerTool{
+		{
+			Handler: t.create,
+			Tool: mcp.NewTool(
+				"genai-inference-router-create",
+				mcp.WithDescription(`Create a GenAI model router via godo.GradientAI.CreateInferenceRouter. JSON body fields: "name", optional "policies" array, and required "fallback_models" (at least one model). Each policy needs a task: either "task_slug" (built-in) plus "models" and "selection_policy":{"prefer":"fastest"|"cheapest"}, or "custom_task":{"name","description"} with "models" and selection_policy. Flat {"model","usecase_class"} policies fail with "task is required". List/get return the same policy shape under model_router.config.`),
+				mcp.WithString("Name", mcp.Required(), mcp.Description("Router name")),
+				mcp.WithString("PoliciesJson", mcp.Description(`JSON array for "policies". Example: [{"task_slug":"code-generation","models":["openai-gpt-5"],"selection_policy":{"prefer":"fastest"}}]. Custom task: use custom_task with name+description instead of task_slug. Omit or "[]" if allowed.`)),
+				mcp.WithArray("FallbackModels", mcp.Required(), mcp.MinItems(1), mcp.Description("At least one fallback model id, in order, sent as fallback_models (required by the API).")),
+			),
+		},
+		{
+			Handler: t.list,
+			Tool: mcp.NewTool(
+				"genai-inference-router-list",
+				mcp.WithDescription("List GenAI model routers (godo.GradientAI.ListInferenceRouters) with pagination."),
+				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1)")),
+				mcp.WithNumber("PerPage", mcp.DefaultNumber(1000), mcp.Description("Items per page (default 1000, max 1000)")),
+			),
+		},
+		{
+			Handler: t.get,
+			Tool: mcp.NewTool(
+				"genai-inference-router-get",
+				mcp.WithDescription("Get a GenAI model router by UUID (godo.GradientAI.GetInferenceRouter)."),
+				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
+			),
+		},
+		{
+			Handler: t.delete,
+			Tool: mcp.NewTool(
+				"genai-inference-router-delete",
+				mcp.WithDescription("Delete a GenAI model router by UUID (godo.GradientAI.DeleteInferenceRouter)."),
+				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
+			),
+		},
+		{
+			Handler: t.listTaskPresets,
+			Tool: mcp.NewTool(
+				"genai-inference-router-task-presets",
+				mcp.WithDescription("List preset inference-router tasks (task_slug, name, models, etc.) from GET /v2/gen-ai/models/routers/tasks/presets via godo.GradientAI.ListInferenceRouterTaskPresets. Use task_slug values when building PoliciesJson for create/update."),
+				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1)")),
+				mcp.WithNumber("PerPage", mcp.DefaultNumber(1000), mcp.Description("Items per page (default 1000, max 1000)")),
+			),
+		},
+		{
+			Handler: t.update,
+			Tool: mcp.NewTool(
+				"genai-inference-router-update",
+				mcp.WithDescription(`Update a GenAI model router (godo.GradientAI.UpdateInferenceRouter, PUT). At least one of Name, Description, PoliciesJson (non-empty), or FallbackModels must be supplied. PoliciesJson must be a JSON array (same rules as create). Omit fields you do not want to change.`),
+				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
+				mcp.WithString("Name", mcp.Description("New router name (optional)")),
+				mcp.WithString("Description", mcp.Description("New description (optional)")),
+				mcp.WithString("PoliciesJson", mcp.Description(`JSON array for "policies" (optional). Same shape as create; set to "[]" only if the API should receive an empty policies list.`)),
+				mcp.WithArray("FallbackModels", mcp.Description("Optional ordered fallback model ids; include this argument only when updating fallbacks.")),
+			),
+		},
+	}
+}

--- a/pkg/registry/genai-inferencerouter/router_tools_test.go
+++ b/pkg/registry/genai-inferencerouter/router_tools_test.go
@@ -1,0 +1,351 @@
+package genaiinferencerouter
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func testGodoClient(t *testing.T, h http.Handler) *godo.Client {
+	t.Helper()
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	c, err := godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL+"/"))
+	require.NoError(t, err)
+	return c
+}
+
+func TestRouterTool_create(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_router":{"uuid":"11f117f7-d076-6272-b542-ca68c578b04b","name":"alex-test-2"}}`))
+	})
+
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	policies := `[{"model":"openai-gpt-5","usecase_class":"MODEL_ROUTER_USECASE_CLASS_CODE_GENERATION"},{"model":"llama3.3-70b-instruct","usecase_class":"MODEL_ROUTER_USECASE_CLASS_CHATBOT"}]`
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Name":           "alex-test-2",
+		"PoliciesJson":   policies,
+		"FallbackModels": []any{"llama3.3-70b-instruct"},
+	}}}
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError)
+
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "/v2/gen-ai/models/routers", gotPath)
+
+	var decoded godo.InferenceRouterCreateRequest
+	require.NoError(t, json.Unmarshal(gotBody, &decoded))
+	require.Equal(t, "alex-test-2", decoded.Name)
+	require.NotNil(t, decoded.Policies)
+	var policyObjs []map[string]any
+	require.NoError(t, json.Unmarshal(decoded.Policies, &policyObjs))
+	require.Len(t, policyObjs, 2)
+	require.Equal(t, "openai-gpt-5", policyObjs[0]["model"])
+	require.Equal(t, "MODEL_ROUTER_USECASE_CLASS_CODE_GENERATION", policyObjs[0]["usecase_class"])
+	require.Equal(t, []string{"llama3.3-70b-instruct"}, decoded.FallbackModels)
+
+	text := resp.Content[0].(mcp.TextContent).Text
+	require.Contains(t, text, "11f117f7-d076-6272-b542-ca68c578b04b")
+}
+
+func TestRouterTool_create_validation(t *testing.T) {
+	c := testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Name": "n",
+	}}}
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+}
+
+func TestRouterTool_create_policiesJson_validation(t *testing.T) {
+	c := testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "not an array",
+			args: map[string]any{"Name": "n", "PoliciesJson": `{"model":"x"}`, "FallbackModels": []any{"m"}},
+		},
+		{
+			name: "invalid json",
+			args: map[string]any{"Name": "n", "PoliciesJson": `[`, "FallbackModels": []any{"m"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.create(context.Background(), req)
+			require.NoError(t, err)
+			require.True(t, resp.IsError, "expected error for %s", tc.name)
+		})
+	}
+}
+
+func TestRouterTool_create_requiresFallbackModels(t *testing.T) {
+	c := testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Name": "n", "FallbackModels": []any{},
+	}}}
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+}
+
+func TestRouterTool_create_omitsPoliciesWhenEmpty(t *testing.T) {
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_router":{"uuid":"u1","name":"no-policies"}}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Name": "no-policies", "FallbackModels": []any{"openai-gpt-oss-120b"},
+	}}}
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(gotBody, &decoded))
+	_, hasPolicies := decoded["policies"]
+	require.False(t, hasPolicies)
+	var fbs []string
+	require.NoError(t, json.Unmarshal(decoded["fallback_models"], &fbs))
+	require.Equal(t, []string{"openai-gpt-oss-120b"}, fbs)
+}
+
+func TestRouterTool_list(t *testing.T) {
+	var gotQuery string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_routers":[],"meta":{"total":0,"page":1,"pages":1}}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Page":    float64(2),
+		"PerPage": float64(50),
+	}}}
+	resp, err := tool.list(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Contains(t, gotQuery, "page=2")
+	require.Contains(t, gotQuery, "per_page=50")
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "model_routers")
+}
+
+func TestRouterTool_get(t *testing.T) {
+	var gotPath string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_router":{"uuid":"u1","name":"n"}}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"UUID": "11f117f7-d076-6272-b542-ca68c578b04b",
+	}}}
+	resp, err := tool.get(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.True(t, strings.HasSuffix(gotPath, "/11f117f7-d076-6272-b542-ca68c578b04b"))
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "model_router")
+}
+
+func TestRouterTool_get_missingUUID(t *testing.T) {
+	c := testGodoClient(t, http.NotFoundHandler())
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+	resp, err := tool.get(context.Background(), mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+}
+
+func TestRouterTool_delete(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"uuid":"11f117f7-d076-6272-b542-ca68c578b04b"}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"UUID": "11f117f7-d076-6272-b542-ca68c578b04b",
+	}}}
+	resp, err := tool.delete(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, http.MethodDelete, gotMethod)
+	require.True(t, strings.HasSuffix(gotPath, "/11f117f7-d076-6272-b542-ca68c578b04b"))
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "11f117f7-d076-6272-b542-ca68c578b04b")
+}
+
+// godo's JSON decoder requires a value on 2xx; an empty body fails decode. The API typically returns {} or {"uuid":"..."}.
+func TestRouterTool_delete_minimalJSONBody(t *testing.T) {
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"UUID": "11f117f7-d076-6272-b542-ca68c578b04b",
+	}}}
+	resp, err := tool.delete(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "11f117f7-d076-6272-b542-ca68c578b04b")
+}
+
+func TestRouterTool_delete_missingUUID(t *testing.T) {
+	c := testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+	resp, err := tool.delete(context.Background(), mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+}
+
+func TestRouterTool_listTaskPresets(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tasks":[{"task_slug":"translation","name":"Translation"}],"meta":{"total":1,"page":1,"pages":1}}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Page": float64(1), "PerPage": float64(100),
+	}}}
+	resp, err := tool.listTaskPresets(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, "/v2/gen-ai/models/routers/tasks/presets", gotPath)
+	require.Contains(t, gotQuery, "page=1")
+	require.Contains(t, gotQuery, "per_page=100")
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, `"tasks"`)
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "translation")
+}
+
+func TestRouterTool_update(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model_router":{"uuid":"u1","name":"renamed"}}`))
+	})
+	c := testGodoClient(t, srv)
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"UUID": "11f117f7-d076-6272-b542-ca68c578b04b",
+		"Name": "renamed",
+	}}}
+	resp, err := tool.update(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, http.MethodPut, gotMethod)
+	require.True(t, strings.HasSuffix(gotPath, "/11f117f7-d076-6272-b542-ca68c578b04b"))
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &body))
+	require.Equal(t, "renamed", body["name"])
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "renamed")
+}
+
+func TestRouterTool_update_validation(t *testing.T) {
+	c := testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	}))
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing uuid", args: map[string]any{"Name": "x"}},
+		{name: "no fields", args: map[string]any{"UUID": "11f117f7-d076-6272-b542-ca68c578b04b"}},
+		{name: "invalid policies", args: map[string]any{"UUID": "11f117f7-d076-6272-b542-ca68c578b04b", "PoliciesJson": `{`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := tool.update(context.Background(), mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}})
+			require.NoError(t, err)
+			require.True(t, resp.IsError, tc.name)
+		})
+	}
+}
+
+func TestRouterTool_Tools(t *testing.T) {
+	tool := NewRouterTool(func(ctx context.Context) (*godo.Client, error) { return nil, nil })
+	names := map[string]bool{}
+	for _, st := range tool.Tools() {
+		names[st.Tool.Name] = true
+	}
+	require.True(t, names["genai-inference-router-create"])
+	require.True(t, names["genai-inference-router-list"])
+	require.True(t, names["genai-inference-router-get"])
+	require.True(t, names["genai-inference-router-delete"])
+	require.True(t, names["genai-inference-router-task-presets"])
+	require.True(t, names["genai-inference-router-update"])
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"mcp-digitalocean/pkg/registry/genai"
 	genaibi "mcp-digitalocean/pkg/registry/genai-batchinference"
 	genaicm "mcp-digitalocean/pkg/registry/genai-custom-models"
+	genaiinferencerouter "mcp-digitalocean/pkg/registry/genai-inferencerouter"
 	inferencemodelcatalog "mcp-digitalocean/pkg/registry/inference-modelcatalog"
 	"mcp-digitalocean/pkg/registry/insights"
 	"mcp-digitalocean/pkg/registry/marketplace"
@@ -47,6 +48,7 @@ var supportedServices = map[string]struct{}{
 	"genai-evaluation":       {},
 	"genai-custom-models":    {},
 	"genai-batchinference":   {},
+	"genai-inferencerouter":  {},
 	"insights":               {},
 	"doks":                   {},
 	"docr":                   {},
@@ -158,6 +160,12 @@ func registerGenAICustomModelsTools(s *server.MCPServer, getClient getClientFn) 
 // registerGenAIBatchInferenceTools registers the GenAI batch inference tools with the MCP server.
 func registerGenAIBatchInferenceTools(s *server.MCPServer, getClient getClientFn) error {
 	s.AddTools(genaibi.NewBatchInferenceTool(getClient).Tools()...)
+	return nil
+}
+
+// registerGenAIInferenceRouterTools registers the GenAI model router tools with the MCP server.
+func registerGenAIInferenceRouterTools(s *server.MCPServer, getClient getClientFn) error {
+	s.AddTools(genaiinferencerouter.NewRouterTool(getClient).Tools()...)
 	return nil
 }
 
@@ -287,6 +295,10 @@ func Register(logger *slog.Logger, s *server.MCPServer, getClient getClientFn, s
 		case "genai-batchinference":
 			if err := registerGenAIBatchInferenceTools(s, getClient); err != nil {
 				return fmt.Errorf("failed to register genai-batchinference tools: %w", err)
+			}
+		case "genai-inferencerouter":
+			if err := registerGenAIInferenceRouterTools(s, getClient); err != nil {
+				return fmt.Errorf("failed to register genai-inferencerouter tools: %w", err)
 			}
 		case "insights":
 			if err := registerInsightsTools(s, getClient); err != nil {

--- a/testing/e2e_genai_inferencerouter_test.go
+++ b/testing/e2e_genai_inferencerouter_test.go
@@ -1,0 +1,324 @@
+//go:build integration
+
+package testing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// listModelRoutersResponse matches GET /v2/gen-ai/models/routers JSON.
+type listModelRoutersResponse struct {
+	Meta struct {
+		Page  int `json:"page"`
+		Pages int `json:"pages"`
+		Total int `json:"total"`
+	} `json:"meta"`
+	ModelRouters []struct {
+		UUID    string   `json:"uuid"`
+		Name    string   `json:"name"`
+		Regions []string `json:"regions"`
+	} `json:"model_routers"`
+}
+
+// getModelRouterResponse matches GET /v2/gen-ai/models/routers/{uuid} JSON.
+type getModelRouterResponse struct {
+	ModelRouter struct {
+		UUID      string   `json:"uuid"`
+		Name      string   `json:"name"`
+		Regions   []string `json:"regions"`
+		CreatedAt string   `json:"created_at"`
+		UpdatedAt string   `json:"updated_at"`
+		Config    struct {
+			FallbackModels []string `json:"fallback_models"`
+			Policies       []any    `json:"policies"`
+		} `json:"config"`
+	} `json:"model_router"`
+}
+
+// deleteModelRouterResponse matches DELETE /v2/gen-ai/models/routers/{uuid} JSON.
+type deleteModelRouterResponse struct {
+	UUID string `json:"uuid"`
+}
+
+func inferenceRouterMCPErrorText(resp *mcp.CallToolResult) string {
+	if resp == nil || len(resp.Content) == 0 {
+		return ""
+	}
+	if tc, ok := resp.Content[0].(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return fmt.Sprintf("%v", resp.Content)
+}
+
+// callToolInferenceRouterDelete is like callTool for genai-inference-router-delete but explains 403 (token scope).
+func callToolInferenceRouterDelete(t *testing.T, routerUUID string) deleteModelRouterResponse {
+	t.Helper()
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-inference-router-delete",
+			Arguments: map[string]interface{}{"UUID": routerUUID},
+		},
+	})
+	require.NoError(t, err)
+	if resp.IsError {
+		errText := inferenceRouterMCPErrorText(resp)
+		low := strings.ToLower(errText)
+		if strings.Contains(errText, "403") || strings.Contains(low, "not authorized") {
+			t.Fatalf("genai-inference-router-delete returned 403 for uuid=%s: DIGITALOCEAN_API_TOKEN cannot delete inference routers (read-only or insufficient scope). If the test created this router, remove it under INFERENCE > Inference Router in the control panel, or use a PAT with write access. API: %s", routerUUID, errText)
+		}
+		t.Fatalf("genai-inference-router-delete failed: %s", errText)
+	}
+	require.NotEmpty(t, resp.Content, "empty delete response")
+	tc, ok := resp.Content[0].(mcp.TextContent)
+	require.True(t, ok, "unexpected delete response type")
+	var out deleteModelRouterResponse
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	return out
+}
+
+// deleteInferenceRouter logs cleanup failures; used when a test aborts before explicit delete.
+func deleteInferenceRouter(t *testing.T, routerUUID string) {
+	t.Helper()
+	if routerUUID == "" {
+		return
+	}
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-inference-router-delete",
+			Arguments: map[string]interface{}{"UUID": routerUUID},
+		},
+	})
+	if err != nil {
+		t.Logf("inference router cleanup delete failed: %v", err)
+		return
+	}
+	if resp != nil && resp.IsError {
+		msg := inferenceRouterMCPErrorText(resp)
+		t.Logf("inference router cleanup delete returned error: %s", msg)
+		if strings.Contains(msg, "403") || strings.Contains(strings.ToLower(msg), "not authorized") {
+			t.Logf("cleanup hint: token may lack delete permission; delete router %s manually (INFERENCE > Inference Router)", routerUUID)
+		}
+	}
+}
+
+// TestInferenceRouterList exercises genai-inference-router-list against the live API.
+func TestInferenceRouterList(t *testing.T) {
+	t.Log("listing model routers (first page)...")
+	out := callTool[listModelRoutersResponse](t, "genai-inference-router-list", map[string]interface{}{
+		"Page":    float64(1),
+		"PerPage": float64(20),
+	})
+
+	require.GreaterOrEqual(t, out.Meta.Total, 0, "meta.total should be present")
+	require.Equal(t, 1, out.Meta.Page)
+	t.Logf("total routers: %d, pages: %d, this page count: %d", out.Meta.Total, out.Meta.Pages, len(out.ModelRouters))
+
+	if out.Meta.Total > 0 {
+		require.NotEmpty(t, out.ModelRouters, "non-zero total should return routers on page 1")
+		for i, r := range out.ModelRouters {
+			require.NotEmpty(t, r.UUID, "router %d missing uuid", i)
+			require.NotEmpty(t, r.Name, "router %d missing name", i)
+		}
+	}
+}
+
+// listTaskPresetsResponse matches GET /v2/gen-ai/models/routers/tasks/presets JSON.
+type listTaskPresetsResponse struct {
+	Meta struct {
+		Page  int `json:"page"`
+		Pages int `json:"pages"`
+		Total int `json:"total"`
+	} `json:"meta"`
+	Tasks []struct {
+		TaskSlug string `json:"task_slug"`
+		Name     string `json:"name"`
+	} `json:"tasks"`
+}
+
+// TestInferenceRouterListTaskPresets exercises genai-inference-router-task-presets against the live API.
+func TestInferenceRouterListTaskPresets(t *testing.T) {
+	t.Log("listing inference router task presets (first page)...")
+	out := callTool[listTaskPresetsResponse](t, "genai-inference-router-task-presets", map[string]interface{}{
+		"Page":    float64(1),
+		"PerPage": float64(50),
+	})
+	require.GreaterOrEqual(t, out.Meta.Total, 0, "meta.total should be present")
+	require.Equal(t, 1, out.Meta.Page)
+	t.Logf("total presets: %d, this page: %d", out.Meta.Total, len(out.Tasks))
+	if out.Meta.Total > 0 {
+		require.NotEmpty(t, out.Tasks, "non-zero total should return tasks on page 1")
+		for i, task := range out.Tasks {
+			require.NotEmpty(t, task.TaskSlug, "task %d missing task_slug", i)
+			require.NotEmpty(t, task.Name, "task %d missing name", i)
+		}
+	}
+}
+
+// TestInferenceRouterListPagination checks page and per_page are honored when multiple pages exist.
+func TestInferenceRouterListPagination(t *testing.T) {
+	first := callTool[listModelRoutersResponse](t, "genai-inference-router-list", map[string]interface{}{
+		"Page":    float64(1),
+		"PerPage": float64(2),
+	})
+	if first.Meta.Total <= 2 {
+		t.Skip("need more than 2 routers to assert pagination; skipping")
+	}
+
+	second := callTool[listModelRoutersResponse](t, "genai-inference-router-list", map[string]interface{}{
+		"Page":    float64(2),
+		"PerPage": float64(2),
+	})
+
+	require.Equal(t, 2, second.Meta.Page)
+	require.NotEmpty(t, second.ModelRouters)
+	// Page 1 and 2 should not return the same primary UUID when totals exceed page size.
+	require.NotEqual(t, first.ModelRouters[0].UUID, second.ModelRouters[0].UUID)
+}
+
+// TestInferenceRouterGet fetches one router by UUID from list results.
+func TestInferenceRouterGet(t *testing.T) {
+	listOut := callTool[listModelRoutersResponse](t, "genai-inference-router-list", map[string]interface{}{
+		"Page":    float64(1),
+		"PerPage": float64(10),
+	})
+	if len(listOut.ModelRouters) == 0 {
+		t.Skip("no model routers in account; skipping get test")
+	}
+
+	uuid := listOut.ModelRouters[0].UUID
+	name := listOut.ModelRouters[0].Name
+	t.Logf("getting model router %s (%s)...", uuid, name)
+
+	got := callTool[getModelRouterResponse](t, "genai-inference-router-get", map[string]interface{}{
+		"UUID": uuid,
+	})
+
+	require.Equal(t, uuid, got.ModelRouter.UUID)
+	require.Equal(t, name, got.ModelRouter.Name)
+	require.NotEmpty(t, got.ModelRouter.CreatedAt)
+	t.Logf("config: %d policies, %d fallback models",
+		len(got.ModelRouter.Config.Policies), len(got.ModelRouter.Config.FallbackModels))
+}
+
+// TestInferenceRouterGetNotFound expects an error result for an unknown UUID.
+func TestInferenceRouterGetNotFound(t *testing.T) {
+	ctx, c := getTestClient(t)
+	fakeUUID := "00000000-0000-0000-0000-000000000001"
+	t.Logf("getting non-existent router %s...", fakeUUID)
+
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-inference-router-get",
+			Arguments: map[string]interface{}{"UUID": fakeUUID},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.IsError, "expected error for missing router")
+
+	if len(resp.Content) > 0 {
+		if tc, ok := resp.Content[0].(mcp.TextContent); ok {
+			t.Logf("error text: %s", tc.Text)
+		}
+	}
+}
+
+// TestInferenceRouterWorkflow runs list -> get for a few routers (bounded API usage).
+func TestInferenceRouterWorkflow(t *testing.T) {
+	t.Log("workflow: list -> get for up to 3 routers")
+	listOut := callTool[listModelRoutersResponse](t, "genai-inference-router-list", map[string]interface{}{
+		"Page":    float64(1),
+		"PerPage": float64(25),
+	})
+	if len(listOut.ModelRouters) == 0 {
+		t.Skip("no model routers; skipping workflow")
+	}
+
+	limit := 3
+	for i, r := range listOut.ModelRouters {
+		if i >= limit {
+			t.Logf("stopping after %d gets", limit)
+			break
+		}
+		detail := callTool[getModelRouterResponse](t, "genai-inference-router-get", map[string]interface{}{
+			"UUID": r.UUID,
+		})
+		require.Equal(t, r.UUID, detail.ModelRouter.UUID)
+		require.Equal(t, r.Name, detail.ModelRouter.Name)
+		t.Logf("  ok: %s", r.Name)
+	}
+}
+
+// TestInferenceRouterCreateDeleteLifecycle creates a router, verifies get, deletes, and expects get to fail.
+func TestInferenceRouterCreateDeleteLifecycle(t *testing.T) {
+	routerName := fmt.Sprintf("mcp-e2e-infer-router-%s", uuid.New().String())
+
+	var routerUUID string
+	t.Cleanup(func() {
+		if routerUUID != "" {
+			deleteInferenceRouter(t, routerUUID)
+		}
+	})
+
+	// Use custom_task so create does not depend on built-in task_slug catalog (avoids "task slug not found" in some environments).
+	policies := `[{"custom_task":{"name":"MCP E2E","description":"Integration test policy for inference router lifecycle."},"models":["openai-gpt-oss-120b"],"selection_policy":{"prefer":"fastest"}}]`
+	t.Logf("creating model router %s...", routerName)
+	created := callTool[getModelRouterResponse](t, "genai-inference-router-create", map[string]interface{}{
+		"Name":           routerName,
+		"PoliciesJson":   policies,
+		"FallbackModels": []interface{}{"openai-gpt-oss-120b"},
+	})
+
+	routerUUID = created.ModelRouter.UUID
+	require.NotEmpty(t, routerUUID)
+	require.Equal(t, routerName, created.ModelRouter.Name)
+	require.NotEmpty(t, created.ModelRouter.Config.Policies, "create should persist policies")
+
+	t.Logf("get by uuid %s...", routerUUID)
+	detail := callTool[getModelRouterResponse](t, "genai-inference-router-get", map[string]interface{}{
+		"UUID": routerUUID,
+	})
+	require.Equal(t, routerUUID, detail.ModelRouter.UUID)
+	require.Equal(t, routerName, detail.ModelRouter.Name)
+
+	t.Log("deleting router...")
+	del := callToolInferenceRouterDelete(t, routerUUID)
+	require.Equal(t, routerUUID, del.UUID)
+	routerUUID = ""
+
+	ctx, c := getTestClient(t)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-inference-router-get",
+			Arguments: map[string]interface{}{"UUID": del.UUID},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.IsError, "get after delete should fail")
+}
+
+// TestInferenceRouterDeleteNotFound expects an error when deleting a non-existent router.
+func TestInferenceRouterDeleteNotFound(t *testing.T) {
+	ctx, c := getTestClient(t)
+	fakeUUID := "00000000-0000-0000-0000-000000000099"
+	t.Logf("deleting non-existent router %s...", fakeUUID)
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "genai-inference-router-delete",
+			Arguments: map[string]interface{}{"UUID": fakeUUID},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.IsError, "delete of missing router should error")
+}


### PR DESCRIPTION
### Summary

Add an MCP tool with CRUD operations for inference routers, along with getting the list of task presets to create the router with.

Relevant `godo` client change for reference: https://github.com/digitalocean/godo/pull/1017

| MCP tool | godo call |
|----------|-----------|
| `genai-inference-router-task-presets` | `(*godo.Client).GradientAI.ListInferenceRouterTaskPresets` |
| `genai-inference-router-create` | `(*godo.Client).GradientAI.CreateInferenceRouter` |
| `genai-inference-router-list` | `(*godo.Client).GradientAI.ListInferenceRouters` |
| `genai-inference-router-get` | `(*godo.Client).GradientAI.GetInferenceRouter` |
| `genai-inference-router-update` | `(*godo.Client).GradientAI.UpdateInferenceRouter` |
| `genai-inference-router-delete` | `(*godo.Client).GradientAI.DeleteInferenceRouter` |

### Testing

Tested with `go test`, and also the end to end integration tests file:
```
go test -v -tags=integration ./testing/... -run 'InferenceRouter'
```

Also tested by building the MCP and testing in cursor, here are a few prompts for some operations 

Create
```
## User

can you create me an inference router with a  coding task, and a doc writing task

## Assistant

Creating an inference router with policies for code generation and long-form documentation writing, using preset task slugs and valid models.

### Tool Mcp

{"name":"user-digitalocean-inference-router-genai-inference-router-create","args":{"Name":"coding-and-doc-writing","FallbackModels":["deepseek-v4-pro"],"PoliciesJson":"[{\"task_slug\":\"code-generation\",\"models\":[\"deepseek-4-flash\",\"anthropic-claude-fable-5\",\"deepseek-v4-pro\"],\"selection_policy\":{\"prefer\":\"fastest\"}},{\"task_slug\":\"long-form-article-blog-writing\",\"models\":[\"deepseek-v4-pro\",\"anthropic-claude-fable-5\",\"openai-gpt-5.5\"],\"selection_policy\":{\"prefer\":\"fastest\"}}]"},"toolCallId":"tool_8ad0ec7a-f048-484a-b6be-c1e73dd31e1","providerIdentifier":"digitalocean-inference-router","toolName":"genai-inference-router-create","smartModeApprovalOnly":false,"skipApproval":false}
```

List/get
```
## User

can you list the most recent three created inference routers and what they do

## Assistant

Fetching inference routers and their details. Checking whether the list API returns creation times and full configs.

### Tool Mcp

{"name":"user-digitalocean-inference-router-genai-inference-router-list","args":{"Page":1,"PerPage":1000},"toolCallId":"tool_4d4bc214-beff-41e7-9f97-b2d3eb088f6","providerIdentifier":"digitalocean-inference-router","toolName":"genai-inference-router-list","smartModeApprovalOnly":false,"skipApproval":false}


## Assistant

Fetching full details for each router — the list endpoint doesn't include `created_at`. We'll retrieve each router and sort by creation time.

### Tool Mcp

{"name":"user-digitalocean-inference-router-genai-inference-router-get","args":{"UUID":"11f165c4-da7f-0562-aee4-4e013e2ddde4"},"toolCallId":"tool_4b465ecd-6b65-4cd4-a832-d8ac5f0d394","providerIdentifier":"digitalocean-inference-router","toolName":"genai-inference-router-get","smartModeApprovalOnly":false,"skipApproval":false}

```

Delete
```
## User

can you delete that inference router i just created

### Tool Mcp

{"name":"user-digitalocean-inference-router-genai-inference-router-delete","args":{"UUID":"11f165c4-da7f-0562-aee4-4e013e2ddde4"},"toolCallId":"tool_e2ec9bd1-5e6a-472f-9375-971c10cce1d","providerIdentifier":"digitalocean-inference-router","toolName":"genai-inference-router-delete","smartModeApprovalOnly":false,"skipApproval":false}

```