### PR TITLE
feat(droplet): set explicit MCP tool annotations across all droplet tools

### DIFF
--- a/pkg/registry/droplet/annotations.go
+++ b/pkg/registry/droplet/annotations.go
@@ -2,16 +2,57 @@ package droplet
 
 import "github.com/mark3labs/mcp-go/mcp"
 
-// withHints returns a ToolOption that sets all four standard MCP tool hint
-// annotations explicitly, overriding the mcp-go library defaults (which assume
-// the worst case: not read-only, destructive, not idempotent). Every tool in
-// this package interacts with the DigitalOcean API, so openWorld is always
-// true; we still pass it for clarity and to lock the value down.
-func withHints(readOnly, destructive, idempotent, openWorld bool) mcp.ToolOption {
-	return func(t *mcp.Tool) {
-		mcp.WithReadOnlyHintAnnotation(readOnly)(t)
-		mcp.WithDestructiveHintAnnotation(destructive)(t)
-		mcp.WithIdempotentHintAnnotation(idempotent)(t)
-		mcp.WithOpenWorldHintAnnotation(openWorld)(t)
-	}
+// hints bundles the four standard MCP tool annotation hints — readOnly,
+// destructive, idempotent, openWorld — into a single typed value. Tool
+// registrations should reference one of the profile vars below
+// (hintsRead, hintsAction, hintsToggle, hintsDelete, hintsReplace) rather
+// than constructing a hints literal at the call site; the profile names
+// document the intent at the registration point and make it impossible to
+// swap two bool arguments.
+type hints struct {
+	readOnly, destructive, idempotent, openWorld bool
 }
+
+// apply sets all four MCP tool hint annotations on t, overriding the mcp-go
+// library defaults (which assume the worst case: not read-only, destructive,
+// not idempotent).
+func (h hints) apply(t *mcp.Tool) {
+	mcp.WithReadOnlyHintAnnotation(h.readOnly)(t)
+	mcp.WithDestructiveHintAnnotation(h.destructive)(t)
+	mcp.WithIdempotentHintAnnotation(h.idempotent)(t)
+	mcp.WithOpenWorldHintAnnotation(h.openWorld)(t)
+}
+
+// withHints returns a ToolOption that applies the given hint profile to a
+// tool registration.
+func withHints(h hints) mcp.ToolOption { return h.apply }
+
+// Hint profiles. Every tool in this package falls into one of five
+// categories; openWorld is true on every profile because every tool
+// interacts with the DigitalOcean API.
+//
+// Delete is destructive AND idempotent: repeating a delete on an
+// already-removed resource returns not-found with no additional side
+// effect. Replace (rebuild, restore) is destructive but non-idempotent
+// because each call kicks off a fresh action that replaces droplet state.
+var (
+	// hintsRead — read-only list/get/inspect tools. Idempotent because
+	// observing state again returns the same data.
+	hintsRead = hints{readOnly: true, idempotent: true, openWorld: true}
+
+	// hintsAction — non-destructive mutation that does not converge on a
+	// target state; each call kicks off a fresh action (reboot, snapshot,
+	// password reset, droplet create).
+	hintsAction = hints{openWorld: true}
+
+	// hintsToggle — mutation that converges on a target state. Repeated
+	// calls have no additional effect (power-on twice = still on; rename
+	// to the same name = no-op).
+	hintsToggle = hints{idempotent: true, openWorld: true}
+
+	// hintsDelete — destructive AND idempotent (see package note above).
+	hintsDelete = hints{destructive: true, idempotent: true, openWorld: true}
+
+	// hintsReplace — destructive AND non-idempotent (see package note above).
+	hintsReplace = hints{destructive: true, openWorld: true}
+)

--- a/pkg/registry/droplet/annotations.go
+++ b/pkg/registry/droplet/annotations.go
@@ -1,0 +1,17 @@
+package droplet
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// withHints returns a ToolOption that sets all four standard MCP tool hint
+// annotations explicitly, overriding the mcp-go library defaults (which assume
+// the worst case: not read-only, destructive, not idempotent). Every tool in
+// this package interacts with the DigitalOcean API, so openWorld is always
+// true; we still pass it for clarity and to lock the value down.
+func withHints(readOnly, destructive, idempotent, openWorld bool) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		mcp.WithReadOnlyHintAnnotation(readOnly)(t)
+		mcp.WithDestructiveHintAnnotation(destructive)(t)
+		mcp.WithIdempotentHintAnnotation(idempotent)(t)
+		mcp.WithOpenWorldHintAnnotation(openWorld)(t)
+	}
+}

--- a/pkg/registry/droplet/annotations_test.go
+++ b/pkg/registry/droplet/annotations_test.go
@@ -12,12 +12,8 @@ import (
 // TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
 // changing an annotation in code without updating the row, fails the test.
 //
-// Order: readOnly, destructive, idempotent, openWorld.
-//
-// Delete ops are destructive=true AND idempotent=true: repeating a delete on
-// an already-removed resource returns not-found with no additional side
-// effect. Rebuild/restore are destructive=true but idempotent=false because
-// each call kicks off a fresh action that replaces droplet state.
+// Order: readOnly, destructive, idempotent, openWorld. See annotations.go
+// for the rationale behind the five profile categories these rows map to.
 var expectedAnnotations = map[string]struct {
 	readOnly, destructive, idempotent, openWorld bool
 }{

--- a/pkg/registry/droplet/annotations_test.go
+++ b/pkg/registry/droplet/annotations_test.go
@@ -45,7 +45,7 @@ var expectedAnnotations = map[string]struct {
 	"power-off-droplet":               {false, false, true, true},
 	"shutdown-droplet":                {false, false, true, true},
 	"restore-droplet":                 {false, true, false, true},
-	"resize-droplet":                  {false, false, false, true},
+	"resize-droplet":                  {false, false, true, true},
 	"rebuild-droplet":                 {false, true, false, true},
 	"rename-droplet":                  {false, false, true, true},
 	"change-kernel-droplet":           {false, false, true, true},

--- a/pkg/registry/droplet/annotations_test.go
+++ b/pkg/registry/droplet/annotations_test.go
@@ -13,6 +13,11 @@ import (
 // changing an annotation in code without updating the row, fails the test.
 //
 // Order: readOnly, destructive, idempotent, openWorld.
+//
+// Delete ops are destructive=true AND idempotent=true: repeating a delete on
+// an already-removed resource returns not-found with no additional side
+// effect. Rebuild/restore are destructive=true but idempotent=false because
+// each call kicks off a fresh action that replaces droplet state.
 var expectedAnnotations = map[string]struct {
 	readOnly, destructive, idempotent, openWorld bool
 }{

--- a/pkg/registry/droplet/annotations_test.go
+++ b/pkg/registry/droplet/annotations_test.go
@@ -1,0 +1,121 @@
+package droplet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+}{
+	// droplet_tools.go
+	"droplet-create":             {false, false, false, true},
+	"droplet-delete":             {false, true, true, true},
+	"droplet-enable-private-net": {false, false, true, true},
+	"droplet-kernels":            {true, false, true, true},
+	"droplet-get":                {true, false, true, true},
+	"droplet-backup-policy":      {true, false, true, true},
+	"droplet-action":             {true, false, true, true},
+	"droplet-list":               {true, false, true, true},
+
+	// droplet_actions_tools.go
+	"reboot-droplet":                  {false, false, false, true},
+	"reset-droplet-password":          {false, false, false, true},
+	"rebuild-droplet-by-slug":         {false, true, false, true},
+	"power-cycle-droplets-tag":        {false, false, false, true},
+	"power-on-droplets-tag":           {false, false, true, true},
+	"power-off-droplets-tag":          {false, false, true, true},
+	"shutdown-droplets-tag":           {false, false, true, true},
+	"enable-backups-droplets-tag":     {false, false, true, true},
+	"disable-backups-droplets-tag":    {false, false, true, true},
+	"snapshot-droplets-tag":           {false, false, false, true},
+	"enable-ipv6-droplets-tag":        {false, false, true, true},
+	"enable-private-net-droplets-tag": {false, false, true, true},
+	"power-cycle-droplet":             {false, false, false, true},
+	"power-on-droplet":                {false, false, true, true},
+	"power-off-droplet":               {false, false, true, true},
+	"shutdown-droplet":                {false, false, true, true},
+	"restore-droplet":                 {false, true, false, true},
+	"resize-droplet":                  {false, false, false, true},
+	"rebuild-droplet":                 {false, true, false, true},
+	"rename-droplet":                  {false, false, true, true},
+	"change-kernel-droplet":           {false, false, true, true},
+	"enable-ipv6-droplet":             {false, false, true, true},
+	"enable-backups-droplet":          {false, false, true, true},
+	"disable-backups-droplet":         {false, false, true, true},
+	"snapshot-droplet":                {false, false, false, true},
+
+	// image_actions_tools.go
+	"image-action-transfer": {false, false, true, true},
+	"image-action-convert":  {false, false, true, true},
+	"image-action-get":      {true, false, true, true},
+
+	// images_tools.go
+	"image-list":   {true, false, true, true},
+	"image-get":    {true, false, true, true},
+	"image-create": {false, false, false, true},
+	"image-update": {false, false, true, true},
+	"image-delete": {false, true, true, true},
+
+	// sizes_tools.go
+	"size-list": {true, false, true, true},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewDropletTool(clientFn).Tools()...)
+	all = append(all, NewDropletActionsTool(clientFn).Tools()...)
+	all = append(all, NewImageActionsTool(clientFn).Tools()...)
+	all = append(all, NewImageTool(clientFn).Tools()...)
+	all = append(all, NewSizesTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+	}
+}

--- a/pkg/registry/droplet/droplet_actions_tools.go
+++ b/pkg/registry/droplet/droplet_actions_tools.go
@@ -588,6 +588,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebootDroplet,
 			Tool: mcp.NewTool("reboot-droplet",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Reboot a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to reboot")),
 			),
@@ -595,6 +596,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.passwordResetDroplet,
 			Tool: mcp.NewTool("reset-droplet-password",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Reset password for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -602,6 +604,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebuildByImageSlugDroplet,
 			Tool: mcp.NewTool("rebuild-droplet-by-slug",
+				withHints(false, true, false, true),
 				mcp.WithDescription("Rebuild a droplet using an image slug"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
 				mcp.WithString("ImageSlug", mcp.Required(), mcp.Description("Slug of the image to rebuild from")),
@@ -610,6 +613,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerCycleByTag,
 			Tool: mcp.NewTool("power-cycle-droplets-tag",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Power cycle droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power cycle")),
 			),
@@ -617,6 +621,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOnByTag,
 			Tool: mcp.NewTool("power-on-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Power on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power on")),
 			),
@@ -624,6 +629,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOffByTag,
 			Tool: mcp.NewTool("power-off-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Power off droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power off")),
 			),
@@ -631,6 +637,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.shutdownByTag,
 			Tool: mcp.NewTool("shutdown-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Shutdown droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to shutdown")),
 			),
@@ -638,6 +645,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableBackupsByTag,
 			Tool: mcp.NewTool("enable-backups-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -645,6 +653,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.disableBackupsByTag,
 			Tool: mcp.NewTool("disable-backups-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Disable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -652,6 +661,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.snapshotByTag,
 			Tool: mcp.NewTool("snapshot-droplets-tag",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Take a snapshot of droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the snapshot")),
@@ -660,6 +670,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableIPv6ByTag,
 			Tool: mcp.NewTool("enable-ipv6-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable IPv6 on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -667,6 +678,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enablePrivateNetworkingByTag,
 			Tool: mcp.NewTool("enable-private-net-droplets-tag",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable private networking on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -674,6 +686,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerCycleDroplet,
 			Tool: mcp.NewTool("power-cycle-droplet",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Power cycle a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power cycle")),
 			),
@@ -681,6 +694,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOnDroplet,
 			Tool: mcp.NewTool("power-on-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Power on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power on")),
 			),
@@ -688,6 +702,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOffDroplet,
 			Tool: mcp.NewTool("power-off-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Power off a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power off")),
 			),
@@ -695,6 +710,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.shutdownDroplet,
 			Tool: mcp.NewTool("shutdown-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Shutdown a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to shutdown")),
 			),
@@ -702,6 +718,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.restoreDroplet,
 			Tool: mcp.NewTool("restore-droplet",
+				withHints(false, true, false, true),
 				mcp.WithDescription("Restore a droplet from a backup/snapshot"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to restore")),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the backup/snapshot image")),
@@ -710,6 +727,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.resizeDroplet,
 			Tool: mcp.NewTool("resize-droplet",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Resize a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to resize")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the new size (e.g., s-1vcpu-1gb)")),
@@ -719,6 +737,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebuildDroplet,
 			Tool: mcp.NewTool("rebuild-droplet",
+				withHints(false, true, false, true),
 				mcp.WithDescription("Rebuild a droplet from an image"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image to rebuild from")),
@@ -727,6 +746,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.renameDroplet,
 			Tool: mcp.NewTool("rename-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Rename a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rename")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the droplet")),
@@ -735,6 +755,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.changeKernel,
 			Tool: mcp.NewTool("change-kernel-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Change a droplet's kernel"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 				mcp.WithNumber("KernelID", mcp.Required(), mcp.Description("ID of the kernel to switch to")),
@@ -743,6 +764,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableIPv6,
 			Tool: mcp.NewTool("enable-ipv6-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable IPv6 on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -750,6 +772,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableBackups,
 			Tool: mcp.NewTool("enable-backups-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -757,6 +780,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.disableBackups,
 			Tool: mcp.NewTool("disable-backups-droplet",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Disable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -764,6 +788,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.snapshotDroplet,
 			Tool: mcp.NewTool("snapshot-droplet",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Take a snapshot of a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the snapshot")),

--- a/pkg/registry/droplet/droplet_actions_tools.go
+++ b/pkg/registry/droplet/droplet_actions_tools.go
@@ -727,7 +727,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.resizeDroplet,
 			Tool: mcp.NewTool("resize-droplet",
-				withHints(hintsAction),
+				withHints(hintsToggle),
 				mcp.WithDescription("Resize a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to resize")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the new size (e.g., s-1vcpu-1gb)")),

--- a/pkg/registry/droplet/droplet_actions_tools.go
+++ b/pkg/registry/droplet/droplet_actions_tools.go
@@ -588,7 +588,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebootDroplet,
 			Tool: mcp.NewTool("reboot-droplet",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Reboot a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to reboot")),
 			),
@@ -596,7 +596,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.passwordResetDroplet,
 			Tool: mcp.NewTool("reset-droplet-password",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Reset password for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -604,7 +604,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebuildByImageSlugDroplet,
 			Tool: mcp.NewTool("rebuild-droplet-by-slug",
-				withHints(false, true, false, true),
+				withHints(hintsReplace),
 				mcp.WithDescription("Rebuild a droplet using an image slug"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
 				mcp.WithString("ImageSlug", mcp.Required(), mcp.Description("Slug of the image to rebuild from")),
@@ -613,7 +613,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerCycleByTag,
 			Tool: mcp.NewTool("power-cycle-droplets-tag",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Power cycle droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power cycle")),
 			),
@@ -621,7 +621,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOnByTag,
 			Tool: mcp.NewTool("power-on-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Power on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power on")),
 			),
@@ -629,7 +629,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOffByTag,
 			Tool: mcp.NewTool("power-off-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Power off droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to power off")),
 			),
@@ -637,7 +637,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.shutdownByTag,
 			Tool: mcp.NewTool("shutdown-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Shutdown droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets to shutdown")),
 			),
@@ -645,7 +645,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableBackupsByTag,
 			Tool: mcp.NewTool("enable-backups-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -653,7 +653,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.disableBackupsByTag,
 			Tool: mcp.NewTool("disable-backups-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Disable backups on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -661,7 +661,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.snapshotByTag,
 			Tool: mcp.NewTool("snapshot-droplets-tag",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Take a snapshot of droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the snapshot")),
@@ -670,7 +670,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableIPv6ByTag,
 			Tool: mcp.NewTool("enable-ipv6-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable IPv6 on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -678,7 +678,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enablePrivateNetworkingByTag,
 			Tool: mcp.NewTool("enable-private-net-droplets-tag",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable private networking on droplets by tag"),
 				mcp.WithString("Tag", mcp.Required(), mcp.Description("Tag of the droplets")),
 			),
@@ -686,7 +686,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerCycleDroplet,
 			Tool: mcp.NewTool("power-cycle-droplet",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Power cycle a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power cycle")),
 			),
@@ -694,7 +694,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOnDroplet,
 			Tool: mcp.NewTool("power-on-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Power on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power on")),
 			),
@@ -702,7 +702,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.powerOffDroplet,
 			Tool: mcp.NewTool("power-off-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Power off a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to power off")),
 			),
@@ -710,7 +710,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.shutdownDroplet,
 			Tool: mcp.NewTool("shutdown-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Shutdown a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to shutdown")),
 			),
@@ -718,7 +718,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.restoreDroplet,
 			Tool: mcp.NewTool("restore-droplet",
-				withHints(false, true, false, true),
+				withHints(hintsReplace),
 				mcp.WithDescription("Restore a droplet from a backup/snapshot"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to restore")),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the backup/snapshot image")),
@@ -727,7 +727,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.resizeDroplet,
 			Tool: mcp.NewTool("resize-droplet",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Resize a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to resize")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the new size (e.g., s-1vcpu-1gb)")),
@@ -737,7 +737,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.rebuildDroplet,
 			Tool: mcp.NewTool("rebuild-droplet",
-				withHints(false, true, false, true),
+				withHints(hintsReplace),
 				mcp.WithDescription("Rebuild a droplet from an image"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rebuild")),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image to rebuild from")),
@@ -746,7 +746,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.renameDroplet,
 			Tool: mcp.NewTool("rename-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Rename a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to rename")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the droplet")),
@@ -755,7 +755,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.changeKernel,
 			Tool: mcp.NewTool("change-kernel-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Change a droplet's kernel"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 				mcp.WithNumber("KernelID", mcp.Required(), mcp.Description("ID of the kernel to switch to")),
@@ -764,7 +764,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableIPv6,
 			Tool: mcp.NewTool("enable-ipv6-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable IPv6 on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -772,7 +772,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.enableBackups,
 			Tool: mcp.NewTool("enable-backups-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -780,7 +780,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.disableBackups,
 			Tool: mcp.NewTool("disable-backups-droplet",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Disable backups on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -788,7 +788,7 @@ func (da *DropletActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: da.snapshotDroplet,
 			Tool: mcp.NewTool("snapshot-droplet",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Take a snapshot of a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the snapshot")),

--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -329,7 +329,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.createDroplet,
 			Tool: mcp.NewTool("droplet-create",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Create a new droplet. Supports standard distribution images via ImageID and 1-click marketplace app images via ImageSlug. Exactly one of ImageID or ImageSlug must be provided."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the droplet size (e.g., s-1vcpu-1gb)")),
@@ -345,7 +345,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDroplet,
 			Tool: mcp.NewTool("droplet-delete",
-				withHints(false, true, true, true),
+				withHints(hintsDelete),
 				mcp.WithDescription("Delete a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to delete")),
 			),
@@ -353,7 +353,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.enablePrivateNetworking,
 			Tool: mcp.NewTool("droplet-enable-private-net",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Enable private networking on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -361,7 +361,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletKernels,
 			Tool: mcp.NewTool("droplet-kernels",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Get available kernels for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -369,7 +369,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletByID,
 			Tool: mcp.NewTool("droplet-get",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Get a droplet by its ID"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Droplet ID")),
 			),
@@ -377,7 +377,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletBackupPolicy,
 			Tool: mcp.NewTool("droplet-backup-policy",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Get a droplet's backup policy"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Droplet ID")),
 			),
@@ -385,7 +385,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletActionByID,
 			Tool: mcp.NewTool("droplet-action",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Get a droplet action by droplet ID and action ID"),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("Droplet ID")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("Action ID")),
@@ -394,7 +394,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDroplets,
 			Tool: mcp.NewTool("droplet-list",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("List all droplets for the user. Supports pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(50), mcp.Description("Items per page")),

--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -329,6 +329,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.createDroplet,
 			Tool: mcp.NewTool("droplet-create",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Create a new droplet. Supports standard distribution images via ImageID and 1-click marketplace app images via ImageSlug. Exactly one of ImageID or ImageSlug must be provided."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the droplet size (e.g., s-1vcpu-1gb)")),
@@ -344,6 +345,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDroplet,
 			Tool: mcp.NewTool("droplet-delete",
+				withHints(false, true, true, true),
 				mcp.WithDescription("Delete a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet to delete")),
 			),
@@ -351,6 +353,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.enablePrivateNetworking,
 			Tool: mcp.NewTool("droplet-enable-private-net",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Enable private networking on a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -358,6 +361,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletKernels,
 			Tool: mcp.NewTool("droplet-kernels",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Get available kernels for a droplet"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the droplet")),
 			),
@@ -365,6 +369,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletByID,
 			Tool: mcp.NewTool("droplet-get",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Get a droplet by its ID"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Droplet ID")),
 			),
@@ -372,6 +377,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletBackupPolicy,
 			Tool: mcp.NewTool("droplet-backup-policy",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Get a droplet's backup policy"),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Droplet ID")),
 			),
@@ -379,6 +385,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDropletActionByID,
 			Tool: mcp.NewTool("droplet-action",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Get a droplet action by droplet ID and action ID"),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("Droplet ID")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("Action ID")),
@@ -387,6 +394,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDroplets,
 			Tool: mcp.NewTool("droplet-list",
+				withHints(true, false, true, true),
 				mcp.WithDescription("List all droplets for the user. Supports pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(50), mcp.Description("Items per page")),

--- a/pkg/registry/droplet/image_actions_tools.go
+++ b/pkg/registry/droplet/image_actions_tools.go
@@ -115,6 +115,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.transferImage,
 			Tool: mcp.NewTool(
 				"image-action-transfer",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Transfer an image to another region."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to transfer")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region slug to transfer to (e.g., nyc3)")),
@@ -124,6 +125,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.convertImageToSnapshot,
 			Tool: mcp.NewTool(
 				"image-action-convert",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Convert an image (backup) to a snapshot."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to convert")),
 			),
@@ -132,6 +134,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.getImageAction,
 			Tool: mcp.NewTool(
 				"image-action-get",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Retrieve the status of an image action."),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("ID of the action")),

--- a/pkg/registry/droplet/image_actions_tools.go
+++ b/pkg/registry/droplet/image_actions_tools.go
@@ -115,7 +115,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.transferImage,
 			Tool: mcp.NewTool(
 				"image-action-transfer",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Transfer an image to another region."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to transfer")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region slug to transfer to (e.g., nyc3)")),
@@ -125,7 +125,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.convertImageToSnapshot,
 			Tool: mcp.NewTool(
 				"image-action-convert",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Convert an image (backup) to a snapshot."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to convert")),
 			),
@@ -134,7 +134,7 @@ func (ia *ImageActionsTool) Tools() []server.ServerTool {
 			Handler: ia.getImageAction,
 			Tool: mcp.NewTool(
 				"image-action-get",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Retrieve the status of an image action."),
 				mcp.WithNumber("ImageID", mcp.Required(), mcp.Description("ID of the image")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("ID of the action")),

--- a/pkg/registry/droplet/images_tools.go
+++ b/pkg/registry/droplet/images_tools.go
@@ -228,7 +228,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.listImages,
 			Tool: mcp.NewTool(
 				"image-list",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("List available images (snapshots, backups, distributions, applications)."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultImagesPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultImagesPageSize), mcp.Description("Items per page")),
@@ -239,7 +239,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.getImageByID,
 			Tool: mcp.NewTool(
 				"image-get",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("Get a specific image by its numeric ID."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Image ID")),
 			),
@@ -248,7 +248,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.createImage,
 			Tool: mcp.NewTool(
 				"image-create",
-				withHints(false, false, false, true),
+				withHints(hintsAction),
 				mcp.WithDescription("Create a custom image from a URL (e.g. QCOW2, ISO)."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the new image")),
 				mcp.WithString("Url", mcp.Required(), mcp.Description("URL to import the image from")),
@@ -262,7 +262,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.updateImage,
 			Tool: mcp.NewTool(
 				"image-update",
-				withHints(false, false, true, true),
+				withHints(hintsToggle),
 				mcp.WithDescription("Update an image's name."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Image ID")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the image")),
@@ -272,7 +272,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.deleteImage,
 			Tool: mcp.NewTool(
 				"image-delete",
-				withHints(false, true, true, true),
+				withHints(hintsDelete),
 				mcp.WithDescription("Delete an image or snapshot."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to delete")),
 			),

--- a/pkg/registry/droplet/images_tools.go
+++ b/pkg/registry/droplet/images_tools.go
@@ -228,6 +228,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.listImages,
 			Tool: mcp.NewTool(
 				"image-list",
+				withHints(true, false, true, true),
 				mcp.WithDescription("List available images (snapshots, backups, distributions, applications)."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultImagesPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultImagesPageSize), mcp.Description("Items per page")),
@@ -238,6 +239,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.getImageByID,
 			Tool: mcp.NewTool(
 				"image-get",
+				withHints(true, false, true, true),
 				mcp.WithDescription("Get a specific image by its numeric ID."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Image ID")),
 			),
@@ -246,6 +248,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.createImage,
 			Tool: mcp.NewTool(
 				"image-create",
+				withHints(false, false, false, true),
 				mcp.WithDescription("Create a custom image from a URL (e.g. QCOW2, ISO)."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the new image")),
 				mcp.WithString("Url", mcp.Required(), mcp.Description("URL to import the image from")),
@@ -259,6 +262,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.updateImage,
 			Tool: mcp.NewTool(
 				"image-update",
+				withHints(false, false, true, true),
 				mcp.WithDescription("Update an image's name."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("Image ID")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the image")),
@@ -268,7 +272,7 @@ func (i *ImageTool) Tools() []server.ServerTool {
 			Handler: i.deleteImage,
 			Tool: mcp.NewTool(
 				"image-delete",
-				mcp.WithDestructiveHintAnnotation(true),
+				withHints(false, true, true, true),
 				mcp.WithDescription("Delete an image or snapshot."),
 				mcp.WithNumber("ID", mcp.Required(), mcp.Description("ID of the image to delete")),
 			),

--- a/pkg/registry/droplet/sizes_tools.go
+++ b/pkg/registry/droplet/sizes_tools.go
@@ -81,6 +81,7 @@ func (s *SizesTool) Tools() []server.ServerTool {
 			Handler: s.listSizes,
 			Tool: mcp.NewTool(
 				"size-list",
+				withHints(true, false, true, true),
 				mcp.WithDescription("List all available droplet sizes. Supports pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultSizesPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultSizesPageSize), mcp.Description("Items per page")),

--- a/pkg/registry/droplet/sizes_tools.go
+++ b/pkg/registry/droplet/sizes_tools.go
@@ -81,7 +81,7 @@ func (s *SizesTool) Tools() []server.ServerTool {
 			Handler: s.listSizes,
 			Tool: mcp.NewTool(
 				"size-list",
-				withHints(true, false, true, true),
+				withHints(hintsRead),
 				mcp.WithDescription("List all available droplet sizes. Supports pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultSizesPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultSizesPageSize), mcp.Description("Items per page")),


### PR DESCRIPTION
## Summary

- Populates the four MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) on every tool in `pkg/registry/droplet/` (42 tools across 5 files).
- Adds a `withHints(...)` helper in `pkg/registry/droplet/annotations.go` so the annotation surface lives in one place at each call site.
- Adds a table-driven spec-lock test `TestToolAnnotations` that pins the contract and fails CI if a new tool is added without explicit annotations or an existing annotation drifts.

## Why

the mcp-go library defaults to `{readOnlyHint:false, destructiveHint:true, idempotentHint:false, openWorldHint:true}` for every tool. That misrepresents read-only tools like `droplet-list` to clients — a list operation reported as destructive. Required for our OpenAI ChatGPT MCP connector submission.

## Before / After for `droplet-list`

**Before** (mcp-go defaults):
```json
{
  "readOnlyHint": false,
  "destructiveHint": true,
  "idempotentHint": false,
  "openWorldHint": true
}
```

**After** (verified via live `tools/list` round-trip against the built binary):
```json
{
  "readOnlyHint": true,
  "destructiveHint": false,
  "idempotentHint": true,
  "openWorldHint": true
}
```

Other representative tools, all matching their semantic intent:
- `droplet-delete`: `{ro:false, destructive:true, idempotent:true, openWorld:true}`
- `rebuild-droplet`: `{ro:false, destructive:true, idempotent:false, openWorld:true}`
- `reboot-droplet`: `{ro:false, destructive:false, idempotent:false, openWorld:true}`
- `image-update`: `{ro:false, destructive:false, idempotent:true, openWorld:true}`
- `size-list`: `{ro:true, destructive:false, idempotent:true, openWorld:true}`

## Spec-lock test

`TestToolAnnotations` walks every `Tools()` registration in the package and asserts the four hint pointers are non-nil and match the per-tool expected matrix. It also catches:
- Adding a new tool without an `expectedAnnotations` row (count guard + per-tool lookup)
- Renaming a tool in code without updating the map
- A tool being registered twice (`seen[name]` dedup check)

## Test plan
- [x] `go test ./pkg/registry/droplet/... -run TestToolAnnotations -v` passes
- [x] `go test ./... -count=1` passes across all 25 packages
- [x] `gofmt -l` and `go vet ./pkg/registry/droplet/...` clean
- [x] Live MCP `tools/list` round-trip against the built binary returns the expected annotations for all sampled tools

## Out of scope

`region-list` from `pkg/registry/common/` (registered unconditionally regardless of `--services`) has the same stale-defaults issue. Not fixed here to keep this PR focused on the droplet ask; worth a follow-up for the other registry packages that hit the same library default.