### PR TITLE
add hints to region-list

### DIFF
--- a/cmd/mcp-digitalocean/main.go
+++ b/cmd/mcp-digitalocean/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	mcpName                 = "mcp-digitalocean"
-	mcpVersion              = "1.0.62"
+	mcpVersion              = "1.0.63"
 	wsLoggingContextTimeout = 15 * time.Second
 	// mcpEndpointPath is the path the streamable HTTP server serves the MCP
 	// protocol on. It matches mcp-go's default so existing clients are unaffected.

--- a/pkg/registry/common/region_tools.go
+++ b/pkg/registry/common/region_tools.go
@@ -64,8 +64,11 @@ func (r *RegionTools) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
 			Handler: r.listRegions,
-			Tool: mcp.NewTool(
-				"region-list",
+			Tool: mcp.NewTool("region-list",
+				mcp.WithReadOnlyHintAnnotation(true),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(true),
 				mcp.WithDescription("List all available regions with features and droplet size availability. Supports pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultRegionsPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultRegionsPageSize), mcp.Description("Items per page")),

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/mcp",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "DigitalOcean MCP Implementation,",
   "author": "DigitalOcean",
   "homepage": "https://github.com/digitalocean-labs/mcp-digitalocean?tab=readme-ov-file#mcp-digitalocean-integration",


### PR DESCRIPTION
Override default annotation with explicit read: true, idempotent: true, openworld: true and desstructive: false for `region-list` tool