### PR TITLE
feat(docs): apply common hint profiles to docs tools

### DIFF
--- a/pkg/registry/docs/docs_annotations_test.go
+++ b/pkg/registry/docs/docs_annotations_test.go
@@ -1,0 +1,63 @@
+package docs
+
+import (
+	"testing"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld. All docs tools are
+// read-only lookups against published documentation, so every row maps to
+// the common.HintsRead profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+}{
+	"docs-search":           {true, false, true, false},
+	"docs-get-page":         {true, false, true, false},
+	"docs-find-for-service": {true, false, true, false},
+	"docs-get-quickstart":   {true, false, true, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	all := NewDocsTool().Tools()
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row - add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+	}
+}

--- a/pkg/registry/docs/docs_tools.go
+++ b/pkg/registry/docs/docs_tools.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"mcp-digitalocean/pkg/registry/common"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -177,6 +179,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.searchDocs,
 			Tool: mcp.NewTool(
 				"docs-search",
+				common.WithHints(common.HintsRead),
 				mcp.WithDescription("Full-text search across DigitalOcean documentation. Returns ranked results with title, URL, and content snippet."),
 				mcp.WithString("Query", mcp.Required(), mcp.Description("Search query string")),
 				mcp.WithNumber("Limit", mcp.DefaultNumber(defaultSearchLimit), mcp.Description("Maximum number of results to return")),
@@ -186,6 +189,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.getDoc,
 			Tool: mcp.NewTool(
 				"docs-get-page",
+				common.WithHints(common.HintsRead),
 				mcp.WithDescription("Fetch the full markdown content of a specific DigitalOcean docs page. Returns clean markdown suitable for LLM consumption."),
 				mcp.WithString("URL", mcp.Required(), mcp.Description("Full URL or path of the docs page (e.g., https://docs.digitalocean.com/products/droplets/getting-started/quickstart/ or /products/droplets/getting-started/quickstart/)")),
 			),
@@ -194,6 +198,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.findDocsForService,
 			Tool: mcp.NewTool(
 				"docs-find-for-service",
+				common.WithHints(common.HintsRead),
 				mcp.WithDescription("Given a DigitalOcean service name (e.g., \"droplets\", \"managed kubernetes\", \"app platform\"), return a list of relevant documentation pages with titles and URLs."),
 				mcp.WithString("Service", mcp.Required(), mcp.Description("DigitalOcean service name (e.g., \"droplets\", \"kubernetes\", \"app platform\", \"databases\")")),
 			),
@@ -202,6 +207,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.getQuickstart,
 			Tool: mcp.NewTool(
 				"docs-get-quickstart",
+				common.WithHints(common.HintsRead),
 				mcp.WithDescription("Get the quickstart or getting-started guide for a DigitalOcean service. Returns the full content as clean markdown."),
 				mcp.WithString("Service", mcp.Required(), mcp.Description("DigitalOcean service name (e.g., \"droplets\", \"kubernetes\", \"app platform\")")),
 			),


### PR DESCRIPTION
## Summary

- Apply `common.WithHints(common.HintsRead)` to all four docs tools (docs-search, docs-get-page, docs-find-for-service, docs-get-quickstart). The docs package was not covered when the shared annotations package landed in #388/#390, so these tools still inherit the mcp-go defaults (destructive, not read-only), which causes unnecessary confirmation prompts in MCP clients.
- Add a per-tool annotation contract test to the docs package, mirroring the droplet package's `TestToolAnnotations`. Adding a docs tool without an annotation row, or changing an annotation without updating the row, fails the test.

Supersedes the annotation portion of #360.

## Test plan

- `go test ./pkg/registry/docs/ ./pkg/registry/common/` passes
- Full `go test ./...` passes
- `gofmt` and `go vet` clean