### PR TITLE
feat(docs): improve search ranking with URL and all-terms scoring

### DIFF
--- a/pkg/registry/docs/docs_client.go
+++ b/pkg/registry/docs/docs_client.go
@@ -263,7 +263,9 @@ func (d *DocsClient) FetchDocPage(url string) (string, error) {
 	return cleaned, nil
 }
 
-// SearchIndex searches the docs index using simple text matching with ranking.
+// SearchIndex searches the docs index using text matching with ranked scoring.
+// Scoring considers title, description, section, and URL path segments.
+// Entries matching all query terms are boosted above partial matches.
 func SearchIndex(index *DocsIndex, query string) []DocsEntry {
 	terms := strings.Fields(strings.ToLower(query))
 	if len(terms) == 0 {
@@ -286,11 +288,16 @@ func SearchIndex(index *DocsIndex, query string) []DocsEntry {
 		titleLower := strings.ToLower(entry.Title)
 		descLower := strings.ToLower(entry.Description)
 		sectionLower := strings.ToLower(entry.Section)
+		urlLower := strings.ToLower(entry.URL)
 		score := 0
+		matchedTerms := 0
 
 		for i, term := range terms {
+			termMatched := false
+
 			if strings.Contains(titleLower, term) {
 				score += 10
+				termMatched = true
 			}
 			// Exact word boundary match in title
 			if wordRegexes[i].MatchString(titleLower) {
@@ -298,10 +305,26 @@ func SearchIndex(index *DocsIndex, query string) []DocsEntry {
 			}
 			if strings.Contains(descLower, term) {
 				score += 3
+				termMatched = true
 			}
 			if strings.Contains(sectionLower, term) {
 				score += 2
+				termMatched = true
 			}
+			// Match against URL path segments (e.g., "manage-domains" matches "domain")
+			if strings.Contains(urlLower, term) {
+				score += 4
+				termMatched = true
+			}
+
+			if termMatched {
+				matchedTerms++
+			}
+		}
+
+		// Boost entries that match all query terms
+		if len(terms) > 1 && matchedTerms == len(terms) {
+			score += 15
 		}
 
 		if score > 0 {

--- a/pkg/registry/docs/docs_client_test.go
+++ b/pkg/registry/docs/docs_client_test.go
@@ -116,6 +116,17 @@ func TestSearchIndex(t *testing.T) {
 			query:         "",
 			expectMinimum: 0,
 		},
+		{
+			name:          "matches URL path segments",
+			query:         "quickstart",
+			expectMinimum: 3,
+		},
+		{
+			name:          "all terms boost ranks multi-term match higher",
+			query:         "create droplet",
+			expectMinimum: 1,
+			expectFirst:   "How to Create a Droplet",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- `SearchIndex` now also matches query terms against URL path segments (+4 score), so a query like "domain" matches pages whose URL contains "manage-domains" even when the title does not.
- Entries that match all query terms get a +15 boost, ranking complete matches above partial ones for multi-term queries.
- Adds two test cases to `TestSearchIndex` covering URL segment matching and the all-terms boost.

No new tools or dependencies. Supersedes the search ranking portion of #360.

## Test plan

- `go test ./pkg/registry/docs/` passes, including the two new cases
- Full `go test ./...` passes
- `gofmt` and `go vet` clean