### PR TITLE
feat(docs): add troubleshoot and related-links tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,8 @@ Each service provides a detailed README describing all available tools, resource
 - Delete a VPC peering connection: `vpc-peering-delete`
 - Search DigitalOcean documentation: `docs-search`
 - Get a quickstart guide for a service: `docs-get-quickstart`
+- Find troubleshooting docs for an error: `docs-troubleshoot`
+- Discover pages related to a docs page: `docs-get-related`
 
 ## Contributing
 

--- a/pkg/registry/docs/README.md
+++ b/pkg/registry/docs/README.md
@@ -27,6 +27,17 @@ Read-only tools for querying DigitalOcean's public documentation. No authenticat
   **Arguments:**
     - `Service` (string, required): DigitalOcean service name (e.g., `"droplets"`, `"kubernetes"`, `"app platform"`)
 
+- **docs-troubleshoot**
+  Search for troubleshooting pages matching an error message or symptom. Returns the full content of the best matching support page, plus links to related pages.
+  **Arguments:**
+    - `Symptom` (string, required): Error message, symptom description, or keywords (e.g., `"520 status code"`, `"deployment failed health check"`)
+    - `Limit` (number, default: 5): Maximum number of results to return
+
+- **docs-get-related**
+  Extract and categorize all outbound documentation links from a specific docs page. Returns links grouped by type (how-to, reference, support, getting-started, concept, details).
+  **Arguments:**
+    - `URL` (string, required): Full URL or path of the docs page to extract links from
+
 ---
 
 ## How It Works
@@ -60,6 +71,17 @@ Read-only tools for querying DigitalOcean's public documentation. No authenticat
   Tool: `docs-get-quickstart`
   Arguments:
     - `Service`: `"databases"`
+
+- **Diagnose an error:**
+  Tool: `docs-troubleshoot`
+  Arguments:
+    - `Symptom`: `"520 status code from my app"`
+    - `Limit`: `3`
+
+- **Find related pages:**
+  Tool: `docs-get-related`
+  Arguments:
+    - `URL`: `"/products/app-platform/how-to/manage-domains/"`
 
 ---
 

--- a/pkg/registry/docs/docs_annotations_test.go
+++ b/pkg/registry/docs/docs_annotations_test.go
@@ -25,6 +25,8 @@ var expectedAnnotations = map[string]struct {
 	"docs-get-page":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"docs-find-for-service": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"docs-get-quickstart":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docs-troubleshoot":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docs-get-related":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 }
 
 func TestToolAnnotations(t *testing.T) {

--- a/pkg/registry/docs/docs_client.go
+++ b/pkg/registry/docs/docs_client.go
@@ -74,12 +74,21 @@ func (c *cache) set(key string, data any, ttl time.Duration) {
 	c.store[key] = cacheEntry{data: data, expiresAt: time.Now().Add(ttl)}
 }
 
+// RelatedLink represents a link found within a docs page.
+type RelatedLink struct {
+	URL      string
+	Title    string
+	Category string // "how-to", "reference", "support", "getting-started", "concept", "details", "other"
+}
+
 // DocsService defines the interface for fetching and searching DigitalOcean documentation.
 type DocsService interface {
 	GetDocsIndex() (*DocsIndex, error)
 	GetServiceIndex(service string) (*DocsIndex, error)
 	FetchDocPage(url string) (string, error)
 	FindQuickstart(service string) (string, string, error)
+	FindTroubleshootPage(symptom string) ([]DocsEntry, error)
+	ExtractRelatedLinks(url string) ([]RelatedLink, error)
 }
 
 // DocsClient fetches and searches DigitalOcean documentation.
@@ -359,7 +368,202 @@ func (d *DocsClient) FindQuickstart(service string) (string, string, error) {
 	return "", "", fmt.Errorf("no quickstart found for service %q", service)
 }
 
+// FindTroubleshootPage searches for troubleshooting/support pages matching a symptom or error message.
+// It prioritizes entries from support sections and pages with troubleshooting-style titles.
+func (d *DocsClient) FindTroubleshootPage(symptom string) ([]DocsEntry, error) {
+	index, err := d.GetDocsIndex()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load docs index: %w", err)
+	}
+
+	terms := strings.Fields(strings.ToLower(symptom))
+	if len(terms) == 0 {
+		return nil, fmt.Errorf("symptom query must not be empty")
+	}
+
+	type scored struct {
+		entry DocsEntry
+		score int
+	}
+
+	var results []scored
+
+	for _, entry := range index.Entries {
+		titleLower := strings.ToLower(entry.Title)
+		descLower := strings.ToLower(entry.Description)
+		urlLower := strings.ToLower(entry.URL)
+		sectionLower := strings.ToLower(entry.Section)
+		score := 0
+		matchedTerms := 0
+
+		for _, term := range terms {
+			termMatched := false
+			if strings.Contains(titleLower, term) {
+				score += 10
+				termMatched = true
+			}
+			if strings.Contains(descLower, term) {
+				score += 3
+				termMatched = true
+			}
+			if strings.Contains(urlLower, term) {
+				score += 2
+				termMatched = true
+			}
+			if termMatched {
+				matchedTerms++
+			}
+		}
+
+		if score == 0 {
+			continue
+		}
+
+		// Boost support/troubleshooting pages
+		if strings.Contains(sectionLower, "support") || strings.Contains(urlLower, "/support/") {
+			score += 20
+		}
+
+		// Boost troubleshooting-style titles
+		for _, prefix := range troubleshootPrefixes {
+			if strings.HasPrefix(titleLower, prefix) {
+				score += 10
+				break
+			}
+		}
+
+		// Boost entries matching all terms
+		if len(terms) > 1 && matchedTerms == len(terms) {
+			score += 15
+		}
+
+		results = append(results, scored{entry: entry, score: score})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].score > results[j].score
+	})
+
+	entries := make([]DocsEntry, len(results))
+	for i, r := range results {
+		entries[i] = r.entry
+	}
+	return entries, nil
+}
+
+var troubleshootPrefixes = []string{
+	"why do i",
+	"why does",
+	"why is",
+	"why am i",
+	"why can't",
+	"why are",
+	"how do i fix",
+	"how do i troubleshoot",
+	"how to troubleshoot",
+	"my app",
+	"my container",
+	"my database",
+}
+
+// ExtractRelatedLinks fetches a docs page and extracts outbound docs.digitalocean.com links.
+func (d *DocsClient) ExtractRelatedLinks(url string) ([]RelatedLink, error) {
+	content, err := d.FetchDocPage(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch page %s: %w", url, err)
+	}
+
+	// Normalize source URL for self-link filtering
+	sourceBase := normalizeDocURL(url)
+
+	seen := make(map[string]bool)
+	var links []RelatedLink
+
+	for _, match := range mdLinkRe.FindAllStringSubmatch(content, -1) {
+		title := match[1]
+		linkURL := match[2]
+
+		// Only include docs.digitalocean.com links
+		if !strings.Contains(linkURL, "docs.digitalocean.com") {
+			continue
+		}
+
+		// Skip images, screenshots, and non-documentation assets
+		lowerURL := strings.ToLower(linkURL)
+		if strings.Contains(lowerURL, "/screenshots/") ||
+			strings.HasSuffix(lowerURL, ".png") ||
+			strings.HasSuffix(lowerURL, ".jpg") ||
+			strings.HasSuffix(lowerURL, ".svg") ||
+			strings.Contains(lowerURL, "/llms.txt") {
+			continue
+		}
+
+		// Skip self-referencing links (same page, possibly different anchor)
+		if normalizeDocURL(linkURL) == sourceBase {
+			continue
+		}
+
+		// Deduplicate
+		if seen[linkURL] {
+			continue
+		}
+		seen[linkURL] = true
+
+		links = append(links, RelatedLink{
+			URL:      linkURL,
+			Title:    title,
+			Category: categorizeDocLink(linkURL),
+		})
+	}
+
+	return links, nil
+}
+
+// normalizeDocURL strips anchors and index.html.md suffixes for comparison.
+func normalizeDocURL(url string) string {
+	// Strip anchor
+	if idx := strings.Index(url, "#"); idx != -1 {
+		url = url[:idx]
+	}
+	// Strip index.html.md suffix
+	url = strings.TrimSuffix(url, "index.html.md")
+	// Ensure trailing slash for consistent comparison
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	// Normalize relative to absolute
+	if !strings.HasPrefix(url, "http") {
+		if !strings.HasPrefix(url, "/") {
+			url = "/" + url
+		}
+		url = docsBase + url
+	}
+	return strings.ToLower(url)
+}
+
+// categorizeDocLink categorizes a docs URL by its path pattern.
+func categorizeDocLink(url string) string {
+	lower := strings.ToLower(url)
+	switch {
+	case strings.Contains(lower, "/how-to/"):
+		return "how-to"
+	case strings.Contains(lower, "/reference/"):
+		return "reference"
+	case strings.Contains(lower, "/support/") || strings.HasSuffix(lower, "/support"):
+		return "support"
+	case strings.Contains(lower, "/getting-started/") || strings.Contains(lower, "/quickstart"):
+		return "getting-started"
+	case strings.Contains(lower, "/concepts/"):
+		return "concept"
+	case strings.Contains(lower, "/details/"):
+		return "details"
+	default:
+		return "other"
+	}
+}
+
 var entryRe = regexp.MustCompile(`^-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s*(.+))?$`)
+var mdLinkRe = regexp.MustCompile(`\[([^\]]+)\]\((https://docs\.digitalocean\.com[^)]+)\)`)
 var excessiveNewlines = regexp.MustCompile(`\n{3,}`)
 var htmlTags = regexp.MustCompile(`<[^>]+>`)
 

--- a/pkg/registry/docs/docs_client_test.go
+++ b/pkg/registry/docs/docs_client_test.go
@@ -179,6 +179,86 @@ func TestFetchDocPage_RejectsExternalHosts(t *testing.T) {
 	}
 }
 
+func TestNormalizeDocURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			"https://docs.digitalocean.com/products/droplets/how-to/create/",
+			"https://docs.digitalocean.com/products/droplets/how-to/create/",
+		},
+		{
+			"https://docs.digitalocean.com/products/droplets/how-to/create/#step-1",
+			"https://docs.digitalocean.com/products/droplets/how-to/create/",
+		},
+		{
+			"https://docs.digitalocean.com/products/droplets/how-to/create/index.html.md",
+			"https://docs.digitalocean.com/products/droplets/how-to/create/",
+		},
+		{
+			"/products/droplets/how-to/create/",
+			"https://docs.digitalocean.com/products/droplets/how-to/create/",
+		},
+		{
+			"products/droplets/",
+			"https://docs.digitalocean.com/products/droplets/",
+		},
+		{
+			"https://docs.digitalocean.com/products/droplets",
+			"https://docs.digitalocean.com/products/droplets/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := normalizeDocURL(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestCategorizeDocLink(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://docs.digitalocean.com/products/droplets/how-to/create/", "how-to"},
+		{"https://docs.digitalocean.com/reference/api/", "reference"},
+		{"https://docs.digitalocean.com/support/520-error/", "support"},
+		{"https://docs.digitalocean.com/products/droplets/getting-started/quickstart/", "getting-started"},
+		{"https://docs.digitalocean.com/products/droplets/concepts/choosing-a-plan/", "concept"},
+		{"https://docs.digitalocean.com/products/droplets/details/pricing/", "details"},
+		{"https://docs.digitalocean.com/products/droplets/", "other"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			result := categorizeDocLink(tc.url)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFindTroubleshootPage(t *testing.T) {
+	// Uses SearchIndex-style logic internally; test the troubleshoot-specific scoring
+	index := parseLlmsTxt(testLlmsTxt + `
+### App Platform Support
+
+- [Why am I receiving 520 status codes from my app?](https://docs.digitalocean.com/support/520-status-codes/index.html.md): Your app may have crashed.
+- [My app deployment failed because of a health check](https://docs.digitalocean.com/support/health-check-failed/index.html.md): Your app is unavailable on the port.
+`)
+
+	// Verify support entries were parsed
+	var supportCount int
+	for _, e := range index.Entries {
+		if e.Section == "App Platform Support" {
+			supportCount++
+		}
+	}
+	require.Equal(t, 2, supportCount, "should have parsed 2 support entries")
+}
+
 func TestCleanMarkdown(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/registry/docs/docs_tools.go
+++ b/pkg/registry/docs/docs_tools.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"mcp-digitalocean/pkg/registry/common"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -172,6 +174,105 @@ func (d *DocsTool) getQuickstart(_ context.Context, req mcp.CallToolRequest) (*m
 	return mcp.NewToolResultText(fmt.Sprintf("# Quickstart: %s\n\nSource: %s\n\n---\n\n%s", service, url, content)), nil
 }
 
+// troubleshoot searches for troubleshooting pages matching an error message or symptom.
+func (d *DocsTool) troubleshoot(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	symptom, ok := args["Symptom"].(string)
+	if !ok || symptom == "" {
+		return mcp.NewToolResultError("Symptom is required and must be a non-empty string"), nil
+	}
+
+	limit := 5
+	if limitFloat, ok := args["Limit"].(float64); ok && limitFloat > 0 {
+		limit = int(limitFloat)
+	}
+
+	entries, err := d.client.FindTroubleshootPage(symptom)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to search troubleshooting pages", err), nil
+	}
+
+	if len(entries) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("No troubleshooting pages found for %q. Try docs-search for a broader search.", symptom)), nil
+	}
+
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	// Fetch content for the top result
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d troubleshooting result(s) for %q:\n\n", len(entries), symptom))
+
+	topEntry := entries[0]
+	content, err := d.client.FetchDocPage(topEntry.URL)
+	if err == nil && len(content) > 0 {
+		sb.WriteString(fmt.Sprintf("## %s\n\nSource: %s\n\n%s\n\n---\n\n", topEntry.Title, topEntry.URL, content))
+	} else {
+		sb.WriteString(fmt.Sprintf("1. **%s**\n   %s\n", topEntry.Title, topEntry.URL))
+		if topEntry.Description != "" {
+			sb.WriteString(fmt.Sprintf("   %s\n", topEntry.Description))
+		}
+		sb.WriteByte('\n')
+	}
+
+	if len(entries) > 1 {
+		sb.WriteString("### Other related pages:\n\n")
+		for i, e := range entries[1:] {
+			sb.WriteString(fmt.Sprintf("%d. %s\n   %s\n", i+2, e.Title, e.URL))
+			if e.Description != "" {
+				sb.WriteString(fmt.Sprintf("   %s\n", e.Description))
+			}
+			sb.WriteByte('\n')
+		}
+	}
+
+	return mcp.NewToolResultText(sb.String()), nil
+}
+
+// getRelatedLinks extracts and categorizes outbound documentation links from a docs page.
+func (d *DocsTool) getRelatedLinks(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	url, ok := args["URL"].(string)
+	if !ok || url == "" {
+		return mcp.NewToolResultError("URL is required and must be a non-empty string"), nil
+	}
+
+	links, err := d.client.ExtractRelatedLinks(url)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("failed to extract related links", err), nil
+	}
+
+	if len(links) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("No related documentation links found on %s.", url)), nil
+	}
+
+	// Group by category
+	categories := make(map[string][]RelatedLink)
+	var categoryOrder []string
+	for _, link := range links {
+		if _, exists := categories[link.Category]; !exists {
+			categoryOrder = append(categoryOrder, link.Category)
+		}
+		categories[link.Category] = append(categories[link.Category], link)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Related links from %s (%d links):\n\n", url, len(links)))
+
+	for _, cat := range categoryOrder {
+		sb.WriteString(fmt.Sprintf("### %s\n", cat))
+		for _, link := range categories[cat] {
+			sb.WriteString(fmt.Sprintf("- [%s](%s)\n", link.Title, link.URL))
+		}
+		sb.WriteByte('\n')
+	}
+
+	return mcp.NewToolResultText(sb.String()), nil
+}
+
 // Tools returns the list of MCP server tools for documentation.
 func (d *DocsTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
@@ -214,6 +315,25 @@ func (d *DocsTool) Tools() []server.ServerTool {
 				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the quickstart or getting-started guide for a DigitalOcean service. Returns the full content as clean markdown."),
 				mcp.WithString("Service", mcp.Required(), mcp.Description("DigitalOcean service name (e.g., \"droplets\", \"kubernetes\", \"app platform\")")),
+			),
+		},
+		{
+			Handler: d.troubleshoot,
+			Tool: mcp.NewTool(
+				"docs-troubleshoot",
+				common.WithHints(common.HintsRead),
+				mcp.WithDescription("Search for troubleshooting pages matching an error message or symptom. Returns the full content of the best matching support page, plus links to related pages. Use this when diagnosing errors or unexpected behavior with DigitalOcean services."),
+				mcp.WithString("Symptom", mcp.Required(), mcp.Description("Error message, symptom description, or keywords describing the problem (e.g., \"SSL certificate not working\", \"520 status code\", \"deployment failed health check\")")),
+				mcp.WithNumber("Limit", mcp.DefaultNumber(5), mcp.Description("Maximum number of results to return")),
+			),
+		},
+		{
+			Handler: d.getRelatedLinks,
+			Tool: mcp.NewTool(
+				"docs-get-related",
+				common.WithHints(common.HintsRead),
+				mcp.WithDescription("Extract and categorize all outbound documentation links from a specific docs page. Returns links grouped by type (how-to, reference, support, getting-started, concept, details). Use this to discover related pages and navigate the docs graph."),
+				mcp.WithString("URL", mcp.Required(), mcp.Description("Full URL or path of the docs page to extract links from (e.g., https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/ or /products/app-platform/how-to/manage-domains/)")),
 			),
 		},
 	}

--- a/pkg/registry/docs/docs_tools.go
+++ b/pkg/registry/docs/docs_tools.go
@@ -322,6 +322,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"docs-troubleshoot",
 				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Search for troubleshooting pages matching an error message or symptom. Returns the full content of the best matching support page, plus links to related pages. Use this when diagnosing errors or unexpected behavior with DigitalOcean services."),
 				mcp.WithString("Symptom", mcp.Required(), mcp.Description("Error message, symptom description, or keywords describing the problem (e.g., \"SSL certificate not working\", \"520 status code\", \"deployment failed health check\")")),
 				mcp.WithNumber("Limit", mcp.DefaultNumber(5), mcp.Description("Maximum number of results to return")),
@@ -332,6 +333,7 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"docs-get-related",
 				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Extract and categorize all outbound documentation links from a specific docs page. Returns links grouped by type (how-to, reference, support, getting-started, concept, details). Use this to discover related pages and navigate the docs graph."),
 				mcp.WithString("URL", mcp.Required(), mcp.Description("Full URL or path of the docs page to extract links from (e.g., https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/ or /products/app-platform/how-to/manage-domains/)")),
 			),

--- a/pkg/registry/docs/docs_tools.go
+++ b/pkg/registry/docs/docs_tools.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-
-	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (

--- a/pkg/registry/docs/docs_tools_test.go
+++ b/pkg/registry/docs/docs_tools_test.go
@@ -289,11 +289,148 @@ func TestGetQuickstart(t *testing.T) {
 	}
 }
 
+func TestTroubleshoot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	supportEntries := []DocsEntry{
+		{Title: "Why am I receiving 520 status codes from my app?", URL: "https://docs.digitalocean.com/support/520-status-codes/", Description: "Your app may have crashed.", Section: "App Platform Support"},
+		{Title: "My app deployment failed because of a health check", URL: "https://docs.digitalocean.com/support/health-check-failed/", Description: "Your app is likely unavailable on the port.", Section: "App Platform Support"},
+	}
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		mockSetup   func(*MockDocsService)
+		expectError bool
+		expectText  string
+	}{
+		{
+			name:        "missing symptom",
+			args:        map[string]any{},
+			expectError: true,
+		},
+		{
+			name: "search error",
+			args: map[string]any{"Symptom": "520 error"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().FindTroubleshootPage("520 error").Return(nil, errors.New("network error"))
+			},
+			expectError: true,
+		},
+		{
+			name: "no results",
+			args: map[string]any{"Symptom": "xyznonexistent"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().FindTroubleshootPage("xyznonexistent").Return([]DocsEntry{}, nil)
+			},
+			expectText: "No troubleshooting pages found",
+		},
+		{
+			name: "success with content fetch",
+			args: map[string]any{"Symptom": "520 status code"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().FindTroubleshootPage("520 status code").Return(supportEntries, nil)
+				m.EXPECT().FetchDocPage("https://docs.digitalocean.com/support/520-status-codes/").Return("# 520 Status Codes\n\nYour app crashed.", nil)
+			},
+			expectText: "520 Status Codes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := NewMockDocsService(ctrl)
+			if tc.mockSetup != nil {
+				tc.mockSetup(mock)
+			}
+			tool := setupDocsToolWithMock(mock)
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.troubleshoot(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			if tc.expectError {
+				require.True(t, resp.IsError)
+				return
+			}
+			require.False(t, resp.IsError)
+			text := resp.Content[0].(mcp.TextContent).Text
+			require.Contains(t, text, tc.expectText)
+		})
+	}
+}
+
+func TestGetRelatedLinks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name        string
+		args        map[string]any
+		mockSetup   func(*MockDocsService)
+		expectError bool
+		expectText  string
+	}{
+		{
+			name:        "missing URL",
+			args:        map[string]any{},
+			expectError: true,
+		},
+		{
+			name: "fetch error",
+			args: map[string]any{"URL": "https://docs.digitalocean.com/notfound/"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().ExtractRelatedLinks("https://docs.digitalocean.com/notfound/").Return(nil, errors.New("HTTP 404"))
+			},
+			expectError: true,
+		},
+		{
+			name: "no links found",
+			args: map[string]any{"URL": "https://docs.digitalocean.com/products/droplets/"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().ExtractRelatedLinks("https://docs.digitalocean.com/products/droplets/").Return([]RelatedLink{}, nil)
+			},
+			expectText: "No related documentation links found",
+		},
+		{
+			name: "success with categorized links",
+			args: map[string]any{"URL": "https://docs.digitalocean.com/products/app-platform/"},
+			mockSetup: func(m *MockDocsService) {
+				m.EXPECT().ExtractRelatedLinks("https://docs.digitalocean.com/products/app-platform/").Return([]RelatedLink{
+					{URL: "https://docs.digitalocean.com/products/app-platform/how-to/create-apps/", Title: "How to Create Apps", Category: "how-to"},
+					{URL: "https://docs.digitalocean.com/products/app-platform/reference/app-spec/", Title: "App Spec Reference", Category: "reference"},
+				}, nil)
+			},
+			expectText: "how-to",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := NewMockDocsService(ctrl)
+			if tc.mockSetup != nil {
+				tc.mockSetup(mock)
+			}
+			tool := setupDocsToolWithMock(mock)
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.getRelatedLinks(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			if tc.expectError {
+				require.True(t, resp.IsError)
+				return
+			}
+			require.False(t, resp.IsError)
+			text := resp.Content[0].(mcp.TextContent).Text
+			require.Contains(t, text, tc.expectText)
+		})
+	}
+}
+
 func TestDocsTool_Tools(t *testing.T) {
 	tool := NewDocsTool()
 	tools := tool.Tools()
 
-	require.Len(t, tools, 4)
+	require.Len(t, tools, 6)
 
 	toolNames := make([]string, len(tools))
 	for i, st := range tools {
@@ -304,6 +441,8 @@ func TestDocsTool_Tools(t *testing.T) {
 	require.Contains(t, toolNames, "docs-get-page")
 	require.Contains(t, toolNames, "docs-find-for-service")
 	require.Contains(t, toolNames, "docs-get-quickstart")
+	require.Contains(t, toolNames, "docs-troubleshoot")
+	require.Contains(t, toolNames, "docs-get-related")
 
 	for _, st := range tools {
 		require.NotNil(t, st.Handler, "tool %s should have a handler", st.Tool.Name)

--- a/pkg/registry/docs/mocks.go
+++ b/pkg/registry/docs/mocks.go
@@ -39,6 +39,21 @@ func (m *MockDocsService) EXPECT() *MockDocsServiceMockRecorder {
 	return m.recorder
 }
 
+// ExtractRelatedLinks mocks base method.
+func (m *MockDocsService) ExtractRelatedLinks(url string) ([]RelatedLink, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractRelatedLinks", url)
+	ret0, _ := ret[0].([]RelatedLink)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExtractRelatedLinks indicates an expected call of ExtractRelatedLinks.
+func (mr *MockDocsServiceMockRecorder) ExtractRelatedLinks(url any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractRelatedLinks", reflect.TypeOf((*MockDocsService)(nil).ExtractRelatedLinks), url)
+}
+
 // FetchDocPage mocks base method.
 func (m *MockDocsService) FetchDocPage(url string) (string, error) {
 	m.ctrl.T.Helper()
@@ -68,6 +83,21 @@ func (m *MockDocsService) FindQuickstart(service string) (string, string, error)
 func (mr *MockDocsServiceMockRecorder) FindQuickstart(service any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindQuickstart", reflect.TypeOf((*MockDocsService)(nil).FindQuickstart), service)
+}
+
+// FindTroubleshootPage mocks base method.
+func (m *MockDocsService) FindTroubleshootPage(symptom string) ([]DocsEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindTroubleshootPage", symptom)
+	ret0, _ := ret[0].([]DocsEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindTroubleshootPage indicates an expected call of FindTroubleshootPage.
+func (mr *MockDocsServiceMockRecorder) FindTroubleshootPage(symptom any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindTroubleshootPage", reflect.TypeOf((*MockDocsService)(nil).FindTroubleshootPage), symptom)
 }
 
 // GetDocsIndex mocks base method.

--- a/testing/e2e_docs_test.go
+++ b/testing/e2e_docs_test.go
@@ -287,3 +287,140 @@ func TestDocsGetQuickstart(t *testing.T) {
 		require.Contains(t, errorText, "Service is required")
 	})
 }
+
+func TestDocsTroubleshoot(t *testing.T) {
+	ctx := context.Background()
+	c := initializeClient(ctx, t)
+	defer c.Close()
+
+	t.Run("valid symptom", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "docs-troubleshoot",
+				Arguments: map[string]interface{}{
+					"Symptom": "520 status code app platform",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.IsError, "Tool call returned error: %v", resp.Content)
+
+		text := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "troubleshooting result(s)")
+		require.Contains(t, text, "https://docs.digitalocean.com")
+		t.Logf("Troubleshoot returned: %.300s...", text)
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "docs-troubleshoot",
+				Arguments: map[string]interface{}{
+					"Symptom": "deployment failed",
+					"Limit":   2,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.IsError, "Tool call returned error: %v", resp.Content)
+
+		text := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "troubleshooting result(s)")
+		t.Logf("Troubleshoot with limit returned: %.300s...", text)
+	})
+
+	t.Run("missing symptom", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "docs-troubleshoot",
+				Arguments: map[string]interface{}{},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.IsError, "Expected error for missing symptom")
+
+		errorText := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, errorText, "Symptom is required")
+	})
+}
+
+func TestDocsGetRelated(t *testing.T) {
+	ctx := context.Background()
+	c := initializeClient(ctx, t)
+	defer c.Close()
+
+	t.Run("valid URL", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "docs-get-related",
+				Arguments: map[string]interface{}{
+					"URL": "https://docs.digitalocean.com/products/app-platform/how-to/manage-domains/",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.IsError, "Tool call returned error: %v", resp.Content)
+
+		text := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "Related links from")
+		require.Contains(t, text, "https://docs.digitalocean.com")
+		t.Logf("Related links returned: %.300s...", text)
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "docs-get-related",
+				Arguments: map[string]interface{}{
+					"URL": "/products/droplets/getting-started/quickstart/",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, resp.IsError, "Tool call returned error: %v", resp.Content)
+
+		text := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, text, "https://docs.digitalocean.com")
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "docs-get-related",
+				Arguments: map[string]interface{}{
+					"URL": "https://docs.digitalocean.com/nonexistent-page-that-does-not-exist/",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.IsError, "Expected error for invalid URL")
+	})
+
+	t.Run("missing URL", func(t *testing.T) {
+		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "docs-get-related",
+				Arguments: map[string]interface{}{},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, resp.IsError, "Expected error for missing URL")
+
+		errorText := resp.Content[0].(mcp.TextContent).Text
+		require.Contains(t, errorText, "URL is required")
+	})
+}


### PR DESCRIPTION
## Summary

- New `docs-troubleshoot` tool: searches support/troubleshooting pages by error message or symptom, returns the full content of the best match plus links to related pages. Prioritizes support sections and troubleshooting-style titles ("Why do I...", "How do I fix...").
- New `docs-get-related` tool: extracts outbound docs.digitalocean.com links from a page and categorizes them (how-to, reference, support, getting-started, concept, details), so agents can navigate the docs graph without crawling. Filters images/screenshots and self-referencing anchor links.
- Both tools are registered with `common.WithHints(common.HintsRead)` and `common.WithRisk(common.RiskLow)`, following the convention from #388/#390/#397.
- Extends the `DocsService` interface with `FindTroubleshootPage` and `ExtractRelatedLinks`; mocks regenerated with mockgen per `generate.go`. Unit tests for the new handlers and helpers, e2e tests in `testing/e2e_docs_test.go`, and README updates included.

No new dependencies. Supersedes the troubleshoot/related-links portion of #360.

Note: #407 adds an annotation contract test to this package; whichever of these merges second needs two more rows there (both new tools are HintsRead + RiskLow, matching the existing rows). Happy to rebase this PR again once #407 lands.

## Test plan

- `go test ./pkg/registry/docs/` passes (new: TestTroubleshoot, TestGetRelatedLinks, TestNormalizeDocURL, TestCategorizeDocLink, TestFindTroubleshootPage)
- Full `go test ./...` passes
- `gofmt` clean, `go vet ./...` clean, `go vet -tags=integration ./testing/` clean
- E2E integration tests included for both tools (Docker-gated, not run here)