### PR TITLE
feat(docr): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/docr/docr_annotations_test.go
+++ b/pkg/registry/docr/docr_annotations_test.go
@@ -32,7 +32,7 @@ var expectedAnnotations = map[string]struct {
 	"docr-list":               {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"docr-create":             {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
 	"docr-delete":             {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
-	"docr-docker-credentials": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-docker-credentials": {true, false, true, false, common.OpRead, common.RiskMedium, false, false},
 	"docr-options":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"docr-validate-name":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 

--- a/pkg/registry/docr/docr_annotations_test.go
+++ b/pkg/registry/docr/docr_annotations_test.go
@@ -1,0 +1,132 @@
+package docr
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See pkg/registry/common/annotations.go for
+// the rationale behind the six profile categories these rows map to.
+// permission is not listed per row because it is derived 1:1 from the tool
+// name and asserted generically. risk is set per tool (via common.WithRisk)
+// because it varies within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// registry_tools.go
+	"docr-get":                {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-list":               {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-create":             {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"docr-delete":             {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"docr-docker-credentials": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-options":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-validate-name":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+
+	// repository_tools.go
+	"docr-repository-list":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-repository-tag-list":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-repository-tag-delete":      {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"docr-repository-manifest-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-repository-manifest-delete": {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+
+	// garbage_collection_tools.go
+	"docr-garbage-collection-start":  {false, true, false, false, common.OpUpdate, common.RiskHigh, false, false},
+	"docr-garbage-collection-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-garbage-collection-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-garbage-collection-update": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+
+	// subscription_tools.go
+	"docr-subscription-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docr-subscription-update": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewRegistryTool(clientFn).Tools()...)
+	all = append(all, NewRepositoryTool(clientFn).Tools()...)
+	all = append(all, NewGarbageCollectionTool(clientFn).Tools()...)
+	all = append(all, NewSubscriptionTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/docr/garbage_collection_tools.go
+++ b/pkg/registry/docr/garbage_collection_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -169,6 +171,8 @@ func (g *GarbageCollectionTool) Tools() []server.ServerTool {
 		{
 			Handler: g.startGarbageCollection,
 			Tool: mcp.NewTool("docr-garbage-collection-start",
+				common.WithHints(common.HintsReplace),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Start a garbage collection for a container registry to free up storage"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("Type", mcp.Description("Type of garbage collection to perform (e.g., 'untagged manifests and unreferenced blobs' or 'unreferenced blobs only')")),
@@ -177,6 +181,8 @@ func (g *GarbageCollectionTool) Tools() []server.ServerTool {
 		{
 			Handler: g.getGarbageCollection,
 			Tool: mcp.NewTool("docr-garbage-collection-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the active garbage collection for a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 			),
@@ -184,6 +190,8 @@ func (g *GarbageCollectionTool) Tools() []server.ServerTool {
 		{
 			Handler: g.listGarbageCollections,
 			Tool: mcp.NewTool("docr-garbage-collection-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List garbage collections for a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultGCPage), mcp.Description("Page number")),
@@ -193,6 +201,8 @@ func (g *GarbageCollectionTool) Tools() []server.ServerTool {
 		{
 			Handler: g.updateGarbageCollection,
 			Tool: mcp.NewTool("docr-garbage-collection-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a garbage collection for a container registry (e.g., to cancel it)"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("GarbageCollectionUUID", mcp.Required(), mcp.Description("UUID of the garbage collection to update")),

--- a/pkg/registry/docr/registry_tools.go
+++ b/pkg/registry/docr/registry_tools.go
@@ -243,7 +243,10 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 			Handler: r.dockerCredentials,
 			Tool: mcp.NewTool("docr-docker-credentials",
 				common.WithHints(common.HintsRead),
-				common.WithRisk(common.RiskLow),
+				// Read-only (does not mutate the registry) but mints Docker
+				// credentials that can grant write access when ReadWrite=true,
+				// so the blast radius is medium, not low.
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Get Docker credentials for a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithBoolean("ReadWrite", mcp.Description("Whether the credentials should have read-write access (default: false, read-only)")),

--- a/pkg/registry/docr/registry_tools.go
+++ b/pkg/registry/docr/registry_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // RegistryTool provides container registry management tools
@@ -203,6 +205,8 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.get,
 			Tool: mcp.NewTool("docr-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a container registry by name"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 			),
@@ -210,12 +214,16 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.list,
 			Tool: mcp.NewTool("docr-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all container registries"),
 			),
 		},
 		{
 			Handler: r.create,
 			Tool: mcp.NewTool("docr-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new container registry"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("SubscriptionTierSlug", mcp.Description("Subscription tier slug (e.g., 'starter', 'basic', 'professional')")),
@@ -225,6 +233,8 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.delete,
 			Tool: mcp.NewTool("docr-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry to delete")),
 			),
@@ -232,6 +242,8 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.dockerCredentials,
 			Tool: mcp.NewTool("docr-docker-credentials",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get Docker credentials for a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithBoolean("ReadWrite", mcp.Description("Whether the credentials should have read-write access (default: false, read-only)")),
@@ -241,12 +253,16 @@ func (r *RegistryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.getOptions,
 			Tool: mcp.NewTool("docr-options",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get available container registry options including subscription tiers and regions"),
 			),
 		},
 		{
 			Handler: r.validateName,
 			Tool: mcp.NewTool("docr-validate-name",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Check if a container registry name is available"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name to validate for availability")),
 			),

--- a/pkg/registry/docr/repository_tools.go
+++ b/pkg/registry/docr/repository_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -240,6 +242,8 @@ func (r *RepositoryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.listRepositories,
 			Tool: mcp.NewTool("docr-repository-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List repositories in a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultRepoPage), mcp.Description("Page number")),
@@ -250,6 +254,8 @@ func (r *RepositoryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.listRepositoryTags,
 			Tool: mcp.NewTool("docr-repository-tag-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List tags for a repository in a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("Repository", mcp.Required(), mcp.Description("Name of the repository")),
@@ -260,6 +266,8 @@ func (r *RepositoryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.deleteTag,
 			Tool: mcp.NewTool("docr-repository-tag-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a tag from a repository in a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("Repository", mcp.Required(), mcp.Description("Name of the repository")),
@@ -269,6 +277,8 @@ func (r *RepositoryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.listRepositoryManifests,
 			Tool: mcp.NewTool("docr-repository-manifest-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List manifests for a repository in a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("Repository", mcp.Required(), mcp.Description("Name of the repository")),
@@ -279,6 +289,8 @@ func (r *RepositoryTool) Tools() []server.ServerTool {
 		{
 			Handler: r.deleteManifest,
 			Tool: mcp.NewTool("docr-repository-manifest-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a manifest from a repository in a container registry"),
 				mcp.WithString("RegistryName", mcp.Required(), mcp.Description("Name of the container registry")),
 				mcp.WithString("Repository", mcp.Required(), mcp.Description("Name of the repository")),

--- a/pkg/registry/docr/subscription_tools.go
+++ b/pkg/registry/docr/subscription_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // SubscriptionTool provides container registry subscription management tools
@@ -75,12 +77,16 @@ func (s *SubscriptionTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getSubscription,
 			Tool: mcp.NewTool("docr-subscription-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the current container registry subscription information"),
 			),
 		},
 		{
 			Handler: s.updateSubscription,
 			Tool: mcp.NewTool("docr-subscription-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the container registry subscription tier"),
 				mcp.WithString("TierSlug", mcp.Required(), mcp.Description("Subscription tier slug to update to (e.g., 'starter', 'basic', 'professional')")),
 			),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below — you are tagged as the `docr` service owner/POC.
>
> cc @nayanjd-do (POC, Nayan Das) — could not add as a formal GitHub reviewer (the account is not a collaborator on this public repo), so tagging here instead.

## What this does

Applies the shared annotation profiles to **every `docr` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, `docr` tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`docr_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list/describe is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → can delete or overwrite data in a hard/impossible-to-undo way (e.g. "delete a registry", "delete a tag"); `false` → additive/reversible only.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Toggles and deletes are idempotent; fresh actions/creates are not.
- **`openWorld`** — `true` → touches external/unbounded systems (web search, third-party APIs); `false` → closed, well-defined domain. Almost all DO resource tools are `false`.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius, not operation type: **low** = reads and reversible toggles; **medium** = single-resource mutation that interrupts/reconfigures but is recoverable, or incurs cost; **high** = irreversible/data-losing (delete), acts on many resources at once, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `docr-get` | Read | read | – | ✓ | low |
| `docr-list` | Read | read | – | ✓ | low |
| `docr-create` | Create | create | – | – | medium |
| `docr-delete` | Delete | delete | ✓ | ✓ | high |
| `docr-docker-credentials` | Read | read | – | ✓ | medium |
| `docr-options` | Read | read | – | ✓ | low |
| `docr-validate-name` | Read | read | – | ✓ | low |
| `docr-repository-list` | Read | read | – | ✓ | low |
| `docr-repository-tag-list` | Read | read | – | ✓ | low |
| `docr-repository-tag-delete` | Delete | delete | ✓ | ✓ | high |
| `docr-repository-manifest-list` | Read | read | – | ✓ | low |
| `docr-repository-manifest-delete` | Delete | delete | ✓ | ✓ | high |
| `docr-garbage-collection-start` | Replace | update | ✓ | – | high |
| `docr-garbage-collection-get` | Read | read | – | ✓ | low |
| `docr-garbage-collection-list` | Read | read | – | ✓ | low |
| `docr-garbage-collection-update` | Toggle | update | – | ✓ | low |
| `docr-subscription-get` | Read | read | – | ✓ | low |
| `docr-subscription-update` | Toggle | update | – | ✓ | medium |

## Points of clarification (please confirm)

1. **`docr-docker-credentials`** — **Read / medium** (updated per @AKatruwar's review). It stays read-only (does not mutate registry state) but issues Docker credentials that can grant *write* access via `ReadWrite: true`, so risk is medium rather than low.
2. **`docr-garbage-collection-start`** — classified **Replace / high** (destructive, non-idempotent). GC permanently deletes untagged manifests / unreferenced blobs to free storage, so we treated it as destructive+irreversible rather than a plain create/action. Confirm this is the intended treatment.
3. **`docr-subscription-update`** — classified **Toggle / medium**. Changing the subscription tier has billing implications but is reversible and single-resource, hence medium (not low). Confirm.
4. **`docr-create`** — **Create / medium** (provisions a paid resource, reversible via delete). Confirm medium vs low.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/docr/...`, `go test ./pkg/registry/docr/...` — all pass.
- `gofmt` clean.
