### PR TITLE
feat(docs): annotate tools with risk classification (supersedes #403)

### DIFF
--- a/pkg/registry/docs/docs_annotations_test.go
+++ b/pkg/registry/docs/docs_annotations_test.go
@@ -1,0 +1,97 @@
+package docs
+
+import (
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. All docs tools are read-only lookups against
+// published DigitalOcean documentation, so every row maps to the
+// common.HintsRead profile at low risk.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	"docs-search":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docs-get-page":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docs-find-for-service": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"docs-get-quickstart":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	all := NewDocsTool().Tools()
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/docs/docs_tools.go
+++ b/pkg/registry/docs/docs_tools.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -177,6 +179,8 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.searchDocs,
 			Tool: mcp.NewTool(
 				"docs-search",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Full-text search across DigitalOcean documentation. Returns ranked results with title, URL, and content snippet."),
 				mcp.WithString("Query", mcp.Required(), mcp.Description("Search query string")),
 				mcp.WithNumber("Limit", mcp.DefaultNumber(defaultSearchLimit), mcp.Description("Maximum number of results to return")),
@@ -186,6 +190,8 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.getDoc,
 			Tool: mcp.NewTool(
 				"docs-get-page",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Fetch the full markdown content of a specific DigitalOcean docs page. Returns clean markdown suitable for LLM consumption."),
 				mcp.WithString("URL", mcp.Required(), mcp.Description("Full URL or path of the docs page (e.g., https://docs.digitalocean.com/products/droplets/getting-started/quickstart/ or /products/droplets/getting-started/quickstart/)")),
 			),
@@ -194,6 +200,8 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.findDocsForService,
 			Tool: mcp.NewTool(
 				"docs-find-for-service",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Given a DigitalOcean service name (e.g., \"droplets\", \"managed kubernetes\", \"app platform\"), return a list of relevant documentation pages with titles and URLs."),
 				mcp.WithString("Service", mcp.Required(), mcp.Description("DigitalOcean service name (e.g., \"droplets\", \"kubernetes\", \"app platform\", \"databases\")")),
 			),
@@ -202,6 +210,8 @@ func (d *DocsTool) Tools() []server.ServerTool {
 			Handler: d.getQuickstart,
 			Tool: mcp.NewTool(
 				"docs-get-quickstart",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the quickstart or getting-started guide for a DigitalOcean service. Returns the full content as clean markdown."),
 				mcp.WithString("Service", mcp.Required(), mcp.Description("DigitalOcean service name (e.g., \"droplets\", \"kubernetes\", \"app platform\")")),
 			),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. 

## Relationship to #403 (please read)

#403 sets `common.WithHints(common.HintsRead)` on the four docs tools. This PR **reuses those exact hint values** but also adds  the per-tool **`risk`** classification (`common.WithRisk(common.RiskLow)`). It also adds the `operation`/`permission`/`parallelizable`/`streamingSafe` `_meta` assertions to the contract test.



**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact `WithHints` + `WithRisk` + inline-struct contract test pattern.

## What this does

Applies `common.WithHints(common.HintsRead)` + `common.WithRisk(common.RiskLow)` to all four docs tools so each carries explicit MCP hints (`readOnly`/`destructive`/`idempotent`/`openWorld`) and tool-registry `_meta` (`operation`, `risk`, `permission`, `parallelizable`, `streamingSafe`) instead of the mcp-go worst-case defaults (`destructive`, not `readOnly`), which otherwise trigger unnecessary confirmation prompts. Adds a contract test mirroring the droplet package.

## Field definitions (please classify against these)

- **`readOnly`** — side-effect free? get/search/describe = read-only.
- **`destructive`** — (only if not read-only) can it delete/overwrite data hard-to-undo? All docs tools: no.
- **`idempotent`** — repeating converges with no extra effect? Reads: yes.
- **`openWorld`** — touches external/unbounded systems (third-party APIs)? These read **DigitalOcean's own published docs corpus**, treated as a closed domain → `false`.
- **`operation`** — `read`.
- **`risk`** — blast radius. Reads are **low**.

## Classification in this PR

| Tool | Profile | operation | readOnly | risk |
|---|---|---|---|---|
| `docs-search` | Read | read | ✓ | low |
| `docs-get-page` | Read | read | ✓ | low |
| `docs-find-for-service` | Read | read | ✓ | low |
| `docs-get-quickstart` | Read | read | ✓ | low |

## Points of clarification (please confirm)

1. **`openWorld = false` for all four.** These tools search/fetch DigitalOcean documentation. We treated the docs corpus as a closed, DO-owned domain (`false`), consistent with other DO resource tools. If you consider docs lookups to hit an "open world" (e.g. arbitrary external fetch), we can revisit — but note none of the six shared hint profiles currently set `openWorld = true`.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/docs/...`, `go test ./pkg/registry/docs/...` — all pass.
- `gofmt` clean.
