### PR TITLE
feat(functions): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/functions/action_tools.go
+++ b/pkg/registry/functions/action_tools.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type ActionTool struct {
@@ -271,6 +273,8 @@ func (t *ActionTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listActions,
 			Tool: mcp.NewTool("functions-list-actions",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all actions in a DigitalOcean Functions namespace. Returns action metadata including name, namespace, version, and limits."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace (from functions-list-namespaces)")),
 				mcp.WithNumber("Limit", mcp.Description("Number of actions to return (0-200, default 30). Use 0 for maximum.")),
@@ -280,6 +284,8 @@ func (t *ActionTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getAction,
 			Tool: mcp.NewTool("functions-get-action",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get detailed information about a specific action in a DigitalOcean Functions namespace, including its configuration and optionally its source code."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActionName", mcp.Required(), mcp.Description("The name of the action")),
@@ -290,6 +296,8 @@ func (t *ActionTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createOrUpdateAction,
 			Tool: mcp.NewTool("functions-create-or-update-action",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create or update an action in a DigitalOcean Functions namespace. If the action already exists it will be overwritten."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActionName", mcp.Required(), mcp.Description("The name of the action to create or update")),
@@ -309,16 +317,19 @@ func (t *ActionTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deleteAction,
 			Tool: mcp.NewTool("functions-delete-action",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete an action from a DigitalOcean Functions namespace."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActionName", mcp.Required(), mcp.Description("The name of the action to delete")),
 				mcp.WithString("PackageName", mcp.Description("The package containing the action, if applicable")),
-				mcp.WithDestructiveHintAnnotation(true),
 			),
 		},
 		{
 			Handler: t.invokeAction,
 			Tool: mcp.NewTool("functions-invoke-action",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Invoke a function action in a DigitalOcean Functions namespace. By default this is a blocking invocation that waits for the result."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActionName", mcp.Required(), mcp.Description("The name of the action to invoke")),

--- a/pkg/registry/functions/activation_tools.go
+++ b/pkg/registry/functions/activation_tools.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type ActivationTool struct {
@@ -164,6 +166,8 @@ func (t *ActivationTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listActivations,
 			Tool: mcp.NewTool("functions-list-activations",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List activations (invocation records) for a DigitalOcean Functions namespace. Activations record every function invocation with timing, status, and optional response data."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace (from functions-list-namespaces)")),
 				mcp.WithString("FunctionName", mcp.Description("Filter activations by function name")),
@@ -177,6 +181,8 @@ func (t *ActivationTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getActivation,
 			Tool: mcp.NewTool("functions-get-activation",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the full activation record for a specific function invocation, including response, logs, timing, and status."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActivationID", mcp.Required(), mcp.Description("The activation ID")),
@@ -185,6 +191,8 @@ func (t *ActivationTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getActivationLogs,
 			Tool: mcp.NewTool("functions-get-activation-logs",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get only the logs for a specific function activation. Useful for debugging function execution."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActivationID", mcp.Required(), mcp.Description("The activation ID")),
@@ -193,6 +201,8 @@ func (t *ActivationTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getActivationResult,
 			Tool: mcp.NewTool("functions-get-activation-result",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get only the result of a specific function activation. Returns the function's return value and status."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("ActivationID", mcp.Required(), mcp.Description("The activation ID")),

--- a/pkg/registry/functions/deployment_guide_tool.go
+++ b/pkg/registry/functions/deployment_guide_tool.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 //go:embed DEPLOY_SPEC.md
@@ -32,6 +34,8 @@ func (t *DeploymentGuideTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getDeploymentGuide,
 			Tool: mcp.NewTool("functions-deployment-guide",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription(
 					"Return the authoritative step-by-step guide for deploying a DigitalOcean "+
 						"Functions project from a local directory using `doctl serverless deploy`. "+
@@ -60,7 +64,6 @@ func (t *DeploymentGuideTool) Tools() []server.ServerTool {
 						"The returned content is markdown. Follow its instructions exactly; do not "+
 						"paraphrase the steps to the user.",
 				),
-				mcp.WithReadOnlyHintAnnotation(true),
 			),
 		},
 	}

--- a/pkg/registry/functions/functions_annotations_test.go
+++ b/pkg/registry/functions/functions_annotations_test.go
@@ -1,0 +1,147 @@
+package functions
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// namespace_tools.go
+	"functions-list-namespaces":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-namespace":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-create-namespace":  {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"functions-delete-namespace":  {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"functions-list-access-keys":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-create-access-key": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"functions-delete-access-key": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// trigger_tools.go
+	"functions-list-triggers":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-trigger":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-create-trigger": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"functions-update-trigger": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"functions-delete-trigger": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// action_tools.go
+	"functions-list-actions":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-action":              {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-create-or-update-action": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"functions-delete-action":           {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"functions-invoke-action":           {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// package_tools.go
+	"functions-list-packages":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-package":              {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-create-or-update-package": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"functions-delete-package":           {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+
+	// activation_tools.go
+	"functions-list-activations":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-activation":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-activation-logs":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"functions-get-activation-result": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+
+	// deployment_guide_tool.go
+	"functions-deployment-guide": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+	resolver := NewOWResolver(clientFn)
+
+	var all []server.ServerTool
+	all = append(all, NewNamespaceTool(clientFn).Tools()...)
+	all = append(all, NewTriggerTool(clientFn).Tools()...)
+	all = append(all, NewActionTool(resolver).Tools()...)
+	all = append(all, NewPackageTool(resolver).Tools()...)
+	all = append(all, NewActivationTool(resolver).Tools()...)
+	all = append(all, NewDeploymentGuideTool().Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/functions/namespace_tools.go
+++ b/pkg/registry/functions/namespace_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type NamespaceTool struct {
@@ -197,12 +199,16 @@ func (t *NamespaceTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listNamespaces,
 			Tool: mcp.NewTool("functions-list-namespaces",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all DigitalOcean Functions namespaces. Returns namespace metadata including api_host, region, label, and UUID."),
 			),
 		},
 		{
 			Handler: t.getNamespace,
 			Tool: mcp.NewTool("functions-get-namespace",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a DigitalOcean Functions namespace by ID. Returns full namespace details including api_host and key for data plane access."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 			),
@@ -210,6 +216,8 @@ func (t *NamespaceTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createNamespace,
 			Tool: mcp.NewTool("functions-create-namespace",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new DigitalOcean Functions namespace."),
 				mcp.WithString("Label", mcp.Required(), mcp.Description("A human-readable label for the namespace")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("The region slug where the namespace will be created (e.g. nyc1, sfo1)")),
@@ -218,14 +226,17 @@ func (t *NamespaceTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deleteNamespace,
 			Tool: mcp.NewTool("functions-delete-namespace",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a DigitalOcean Functions namespace. This permanently removes the namespace and all its functions, packages, and triggers."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace to delete")),
-				mcp.WithDestructiveHintAnnotation(true),
 			),
 		},
 		{
 			Handler: t.listAccessKeys,
 			Tool: mcp.NewTool("functions-list-access-keys",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List access keys for a DigitalOcean Functions namespace. Returns metadata only (name, id, creation/expiry timestamps) — secret values are NOT returned and cannot be retrieved once a key has been created.\n\nKeys whose names start with `mcp-do-` are reserved for this MCP server's own internal use. They are managed automatically and must not be deleted by agents."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 			),
@@ -233,6 +244,8 @@ func (t *NamespaceTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createAccessKey,
 			Tool: mcp.NewTool("functions-create-access-key",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create an access key for a DigitalOcean Functions namespace. The returned secret appears only in this response and cannot be retrieved later — store it immediately.\n\nAccess keys are credentials for programmatic access to a namespace's OpenWhisk data plane and are typically used by third-party tooling or CI. Agents should not need to call this tool as part of normal deploy or CRUD flows — the MCP server manages its own data-plane auth internally, and `doctl serverless connect <hint>` uses the user's existing DigitalOcean API token. Only call this tool when the user explicitly asks for an access key.\n\nPrefix rules:\n- The prefix `mcp-do-` is reserved for the MCP server's internal use. Never create keys with this prefix; any you do create will be auto-deleted on the next MCP call that touches the namespace.\n- For any other key you create on behalf of the user, pick a descriptive name they can recognize later.\n- Always set `ExpiresIn` to a bounded value (e.g. `\"24h\"`) unless the user explicitly asks for a non-expiring key; access keys count toward a 200-per-account limit.\n\nRequires the `function:admin` scope on the caller's API token."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("A name for the access key. Never use the `mcp-do-` prefix — it is reserved for the MCP server.")),
@@ -242,10 +255,11 @@ func (t *NamespaceTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deleteAccessKey,
 			Tool: mcp.NewTool("functions-delete-access-key",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete an access key for a DigitalOcean Functions namespace. This is irreversible — once deleted, the key's secret can never be used again.\n\nDo NOT delete keys whose names start with `mcp-do-` — those are managed by the MCP server itself. Deleting them causes unnecessary API churn as the server will recreate them on the next use.\n\nDo NOT delete keys with any other name prefix without explicit user consent — those belong to the user or to other tooling."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("KeyID", mcp.Required(), mcp.Description("The ID of the access key to delete")),
-				mcp.WithDestructiveHintAnnotation(true),
 			),
 		},
 	}

--- a/pkg/registry/functions/package_tools.go
+++ b/pkg/registry/functions/package_tools.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type PackageTool struct {
@@ -172,6 +174,8 @@ func (t *PackageTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listPackages,
 			Tool: mcp.NewTool("functions-list-packages",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all packages in a DigitalOcean Functions namespace. Packages group related actions together."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace (from functions-list-namespaces)")),
 				mcp.WithNumber("Limit", mcp.Description("Number of packages to return (0-200, default 30). Use 0 for maximum.")),
@@ -182,6 +186,8 @@ func (t *PackageTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getPackage,
 			Tool: mcp.NewTool("functions-get-package",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get detailed information about a specific package in a DigitalOcean Functions namespace, including its actions, parameters, and annotations."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("PackageName", mcp.Required(), mcp.Description("The name of the package")),
@@ -190,6 +196,8 @@ func (t *PackageTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createOrUpdatePackage,
 			Tool: mcp.NewTool("functions-create-or-update-package",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create or update a package in a DigitalOcean Functions namespace. Packages are used to group related actions."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("PackageName", mcp.Required(), mcp.Description("The name of the package to create or update")),
@@ -202,11 +210,12 @@ func (t *PackageTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deletePackage,
 			Tool: mcp.NewTool("functions-delete-package",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a package from a DigitalOcean Functions namespace."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("PackageName", mcp.Required(), mcp.Description("The name of the package to delete")),
 				mcp.WithBoolean("Force", mcp.Description("Force delete the package even if it contains actions. Default is false.")),
-				mcp.WithDestructiveHintAnnotation(true),
 			),
 		},
 	}

--- a/pkg/registry/functions/trigger_tools.go
+++ b/pkg/registry/functions/trigger_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type TriggerTool struct {
@@ -205,6 +207,8 @@ func (t *TriggerTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listTriggers,
 			Tool: mcp.NewTool("functions-list-triggers",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all triggers for a DigitalOcean Functions namespace."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 			),
@@ -212,6 +216,8 @@ func (t *TriggerTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getTrigger,
 			Tool: mcp.NewTool("functions-get-trigger",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a specific trigger in a DigitalOcean Functions namespace."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("TriggerName", mcp.Required(), mcp.Description("The name of the trigger")),
@@ -220,6 +226,8 @@ func (t *TriggerTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createTrigger,
 			Tool: mcp.NewTool("functions-create-trigger",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a scheduled trigger for a function in a DigitalOcean Functions namespace. Currently only SCHEDULED type triggers are supported."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("A name for the trigger")),
@@ -232,6 +240,8 @@ func (t *TriggerTool) Tools() []server.ServerTool {
 		{
 			Handler: t.updateTrigger,
 			Tool: mcp.NewTool("functions-update-trigger",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a trigger in a DigitalOcean Functions namespace. You can enable/disable the trigger or change the cron schedule."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("TriggerName", mcp.Required(), mcp.Description("The name of the trigger to update")),
@@ -243,10 +253,11 @@ func (t *TriggerTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deleteTrigger,
 			Tool: mcp.NewTool("functions-delete-trigger",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a trigger from a DigitalOcean Functions namespace."),
 				mcp.WithString("NamespaceID", mcp.Required(), mcp.Description("The UUID of the namespace")),
 				mcp.WithString("TriggerName", mcp.Required(), mcp.Description("The name of the trigger to delete")),
-				mcp.WithDestructiveHintAnnotation(true),
 			),
 		},
 	}


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below — you are tagged as the `functions` service owner/POC.

## What this does

Applies the shared annotation profiles to **every `functions` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, `functions` tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

This also **replaces the ad-hoc inline hints** that were previously set on a few tools (`mcp.WithDestructiveHintAnnotation(true)` on the delete tools, `mcp.WithReadOnlyHintAnnotation(true)` on `functions-deployment-guide`) with the shared profiles, so all tools are annotated consistently and completely (the inline hints only set one bool each and left the registry `_meta` unset).

A per-tool contract test (`functions_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list/describe is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → can delete or overwrite data in a hard/impossible-to-undo way (e.g. "delete a namespace", "delete an action"); `false` → additive/reversible only.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Toggles and deletes are idempotent; fresh actions/creates/invocations are not.
- **`openWorld`** — `true` → touches external/unbounded systems (web search, third-party APIs); `false` → closed, well-defined domain. All `functions` tools are `false`.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius, not operation type: **low** = reads and reversible toggles; **medium** = single-resource mutation that interrupts/reconfigures but is recoverable, or incurs cost; **high** = irreversible/data-losing (delete), acts on many resources at once, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `functions-list-namespaces` | Read | read | – | ✓ | low |
| `functions-get-namespace` | Read | read | – | ✓ | low |
| `functions-create-namespace` | Create | create | – | – | medium |
| `functions-delete-namespace` | Delete | delete | ✓ | ✓ | high |
| `functions-list-access-keys` | Read | read | – | ✓ | low |
| `functions-create-access-key` | Create | create | – | – | medium |
| `functions-delete-access-key` | Delete | delete | ✓ | ✓ | medium |
| `functions-list-triggers` | Read | read | – | ✓ | low |
| `functions-get-trigger` | Read | read | – | ✓ | low |
| `functions-create-trigger` | Create | create | – | – | low |
| `functions-update-trigger` | Toggle | update | – | ✓ | low |
| `functions-delete-trigger` | Delete | delete | ✓ | ✓ | medium |
| `functions-list-actions` | Read | read | – | ✓ | low |
| `functions-get-action` | Read | read | – | ✓ | low |
| `functions-create-or-update-action` | Toggle | update | – | ✓ | medium |
| `functions-delete-action` | Delete | delete | ✓ | ✓ | high |
| `functions-invoke-action` | Action | update | – | – | medium |
| `functions-list-packages` | Read | read | – | ✓ | low |
| `functions-get-package` | Read | read | – | ✓ | low |
| `functions-create-or-update-package` | Toggle | update | – | ✓ | low |
| `functions-delete-package` | Delete | delete | ✓ | ✓ | high |
| `functions-list-activations` | Read | read | – | ✓ | low |
| `functions-get-activation` | Read | read | – | ✓ | low |
| `functions-get-activation-logs` | Read | read | – | ✓ | low |
| `functions-get-activation-result` | Read | read | – | ✓ | low |
| `functions-deployment-guide` | Read | read | – | ✓ | low |

## Points of clarification (please check)

1. **`functions-create-or-update-action`** and **`functions-create-or-update-package`** — classified as **Toggle** (idempotent `update`), because they are upserts (`overwrite=true`): re-applying the same definition converges to the same state. They can also *create* a new resource on first call, so if you'd rather see them as `Create`, say so. Risk: action = **medium** (overwrites deployed code), package = **low** (grouping container, no code).
2. **`functions-invoke-action`** — classified **Action / medium** (non-idempotent `update`). Invoking runs user code with side effects and is not idempotent. Flagging in case you consider a plain invoke lower risk (low) — we rounded up because a function can mutate external state.
3. **`functions-delete-access-key`** — **Delete / medium** rather than high: keys are re-creatable and deletion doesn't destroy namespace data, but it can break downstream auth. Confirm medium.
4. **`functions-create-access-key`** / **`functions-create-namespace`** — **Create / medium** (mint a credential / provision a namespace). Confirm medium vs low.
5. **`functions-create-trigger`** — **Create / low** (a scheduled trigger is cheap and reversible via delete). Confirm low.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/functions/...`, `go test ./pkg/registry/functions/...` — all pass.
- `gofmt` clean.
