### PR TITLE
feat(genai): annotate evaluation tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/genai/evaluation_tools.go
+++ b/pkg/registry/genai/evaluation_tools.go
@@ -16,6 +16,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // genAIAPIPath is the relative path prefix for GenAI endpoints (same style as godo's "v2/droplets").
@@ -968,6 +970,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.listEvaluationMetrics,
 			Tool: mcp.NewTool(
 				"genai-list-evaluation-metrics",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all available evaluation metrics."),
 			),
 		},
@@ -975,6 +979,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.listEvaluationTestCases,
 			Tool: mcp.NewTool(
 				"genai-list-evaluation-test-cases",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List evaluation test cases for a workspace."),
 				mcp.WithString("workspace_uuid", mcp.Description("Workspace UUID (optional if agent_workspace_name is provided)")),
 				mcp.WithString("agent_workspace_name", mcp.Description("Workspace name (optional if workspace_uuid is provided)")),
@@ -984,6 +990,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.createEvaluationDataset,
 			Tool: mcp.NewTool(
 				"genai-create-evaluation-dataset",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create an evaluation dataset by uploading a CSV file. The file must contain a 'query' column with JSON objects."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the dataset")),
 				mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the CSV file to upload")),
@@ -993,6 +1001,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.createEvaluationTestCase,
 			Tool: mcp.NewTool(
 				"genai-create-evaluation-test-case",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create an evaluation test case."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name of the test case")),
 				mcp.WithString("description", mcp.Description("Description of the test case")),
@@ -1007,6 +1017,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.updateEvaluationTestCase,
 			Tool: mcp.NewTool(
 				"genai-update-evaluation-test-case",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update an evaluation test case."),
 				mcp.WithString("test_case_uuid", mcp.Required(), mcp.Description("Test case UUID to update")),
 				mcp.WithString("name", mcp.Description("New name for the test case")),
@@ -1020,6 +1032,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.runEvaluationTestCase,
 			Tool: mcp.NewTool(
 				"genai-run-evaluation-test-case",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Run an evaluation test case."),
 				mcp.WithString("test_case_uuid", mcp.Required(), mcp.Description("Test case UUID to run")),
 				mcp.WithArray("agent_deployment_names", mcp.Description("List of agent deployment names"), mcp.Items(map[string]any{"type": "string"})),
@@ -1030,6 +1044,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.getEvaluationRun,
 			Tool: mcp.NewTool(
 				"genai-get-evaluation-run",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the status and results of an evaluation run."),
 				mcp.WithString("evaluation_run_uuid", mcp.Required(), mcp.Description("Evaluation run UUID")),
 			),
@@ -1038,6 +1054,8 @@ func (et *EvaluationTool) Tools() []server.ServerTool {
 			Handler: et.runEvaluationWorkflow,
 			Tool: mcp.NewTool(
 				"genai-run-evaluation-workflow",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Run a complete evaluation workflow: validate dataset, create/update test case, run evaluation, and poll for results. This is a convenience tool for users unfamiliar with the multi-step evaluation process."),
 				mcp.WithString("dataset_file_path", mcp.Required(), mcp.Description("Path to the CSV evaluation dataset")),
 				mcp.WithString("workspace_name", mcp.Required(), mcp.Description("Agent workspace name")),

--- a/pkg/registry/genai/genai_annotations_test.go
+++ b/pkg/registry/genai/genai_annotations_test.go
@@ -1,0 +1,131 @@
+package genai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// evaluation_tools.go (agent/workspace evaluation)
+	"genai-list-evaluation-metrics":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-list-evaluation-test-cases":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-create-evaluation-dataset":   {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"genai-create-evaluation-test-case": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"genai-update-evaluation-test-case": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"genai-run-evaluation-test-case":    {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-get-evaluation-run":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-run-evaluation-workflow":     {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// model_evaluation_tools.go (model evaluation)
+	"genai-model-eval-list-metrics":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-list-datasets":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-list-presets":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-get-preset":               {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-create-dataset":           {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"genai-model-eval-create-run":               {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-model-eval-list-runs":                {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-get-run":                  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-update-run":               {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"genai-model-eval-get-results-download-url": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-model-eval-delete-run":               {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"genai-model-eval-cancel-run":               {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"genai-model-eval-delete-preset":            {false, true, true, false, common.OpDelete, common.RiskLow, false, false},
+	"genai-model-eval-delete-dataset":           {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"genai-model-eval-run-workflow":             {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewEvaluationTool(clientFn).Tools()...)
+	all = append(all, NewModelEvaluationTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/genai/model_evaluation_tools.go
+++ b/pkg/registry/genai/model_evaluation_tools.go
@@ -13,6 +13,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // toGodoStarMetric converts the locally parsed star metric into the godo SDK type.
@@ -912,6 +914,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.listMetrics,
 			Tool: mcp.NewTool(
 				"genai-model-eval-list-metrics",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all available model evaluation metrics."),
 			),
 		},
@@ -919,6 +923,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.listDatasets,
 			Tool: mcp.NewTool(
 				"genai-model-eval-list-datasets",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List previously uploaded evaluation datasets so you can reuse an existing dataset's UUID in genai-model-eval-create-run. Defaults to model-evaluation datasets. Each item includes dataset_uuid, dataset_name, created_at, row_count, file_size, and has_ground_truth. Use this to find the dataset_uuid for a dataset the user already uploaded (instead of uploading a new one)."),
 				mcp.WithString("dataset_type", mcp.Description("Filter by dataset type. Defaults to EVALUATION_DATASET_TYPE_MODEL (datasets usable for model evaluation). Other values: EVALUATION_DATASET_TYPE_UNKNOWN, EVALUATION_DATASET_TYPE_ADK, EVALUATION_DATASET_TYPE_NON_ADK.")),
 			),
@@ -927,6 +933,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.listPresets,
 			Tool: mcp.NewTool(
 				"genai-model-eval-list-presets",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all model evaluation presets. Presets are reusable evaluation configurations containing a dataset, judge model, and metrics."),
 			),
 		},
@@ -934,6 +942,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.getPreset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-get-preset",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a single model evaluation preset by UUID."),
 				mcp.WithString("eval_preset_uuid", mcp.Required(), mcp.Description("UUID of the evaluation preset")),
 			),
@@ -942,6 +952,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.createDataset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-create-dataset",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Upload and register a model evaluation dataset (presign → Spaces upload → database record). Accepts .csv (with 'input' column) or .jsonl (one JSON object per line with 'input' field); 'ground_truth' is optional. Returns evaluation_dataset_uuid for use with genai-model-eval-create-run."),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the dataset")),
 				mcp.WithString("file_path", mcp.Required(), mcp.Description("Path to the .csv or .jsonl dataset file to upload")),
@@ -951,6 +963,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.createRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-create-run",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription(genaiModelEvalCreateRunToolDescription),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for this evaluation run")),
 				mcp.WithString("candidate_model_name", mcp.Required(), mcp.Description("Exact candidate model name the user provided or confirmed (character-for-character, whitespace trimmed). Partial names return nearest matches only.")),
@@ -973,6 +987,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.listRuns,
 			Tool: mcp.NewTool(
 				"genai-model-eval-list-runs",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List model evaluation runs with optional filters. Each run includes its eval_run_uuid (use it with genai-model-eval-get-run / cancel-run / delete-run), name, status, and the candidate/judge model and dataset it used."),
 				mcp.WithString("eval_preset_uuid", mcp.Description("Filter by preset UUID")),
 				mcp.WithString("status", mcp.Description("Filter by run status. Accepts the full enum values: MODEL_EVALUATION_RUN_QUEUED, MODEL_EVALUATION_RUN_RUNNING_DATASET, MODEL_EVALUATION_RUN_EVALUATING_RESULTS, MODEL_EVALUATION_RUN_CANCELLING, MODEL_EVALUATION_RUN_CANCELLED, MODEL_EVALUATION_RUN_SUCCESSFUL, MODEL_EVALUATION_RUN_PARTIALLY_SUCCESSFUL (some rows scored, others failed), MODEL_EVALUATION_RUN_FAILED.")),
@@ -984,6 +1000,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.getRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-get-run",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the status, details, and per-prompt results of a model evaluation run."),
 				mcp.WithString("eval_run_uuid", mcp.Required(), mcp.Description("UUID of the evaluation run (the eval_run_uuid returned by genai-model-eval-list-runs or genai-model-eval-create-run)")),
 				mcp.WithNumber("page", mcp.Description("Page number for per-prompt results pagination")),
@@ -994,6 +1012,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.updateRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-update-run",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a model evaluation run. Currently only the run name can be changed."),
 				mcp.WithString("eval_run_uuid", mcp.Required(), mcp.Description("UUID of the evaluation run")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("New name for the evaluation run")),
@@ -1003,6 +1023,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.getResultsDownloadURL,
 			Tool: mcp.NewTool(
 				"genai-model-eval-get-results-download-url",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a presigned download URL for the full results of a model evaluation run. The returned URL is short-lived (expires in ~15 minutes) and points to a gzip-compressed JSON (.json.gz) file, so use it promptly."),
 				mcp.WithString("eval_run_uuid", mcp.Required(), mcp.Description("UUID of the evaluation run (the eval_run_uuid returned by genai-model-eval-list-runs)")),
 			),
@@ -1011,6 +1033,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.deleteRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-delete-run",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a model evaluation run by UUID. Deletion is permanent: the run record and its results cannot be recovered.\n\n"+
 					"CONSENT REQUIRED (every delete): Do not call with confirm_deletion: true until the user has explicitly agreed in chat. "+
 					"Present the eval_run_uuid and that deletion is permanent; ask for yes/no."),
@@ -1022,6 +1046,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.cancelRun,
 			Tool: mcp.NewTool(
 				"genai-model-eval-cancel-run",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Cancel an in-progress model evaluation run by UUID. The run transitions to MODEL_EVALUATION_RUN_CANCELLING and then MODEL_EVALUATION_RUN_CANCELLED. Any partial results may be lost.\n\n"+
 					"CONSENT REQUIRED (every cancel): Do not call with confirm_cancel: true until the user has explicitly agreed in chat. "+
 					"Present the eval_run_uuid and that any partial results may be lost; ask for yes/no."),
@@ -1033,6 +1059,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.deletePreset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-delete-preset",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Delete a saved model evaluation preset by UUID. Deletion is permanent and existing runs that referenced the preset are not affected.\n\n"+
 					"CONSENT REQUIRED (every delete): Do not call with confirm_deletion: true until the user has explicitly agreed in chat. "+
 					"Present the eval_preset_uuid and that deletion is permanent; ask for yes/no."),
@@ -1044,6 +1072,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.deleteDataset,
 			Tool: mcp.NewTool(
 				"genai-model-eval-delete-dataset",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete an evaluation dataset by UUID. Works for both model and agent evaluation datasets. Deletion is permanent: the dataset record cannot be recovered.\n\n"+
 					"CONSENT REQUIRED (every delete): Do not call with confirm_deletion: true until the user has explicitly agreed in chat. "+
 					"Present the dataset_uuid and that deletion is permanent; ask for yes/no."),
@@ -1055,6 +1085,8 @@ func (met *ModelEvaluationTool) Tools() []server.ServerTool {
 			Handler: met.runWorkflow,
 			Tool: mcp.NewTool(
 				"genai-model-eval-run-workflow",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription(genaiModelEvalWorkflowToolDescription),
 				mcp.WithString("dataset_file_path", mcp.Required(), mcp.Description("Path to the .csv or .jsonl evaluation dataset")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Name for the evaluation run")),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. 


## What this does

Applies the shared annotation profiles to **every tool in the `genai` package** (both the agent/workspace `EvaluationTool` and the `ModelEvaluationTool`) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, `genai` tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`genai_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list/describe is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → can delete or overwrite data in a hard/impossible-to-undo way; `false` → additive/reversible only.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Toggles, updates, and deletes are idempotent; fresh creates/runs are not.
- **`openWorld`** — `true` → touches external/unbounded systems (web search, third-party APIs); `false` → closed, well-defined domain. All `genai` tools are `false`.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius, not operation type: **low** = reads and reversible toggles; **medium** = single-resource mutation that interrupts/reconfigures but is recoverable, or incurs cost/compute; **high** = irreversible/data-losing (delete), acts on many resources at once, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

### Agent/workspace evaluation (`evaluation_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `genai-list-evaluation-metrics` | Read | read | – | ✓ | low |
| `genai-list-evaluation-test-cases` | Read | read | – | ✓ | low |
| `genai-create-evaluation-dataset` | Create | create | – | – | low |
| `genai-create-evaluation-test-case` | Create | create | – | – | low |
| `genai-update-evaluation-test-case` | Toggle | update | – | ✓ | low |
| `genai-run-evaluation-test-case` | Create | create | – | – | medium |
| `genai-get-evaluation-run` | Read | read | – | ✓ | low |
| `genai-run-evaluation-workflow` | Action | update | – | – | medium |

### Model evaluation (`model_evaluation_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `genai-model-eval-list-metrics` | Read | read | – | ✓ | low |
| `genai-model-eval-list-datasets` | Read | read | – | ✓ | low |
| `genai-model-eval-list-presets` | Read | read | – | ✓ | low |
| `genai-model-eval-get-preset` | Read | read | – | ✓ | low |
| `genai-model-eval-create-dataset` | Create | create | – | – | low |
| `genai-model-eval-create-run` | Create | create | – | – | medium |
| `genai-model-eval-list-runs` | Read | read | – | ✓ | low |
| `genai-model-eval-get-run` | Read | read | – | ✓ | low |
| `genai-model-eval-update-run` | Toggle | update | – | ✓ | low |
| `genai-model-eval-get-results-download-url` | Read | read | – | ✓ | low |
| `genai-model-eval-delete-run` | Delete | delete | ✓ | ✓ | medium |
| `genai-model-eval-cancel-run` | Toggle | update | – | ✓ | medium |
| `genai-model-eval-delete-preset` | Delete | delete | ✓ | ✓ | low |
| `genai-model-eval-delete-dataset` | Delete | delete | ✓ | ✓ | medium |
| `genai-model-eval-run-workflow` | Action | update | – | – | medium |

## Points of clarification (please check)

1. **Run-launching tools** — `genai-run-evaluation-test-case`, `genai-model-eval-create-run` are modeled as **Create** (they create a new run resource), while `genai-run-evaluation-workflow` and `genai-model-eval-run-workflow` are modeled as **Action** (`update`, non-idempotent orchestrations that validate + create + run + poll). All are **medium** risk because they consume judge-model compute/cost. If you'd rather see the workflow tools as `Create` too, say so.
2. **`genai-model-eval-cancel-run`** — modeled as **Toggle** (idempotent `update`, converges to CANCELLED) at **medium** (partial results may be lost). It is not treated as `destructive` because it stops a run rather than deleting stored data. Confirm.
3. **Delete risk levels** — `delete-run` and `delete-dataset` are **medium** (permanent, but single-artifact blast radius; a dataset is more painful to recreate), and `delete-preset` is **low** (a preset is a reusable config; existing runs are unaffected). Please confirm these delete risk levels — happy to bump any to **high** if you consider the data loss more severe.
4. **`create-run` / `run-*` risk** — set to **medium** for cost/compute. Confirm this is the right level (vs low).

## Test plan

- `go build ./...`, `go vet ./pkg/registry/genai/...`, `go test ./pkg/registry/genai/...` — all pass.
- `gofmt` clean.
