### PR TITLE
feat(genai-custom-models): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/genai-custom-models/custom_models_annotations_test.go
+++ b/pkg/registry/genai-custom-models/custom_models_annotations_test.go
@@ -1,0 +1,111 @@
+package genaicustommodels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// custom_models_tools.go
+	"genai-models-unified-search":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-custom-models-list":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-custom-models-import":          {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-custom-models-update-metadata": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"genai-custom-models-get":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-custom-models-delete":          {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewCustomModelsTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/genai-custom-models/custom_models_tools.go
+++ b/pkg/registry/genai-custom-models/custom_models_tools.go
@@ -9,6 +9,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -392,6 +394,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.unifiedSearch,
 			Tool: mcp.NewTool(
 				"genai-models-unified-search",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("PRIMARY tool for listing or searching models. Use when the user asks to list all models, show available models, or search by partial name. Returns two markdown tables (Model Catalog and Custom Models) with one row per model: custom columns are UUID, Name, Source, Status, Architecture, Input Modalities, Output Modalities, Error Message; catalog columns include Provider, Type, Context Window, Capabilities, and modalities. Empty query lists everything; partial query returns nearest matches."),
 				mcp.WithString("query", mcp.Description("Partial model name or search string (optional). Empty returns all models in both tables.")),
 			),
@@ -400,6 +404,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.listModels,
 			Tool: mcp.NewTool(
 				"genai-custom-models-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all custom models in one markdown table (one row per model, every UUID shown including STATUS_FAILED). Columns: UUID, Name, Source, Status, Architecture, Input Modalities, Output Modalities, Error Message. Do not summarize the table in the response. For catalog + custom together use genai-models-unified-search. Optional status/page/per_page filters."),
 				mcp.WithString("status", mcp.Description("Filter by status: STATUS_IMPORTING, STATUS_READY, STATUS_FAILED, STATUS_DELETED")),
 				mcp.WithNumber("page", mcp.Description("Page number for pagination (default: 1)")),
@@ -410,6 +416,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.importModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-import",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription(genaiCustomModelsImportToolDescription),
 				mcp.WithString("name", mcp.Description("Optional display name for the custom model (leading/trailing whitespace is trimmed when provided).")),
 				mcp.WithString("source_type", mcp.Required(), mcp.Description("Source type: SOURCE_TYPE_HUGGINGFACE, SOURCE_TYPE_SPACES_BUCKET, SOURCE_TYPE_SDK_UPLOAD, SOURCE_TYPE_FINE_TUNING")),
@@ -424,6 +432,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.updateMetadata,
 			Tool: mcp.NewTool(
 				"genai-custom-models-update-metadata",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update the metadata of an existing custom model. Editable fields include name, description, tags, input/output modalities, parameters, and license."),
 				mcp.WithString("uuid", mcp.Required(), mcp.Description("UUID of the custom model to update")),
 				mcp.WithString("name", mcp.Description("New name for the model")),
@@ -439,6 +449,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.getModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the full catalog card for a custom model, including its status, architecture, source info, size, license, tags, active deployments, and cost estimate."),
 				mcp.WithString("uuid", mcp.Required(), mcp.Description("UUID of the custom model to retrieve")),
 			),
@@ -447,6 +459,8 @@ func (cmt *CustomModelsTool) Tools() []server.ServerTool {
 			Handler: cmt.deleteModel,
 			Tool: mcp.NewTool(
 				"genai-custom-models-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription(genaiCustomModelsDeleteToolDescription),
 				mcp.WithString("name", mcp.Description("Exact custom model name the user provided or confirmed (character-for-character, whitespace trimmed). Use this OR uuid. Partial names return candidates only.")),
 				mcp.WithString("uuid", mcp.Description("Exact full custom model UUID (8-4-4-4-12 hex). Use this OR name. Partial uuids return candidates only; never delete on a partial uuid even if one match.")),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. 

## What this does

Applies the shared annotation profiles to **every `genai-custom-models` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`custom_models_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test).

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list/search is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → can delete or overwrite data in a hard/impossible-to-undo way (e.g. "delete a model"); `false` → additive/reversible only.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Metadata updates and deletes are idempotent; a fresh import is not.
- **`openWorld`** — `true` → touches external/unbounded systems (web search, third-party APIs); `false` → closed, well-defined domain. Set to `false` here (see clarification #2).
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius, not operation type: **low** = reads and reversible toggles; **medium** = single-resource mutation that incurs cost or reconfigures but is recoverable; **high** = irreversible/data-losing (delete), acts on many resources at once, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `genai-models-unified-search` | Read | read | – | ✓ | low |
| `genai-custom-models-list` | Read | read | – | ✓ | low |
| `genai-custom-models-import` | Create | create | – | – | medium |
| `genai-custom-models-update-metadata` | Toggle | update | – | ✓ | low |
| `genai-custom-models-get` | Read | read | – | ✓ | low |
| `genai-custom-models-delete` | Delete | delete | ✓ | ✓ | high |

## Points of clarification (please check)

1. **`genai-custom-models-import`** — classified **Create / medium** (non-idempotent): it starts an async import job, incurs storage cost, and the tool already enforces explicit T&C consent. Confirm medium (vs high) — it provisions a paid, cleanable resource rather than acting destructively.
2. **`openWorld`** — `import` pulls from external sources (HuggingFace, Spaces buckets) and `unified-search` reads the model catalog. I set `openWorld: false` for all tools because the tool contract/domain is the DO GenAI API (the external fetch is an implementation detail of the import). If you'd prefer `import` (and/or `unified-search`) to be `openWorld: true`, say so.
3. **`genai-custom-models-delete`** — **Delete / high** (permanent; may be blocked by active deployments). The tool enforces explicit deletion consent. Confirm high.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/genai-custom-models/...`, `go test ./pkg/registry/genai-custom-models/...` — all pass.
- `gofmt` clean.
