### PR TITLE
feat(genai-batchinference): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/genai-batchinference/batch_inference_annotations_test.go
+++ b/pkg/registry/genai-batchinference/batch_inference_annotations_test.go
@@ -1,0 +1,112 @@
+package genaibatchinference
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// batch_inference_tools.go
+	"genai-batch-inference-create-file": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"genai-batch-inference-upload-file": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"genai-batch-inference-create":      {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-batch-inference-get":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-batch-inference-get-results": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-batch-inference-cancel":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"genai-batch-inference-list":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewBatchInferenceTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/genai-batchinference/batch_inference_tools.go
+++ b/pkg/registry/genai-batchinference/batch_inference_tools.go
@@ -9,6 +9,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // BatchInferenceTool provides GenAI Batch Inference lifecycle management tools.
@@ -203,6 +205,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.createFile,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-create-file",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a presigned URL for uploading a batch inference JSONL input file. The file must have a .jsonl extension. Upload the file to the returned URL via HTTP PUT before creating a batch job."),
 				mcp.WithString("FileName", mcp.Required(), mcp.Description("Name of the JSONL file to upload (must end in .jsonl)")),
 			),
@@ -211,6 +215,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.uploadInputFile,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-upload-file",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Upload JSONL content to the presigned S3 URL returned by create-file. The content should be newline-delimited JSON (one request per line). Must be called after create-file and before create."),
 				mcp.WithString("UploadURL", mcp.Required(), mcp.Description("Presigned upload URL from create-file response")),
 				mcp.WithString("Content", mcp.Required(), mcp.Description("JSONL content to upload (newline-delimited JSON)")),
@@ -220,6 +226,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.createJob,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new batch inference job. Requires a previously uploaded file (via create-file). For OpenAI provider, the Endpoint argument is also required."),
 				mcp.WithString("Provider", mcp.Required(), mcp.Description("Batch provider: 'openai' or 'anthropic'")),
 				mcp.WithString("FileID", mcp.Required(), mcp.Description("UUID of a previously uploaded .jsonl file")),
@@ -232,6 +240,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.getJob,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the current status and metadata of a batch inference job by its ID."),
 				mcp.WithString("BatchID", mcp.Required(), mcp.Description("UUID of the batch inference job")),
 			),
@@ -240,6 +250,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.getJobResults,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-get-results",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the results download URL for a completed batch inference job. Returns a presigned download URL and output file ID. Fails if the job has not completed."),
 				mcp.WithString("BatchID", mcp.Required(), mcp.Description("UUID of the batch inference job")),
 			),
@@ -248,8 +260,9 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.cancelJob,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-cancel",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Request cancellation of a batch inference job. The job may not be cancelled immediately; poll with get to check status."),
-				mcp.WithDestructiveHintAnnotation(true),
 				mcp.WithString("BatchID", mcp.Required(), mcp.Description("UUID of the batch inference job to cancel")),
 			),
 		},
@@ -257,6 +270,8 @@ func (b *BatchInferenceTool) Tools() []server.ServerTool {
 			Handler: b.listJobs,
 			Tool: mcp.NewTool(
 				"genai-batch-inference-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List batch inference jobs with optional status filter and cursor-based pagination. Returns Relay-style edges with per-row cursors and page_info."),
 				mcp.WithString("Status", mcp.Description("Filter by job status (e.g. 'completed', 'in_progress', 'failed')")),
 				mcp.WithNumber("Limit", mcp.Description("Maximum number of jobs to return per page")),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. 


## What this does

Applies the shared annotation profiles to **every `genai-batchinference` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

This also **replaces the ad-hoc inline hint** on `genai-batch-inference-cancel` (`mcp.WithDestructiveHintAnnotation(true)`) with the shared `Toggle` profile — see clarification #2 for the reasoning behind the reclassification.

A per-tool contract test (`batch_inference_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → can delete or overwrite data in a hard/impossible-to-undo way; `false` → additive/reversible only.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Cancel is idempotent (already-cancelled = no-op); a fresh create/upload is not.
- **`openWorld`** — `true` → touches external/unbounded systems; `false` → closed, well-defined domain. Set to `false` here (see clarification #3).
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius, not operation type: **low** = reads and reversible/no-cost writes; **medium** = single-resource mutation that incurs cost or interrupts but is recoverable; **high** = irreversible/data-losing, acts on many resources at once, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `genai-batch-inference-create-file` | Create | create | – | – | low |
| `genai-batch-inference-upload-file` | Create | create | – | – | low |
| `genai-batch-inference-create` | Create | create | – | – | medium |
| `genai-batch-inference-get` | Read | read | – | ✓ | low |
| `genai-batch-inference-get-results` | Read | read | – | ✓ | low |
| `genai-batch-inference-cancel` | Toggle | update | – | ✓ | medium |
| `genai-batch-inference-list` | Read | read | – | ✓ | low |

## Points of clarification (please check)

1. **`genai-batch-inference-create`** — **Create / medium**: launching a batch job consumes provider compute/cost. `create-file` and `upload-file` are **Create / low** because they only mint a presigned URL and stage input (no job cost yet). Confirm the medium/low split.
2. **`genai-batch-inference-cancel` reclassified** — the code previously marked this **destructive**. I changed it to the **Toggle** profile (`update`, idempotent, **not** destructive) at **medium** risk, matching how `genai-model-eval-cancel-run` is treated: cancel interrupts an in-flight job (partial results may be lost) but does not delete stored data. If you specifically want `cancel` to remain `destructive: true`, tell me and I'll switch it to a destructive profile.
3. **`openWorld`** — `upload-file` PUTs to a presigned Spaces/S3 URL and batch jobs proxy OpenAI/Anthropic providers. I set `openWorld: false` for all tools (the tool contract/domain is the DO GenAI batch API; the provider/storage calls are implementation details). If you'd prefer `create`/`upload-file` to be `openWorld: true`, say so.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/genai-batchinference/...`, `go test ./pkg/registry/genai-batchinference/...` — all pass.
- `gofmt` clean.
