### PR TITLE
feat(genai-inferencerouter): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/genai-inferencerouter/router_annotations_test.go
+++ b/pkg/registry/genai-inferencerouter/router_annotations_test.go
@@ -1,0 +1,111 @@
+package genaiinferencerouter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// router_tools.go
+	"genai-inference-router-create":       {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-inference-router-list":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-inference-router-get":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-inference-router-delete":       {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"genai-inference-router-task-presets": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"genai-inference-router-update":       {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewRouterTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/genai-inferencerouter/router_annotations_test.go
+++ b/pkg/registry/genai-inferencerouter/router_annotations_test.go
@@ -28,12 +28,12 @@ var expectedAnnotations = map[string]struct {
 	parallelizable, streamingSafe                bool
 }{
 	// router_tools.go
-	"genai-inference-router-create":       {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"genai-inference-router-create":       {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
 	"genai-inference-router-list":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"genai-inference-router-get":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"genai-inference-router-delete":       {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
 	"genai-inference-router-task-presets": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
-	"genai-inference-router-update":       {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"genai-inference-router-update":       {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
 }
 
 func TestToolAnnotations(t *testing.T) {

--- a/pkg/registry/genai-inferencerouter/router_tools.go
+++ b/pkg/registry/genai-inferencerouter/router_tools.go
@@ -333,7 +333,7 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-inference-router-create",
 				common.WithHints(common.HintsCreate),
-				common.WithRisk(common.RiskMedium),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription(`Create a GenAI model router via godo.GradientAI.CreateInferenceRouter. JSON body fields: "name", optional "policies" array, and required "fallback_models" (at least one model). Each policy needs a task: either "task_slug" (built-in) plus "models" and "selection_policy":{"prefer":"fastest"|"cheapest"}, or "custom_task":{"name","description"} with "models" and selection_policy. Flat {"model","usecase_class"} policies fail with "task is required". List/get return the same policy shape under model_router.config.`),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Router name")),
 				mcp.WithString("PoliciesJson", mcp.Description(`JSON array for "policies". Example: [{"task_slug":"code-generation","models":["openai-gpt-5"],"selection_policy":{"prefer":"fastest"}}]. Custom task: use custom_task with name+description instead of task_slug. Omit or "[]" if allowed.`)),
@@ -387,7 +387,9 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Tool: mcp.NewTool(
 				"genai-inference-router-update",
 				common.WithHints(common.HintsToggle),
-				common.WithRisk(common.RiskLow),
+				// Reconfiguring a router that is actively serving traffic can
+				// incur cost / affect live routing, so risk is medium.
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription(`Update a GenAI model router (godo.GradientAI.UpdateInferenceRouter, PUT). At least one of Name, Description, PoliciesJson (non-empty), or FallbackModels must be supplied. PoliciesJson must be a JSON array (same rules as create). Omit fields you do not want to change.`),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
 				mcp.WithString("Name", mcp.Description("New router name (optional)")),

--- a/pkg/registry/genai-inferencerouter/router_tools.go
+++ b/pkg/registry/genai-inferencerouter/router_tools.go
@@ -10,6 +10,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // RouterTool exposes GenAI inference router operations via godo.GradientAI.
@@ -330,6 +332,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.create,
 			Tool: mcp.NewTool(
 				"genai-inference-router-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription(`Create a GenAI model router via godo.GradientAI.CreateInferenceRouter. JSON body fields: "name", optional "policies" array, and required "fallback_models" (at least one model). Each policy needs a task: either "task_slug" (built-in) plus "models" and "selection_policy":{"prefer":"fastest"|"cheapest"}, or "custom_task":{"name","description"} with "models" and selection_policy. Flat {"model","usecase_class"} policies fail with "task is required". List/get return the same policy shape under model_router.config.`),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Router name")),
 				mcp.WithString("PoliciesJson", mcp.Description(`JSON array for "policies". Example: [{"task_slug":"code-generation","models":["openai-gpt-5"],"selection_policy":{"prefer":"fastest"}}]. Custom task: use custom_task with name+description instead of task_slug. Omit or "[]" if allowed.`)),
@@ -340,6 +344,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.list,
 			Tool: mcp.NewTool(
 				"genai-inference-router-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List GenAI model routers (godo.GradientAI.ListInferenceRouters) with pagination."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1)")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(1000), mcp.Description("Items per page (default 1000, max 1000)")),
@@ -349,6 +355,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.get,
 			Tool: mcp.NewTool(
 				"genai-inference-router-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a GenAI model router by UUID (godo.GradientAI.GetInferenceRouter)."),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
 			),
@@ -357,6 +365,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.delete,
 			Tool: mcp.NewTool(
 				"genai-inference-router-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a GenAI model router by UUID (godo.GradientAI.DeleteInferenceRouter)."),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
 			),
@@ -365,6 +375,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.listTaskPresets,
 			Tool: mcp.NewTool(
 				"genai-inference-router-task-presets",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List preset inference-router tasks (task_slug, name, models, etc.) from GET /v2/gen-ai/models/routers/tasks/presets via godo.GradientAI.ListInferenceRouterTaskPresets. Use task_slug values when building PoliciesJson for create/update."),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1)")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(1000), mcp.Description("Items per page (default 1000, max 1000)")),
@@ -374,6 +386,8 @@ func (t *RouterTool) Tools() []server.ServerTool {
 			Handler: t.update,
 			Tool: mcp.NewTool(
 				"genai-inference-router-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription(`Update a GenAI model router (godo.GradientAI.UpdateInferenceRouter, PUT). At least one of Name, Description, PoliciesJson (non-empty), or FallbackModels must be supplied. PoliciesJson must be a JSON array (same rules as create). Omit fields you do not want to change.`),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("Model router UUID")),
 				mcp.WithString("Name", mcp.Description("New router name (optional)")),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.
>
> **cc @d-isaacson** (Drew Isaacson) — `genai-inferencerouter` service owner/POC. GitHub rejected a formal review request because this account is not a collaborator on this public mirror (HTTP 422), so you're mentioned here instead. Please review / re-assign.

## What this does

Applies the shared annotation profiles to **every `genai-inferencerouter` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`router_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`: adding a tool without a row, or changing an annotation in code without updating the row, fails the test.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — is the tool side-effect free? A get/list is read-only; anything that writes is not.
- **`destructive`** — only meaningful when not read-only. `true` → deletes/overwrites data hard-to-undo; `false` → additive/reversible.
- **`idempotent`** — does repeating the call converge to the same state with no extra effect? Updates and deletes are idempotent; a fresh create is not.
- **`openWorld`** — `true` → touches external/unbounded systems; `false` → closed, well-defined domain. All tools here are `false`.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** (the field approval gating enforces) — blast radius: **low** = reads and reversible config changes; **medium** = single-resource provisioning/reconfig that is recoverable; **high** = irreversible/data-losing (delete), acts on many resources, or provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `genai-inference-router-create` | Create | create | – | – | low |
| `genai-inference-router-list` | Read | read | – | ✓ | low |
| `genai-inference-router-get` | Read | read | – | ✓ | low |
| `genai-inference-router-delete` | Delete | delete | ✓ | ✓ | high |
| `genai-inference-router-task-presets` | Read | read | – | ✓ | low |
| `genai-inference-router-update` | Toggle | update | – | ✓ | medium |

## Points of clarification (please confirm)

1. **`genai-inference-router-update`** — **Toggle / medium** (updated per @d-isaacson's review): reconfiguring a router that is actively serving traffic can incur cost / affect live routing.
2. **`genai-inference-router-create`** — **Create / low** (updated per @d-isaacson's review): creating an inference router is free.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/genai-inferencerouter/...`, `go test ./pkg/registry/genai-inferencerouter/...` — all pass.
- `gofmt` clean.
