### PR TITLE
feat(dedicated-inference): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/dedicated-inference/dedicated_inference_annotations_test.go
+++ b/pkg/registry/dedicated-inference/dedicated_inference_annotations_test.go
@@ -1,0 +1,110 @@
+package dedicatedinference
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// dedicated_inference_tools.go
+	"dedicated-inference-create": {false, false, false, false, common.OpCreate, common.RiskHigh, false, false},
+	"dedicated-inference-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"dedicated-inference-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"dedicated-inference-update": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"dedicated-inference-delete": {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewDedicatedInferenceTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/dedicated-inference/dedicated_inference_tools.go
+++ b/pkg/registry/dedicated-inference/dedicated_inference_tools.go
@@ -8,6 +8,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // DedicatedInferenceTool provides Dedicated Inference lifecycle management tools.
@@ -223,6 +225,8 @@ func (d *DedicatedInferenceTool) Tools() []server.ServerTool {
 			Handler: d.createDedicatedInference,
 			Tool: mcp.NewTool(
 				"dedicated-inference-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Create a new Dedicated Inference instance (CreateDedicatedInferenceV2). See spec/dedicated-inference-create-schema.json for the HTTP/API-aligned request shape. Tool arguments use UpperCamelCase; returns instance and optional initial auth token."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the dedicated inference instance")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region slug for deployment (e.g. nyc2, tor1, atl1)")),
@@ -237,6 +241,8 @@ func (d *DedicatedInferenceTool) Tools() []server.ServerTool {
 			Handler: d.getDedicatedInference,
 			Tool: mcp.NewTool(
 				"dedicated-inference-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get details of a Dedicated Inference instance (GetDedicatedInferenceV2) by ID."),
 				mcp.WithString("DedicatedInferenceID", mcp.Required(), mcp.Description("UUID of the dedicated inference instance")),
 			),
@@ -245,6 +251,8 @@ func (d *DedicatedInferenceTool) Tools() []server.ServerTool {
 			Handler: d.listDedicatedInferences,
 			Tool: mcp.NewTool(
 				"dedicated-inference-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List Dedicated Inference instances (ListDedicatedInferenceV2) with optional filters and pagination."),
 				mcp.WithString("Region", mcp.Description("Filter by region slug (e.g. nyc2)")),
 				mcp.WithString("Name", mcp.Description("Filter by instance name")),
@@ -256,6 +264,8 @@ func (d *DedicatedInferenceTool) Tools() []server.ServerTool {
 			Handler: d.updateDedicatedInference,
 			Tool: mcp.NewTool(
 				"dedicated-inference-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a Dedicated Inference instance (UpdateDedicatedInferenceV2). See spec/dedicated-inference-update-schema.json for the HTTP/API-aligned body shape."),
 				mcp.WithString("DedicatedInferenceID", mcp.Required(), mcp.Description("UUID of the dedicated inference instance to update")),
 				mcp.WithString("Name", mcp.Description("New name for the instance")),
@@ -271,8 +281,9 @@ func (d *DedicatedInferenceTool) Tools() []server.ServerTool {
 			Handler: d.deleteDedicatedInference,
 			Tool: mcp.NewTool(
 				"dedicated-inference-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a Dedicated Inference instance (DeleteDedicatedInferenceV2)."),
-				mcp.WithDestructiveHintAnnotation(true),
 				mcp.WithString("DedicatedInferenceID", mcp.Required(), mcp.Description("UUID of the dedicated inference instance to delete")),
 			),
 		},


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. .

## What this does

Applies the shared annotation profiles to **every `dedicated-inference` tool** so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

This also **replaces the ad-hoc inline hint** on `dedicated-inference-delete` (`mcp.WithDestructiveHintAnnotation(true)`) with the shared `Delete` profile.

A per-tool contract test (`dedicated_inference_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for delete.
- **`idempotent`** — repeating converges to the same state. Updates and deletes are idempotent; a fresh create is not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads; **medium** = recoverable single-resource reconfigure; **high** = irreversible/data-losing, or expensive provisioning you would not fan out. When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `dedicated-inference-create` | Create | create | – | – | high |
| `dedicated-inference-get` | Read | read | – | ✓ | low |
| `dedicated-inference-list` | Read | read | – | ✓ | low |
| `dedicated-inference-update` | Toggle | update | – | ✓ | medium |
| `dedicated-inference-delete` | Delete | delete | ✓ | ✓ | high |

## Points of clarification (please confirm)

1. **`dedicated-inference-create`** — classified **Create / high** (not medium): provisioning a dedicated GPU inference instance is expensive and not something you'd fan out. Confirm high.
2. **`dedicated-inference-update`** — **Toggle / medium**: changing region/model-deployments/endpoint reconfigures a running instance (recoverable). Confirm medium.
3. **`dedicated-inference-delete`** — **Delete / high**. Confirm.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/dedicated-inference/...`, `go test ./pkg/registry/dedicated-inference/...` — all pass.
- `gofmt` clean.
