### PR TITLE
feat(volumes): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/volumes/volume.go
+++ b/pkg/registry/volumes/volume.go
@@ -7,6 +7,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type VolumeTool struct {
@@ -335,6 +337,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.createVolume,
 			Tool: mcp.NewTool(
 				"volume-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new block storage volume"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("The name of the volume")),
 				mcp.WithNumber("SizeGigaBytes", mcp.Required(), mcp.Description("The size of the volume in GB")),
@@ -350,6 +354,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.listVolumes,
 			Tool: mcp.NewTool(
 				"volume-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List block storage volumes with optional Name/Region filters. Supports pagination."),
 				mcp.WithString("Name", mcp.Description("Name filtering parameter")),
 				mcp.WithString("Region", mcp.Description("Region filtering parameter")),
@@ -361,6 +367,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.getVolumeByID,
 			Tool: mcp.NewTool(
 				"volume-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a block storage volume by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("The ID of the volume to get")),
 			),
@@ -369,6 +377,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.deleteVolume,
 			Tool: mcp.NewTool(
 				"volume-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a block storage volume by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("The ID of the volume to delete")),
 			),
@@ -377,6 +387,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.createSnapshot,
 			Tool: mcp.NewTool(
 				"volume-snapshot-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a new snapshot from a volume"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume to create a snapshot from")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("The name of the snapshot")),
@@ -387,6 +399,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.listSnapshots,
 			Tool: mcp.NewTool(
 				"volume-snapshot-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List snapshots for a volume. Supports pagination."),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume to list snapshots for")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultVolumeListPage), mcp.Description("Page number")),
@@ -397,6 +411,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.getSnapshotByID,
 			Tool: mcp.NewTool(
 				"volume-snapshot-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a snapshot by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("The ID of the snapshot to get")),
 			),
@@ -405,6 +421,8 @@ func (vt *VolumeTool) Tools() []server.ServerTool {
 			Handler: vt.deleteSnapshot,
 			Tool: mcp.NewTool(
 				"volume-snapshot-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a snapshot by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("The ID of the snapshot to delete")),
 			),

--- a/pkg/registry/volumes/volume_actions.go
+++ b/pkg/registry/volumes/volume_actions.go
@@ -7,6 +7,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type VolumeActionsTool struct {
@@ -178,6 +180,8 @@ func (v *VolumeActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: v.attachVolume,
 			Tool: mcp.NewTool("volume-attach",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Attach a volume to a droplet"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume to attach")),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("The ID of the droplet to attach the volume to")),
@@ -186,6 +190,8 @@ func (v *VolumeActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: v.detachVolume,
 			Tool: mcp.NewTool("volume-detach",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Detach a volume from a droplet"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume to detach")),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("The ID of the droplet to detach the volume from")),
@@ -194,6 +200,8 @@ func (v *VolumeActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: v.getVolumeAction,
 			Tool: mcp.NewTool("volume-action-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a volume action by ID"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume")),
 				mcp.WithNumber("ActionID", mcp.Required(), mcp.Description("The ID of the action")),
@@ -202,6 +210,8 @@ func (v *VolumeActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: v.listVolumeActions,
 			Tool: mcp.NewTool("volume-action-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List volume actions"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultVolumeListPage), mcp.Description("Page number")),
@@ -211,6 +221,8 @@ func (v *VolumeActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: v.resizeVolume,
 			Tool: mcp.NewTool("volume-resize",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Resize a volume"),
 				mcp.WithString("VolumeID", mcp.Required(), mcp.Description("The ID of the volume to resize")),
 				mcp.WithNumber("SizeGigaBytes", mcp.Required(), mcp.Description("The size of the volume in GB")),

--- a/pkg/registry/volumes/volumes_annotations_test.go
+++ b/pkg/registry/volumes/volumes_annotations_test.go
@@ -1,0 +1,121 @@
+package volumes
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// volume.go
+	"volume-create":          {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"volume-list":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-get":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-delete":          {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"volume-snapshot-create": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"volume-snapshot-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-snapshot-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-snapshot-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// volume_actions.go
+	"volume-attach":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"volume-detach":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"volume-action-get":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-action-list": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"volume-resize":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewVolumeTool(clientFn).Tools()...)
+	all = append(all, NewVolumeActionsTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.
>
> **cc @andrehernandez0** (Andre Hernandez) — `volumes` service owner/POC. GitHub rejected a formal review request because this account is not a collaborator on this public mirror (HTTP 422), so you're mentioned here instead. Please review / re-assign.

## What this does

Applies the shared annotation profiles to **every `volumes` tool** (block-storage volumes + volume actions) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`volumes_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for the deletes.
- **`idempotent`** — repeating converges to the same state. Attach/detach/resize and deletes are idempotent; a fresh create is not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and cheap/reversible ops; **medium** = single-resource mutation that reconfigures/interrupts but is recoverable, or provisions a paid resource; **high** = irreversible/data-losing (deleting live data). When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

### Volumes (`volume.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `volume-create` | Create | create | – | – | medium |
| `volume-list` | Read | read | – | ✓ | low |
| `volume-get` | Read | read | – | ✓ | low |
| `volume-delete` | Delete | delete | ✓ | ✓ | high |
| `volume-snapshot-create` | Create | create | – | – | low |
| `volume-snapshot-list` | Read | read | – | ✓ | low |
| `volume-snapshot-get` | Read | read | – | ✓ | low |
| `volume-snapshot-delete` | Delete | delete | ✓ | ✓ | medium |

### Volume actions (`volume_actions.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `volume-attach` | Toggle | update | – | ✓ | medium |
| `volume-detach` | Toggle | update | – | ✓ | medium |
| `volume-action-get` | Read | read | – | ✓ | low |
| `volume-action-list` | Read | read | – | ✓ | low |
| `volume-resize` | Toggle | update | – | ✓ | medium |

## Points of clarification (please confirm)

1. **Delete risk split** — `volume-delete` is **high** (destroys live block-storage data); `volume-snapshot-delete` is **medium** (removes one backup, live volume intact). Please confirm — happy to bump the snapshot delete to high if you consider losing a backup equally severe.
2. **`volume-attach` / `volume-detach` / `volume-resize`** — modeled as **Toggle** (idempotent `update`) at **medium** (they interrupt/reconfigure a live volume↔droplet attachment but are recoverable). Confirm medium.
3. **`volume-create` medium vs `volume-snapshot-create` low** — create provisions a paid volume (medium); a snapshot is a cheap additive backup (low). Confirm.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/volumes/...`, `go test ./pkg/registry/volumes/...` — all pass.
- `gofmt` clean.
