### PR TITLE
feat(nfs): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/nfs/nfs.go
+++ b/pkg/registry/nfs/nfs.go
@@ -7,6 +7,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -274,6 +276,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.createFileShare,
 			Tool: mcp.NewTool(
 				"nfs-file-share-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new file share"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the file share")),
 				mcp.WithNumber("SizeGibibytes", mcp.Required(), mcp.Description("Size of the file share in GiB")),
@@ -286,6 +290,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.listFileShares,
 			Tool: mcp.NewTool(
 				"nfs-file-share-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List nfs file shares with optional Region filters. Supports pagination."),
 				mcp.WithString("Region", mcp.Description("Optional region filtering parameter")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number of the results to fetch")),
@@ -296,6 +302,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.getFileShareByID,
 			Tool: mcp.NewTool(
 				"nfs-file-share-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a file share by ID."),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the file share to get")),
 			),
@@ -304,6 +312,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.deleteFileShare,
 			Tool: mcp.NewTool(
 				"nfs-file-share-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a file share by ID."),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the file share to delete")),
 			),
@@ -312,6 +322,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.listNfsSnapshots,
 			Tool: mcp.NewTool(
 				"nfs-snapshot-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all NFS snapshots - supports pagination and filtering by region and share ID"),
 				mcp.WithString("Region", mcp.Description("Optional region of the NFS snapshot")),
 				mcp.WithString("ShareID", mcp.Description("Optional ID of the NFS share to list snapshots for")),
@@ -323,6 +335,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.getNfsSnapshotByID,
 			Tool: mcp.NewTool(
 				"nfs-snapshot-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a NFS snapshot by ID."),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the NFS snapshot to get")),
 			),
@@ -331,6 +345,8 @@ func (n *NfsTool) Tools() []server.ServerTool {
 			Handler: n.deleteNfsSnapshot,
 			Tool: mcp.NewTool(
 				"nfs-snapshot-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a NFS snapshot by ID."),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the NFS snapshot to delete")),
 			),

--- a/pkg/registry/nfs/nfs_actions.go
+++ b/pkg/registry/nfs/nfs_actions.go
@@ -7,6 +7,8 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type NfsActionsTool struct {
@@ -195,6 +197,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.resizeFileShare,
 			Tool: mcp.NewTool("nfs-resize",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Resize a NFS file share"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to resize")),
 				mcp.WithNumber("SizeGibibytes", mcp.Required(), mcp.Description("Size of the file share in GiB")),
@@ -203,6 +207,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.snapshotFileShare,
 			Tool: mcp.NewTool("nfs-snapshot",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a snapshot of a NFS file share"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to snapshot")),
 				mcp.WithString("SnapshotName", mcp.Required(), mcp.Description("Name of the snapshot")),
@@ -211,6 +217,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.attachFileShare,
 			Tool: mcp.NewTool("nfs-attach",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Attach a NFS file share to a VPC"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to attach")),
 				mcp.WithString("VpcID", mcp.Required(), mcp.Description("ID of the VPC to attach the file share to")),
@@ -219,6 +227,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.detachFileShare,
 			Tool: mcp.NewTool("nfs-detach",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Detach a NFS file share from a VPC"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to detach")),
 				mcp.WithString("VpcID", mcp.Required(), mcp.Description("ID of the VPC to detach the file share from")),
@@ -227,6 +237,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.reassignFileShare,
 			Tool: mcp.NewTool("nfs-reassign",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Reassign a NFS file share from one VPC to another"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to reassign")),
 				mcp.WithString("OldVpcID", mcp.Required(), mcp.Description("ID of the VPC to reassign the file share from")),
@@ -236,6 +248,8 @@ func (n *NfsActionsTool) Tools() []server.ServerTool {
 		{
 			Handler: n.switchPerformanceTier,
 			Tool: mcp.NewTool("nfs-switch-performance-tier",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Switch the performance tier of a NFS file share"),
 				mcp.WithString("ShareID", mcp.Required(), mcp.Description("ID of the NFS file share to switch the performance tier of")),
 				mcp.WithString("PerformanceTier", mcp.Required(), mcp.Description("Performance tier to switch the file share to")),

--- a/pkg/registry/nfs/nfs_annotations_test.go
+++ b/pkg/registry/nfs/nfs_annotations_test.go
@@ -1,0 +1,121 @@
+package nfs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// nfs.go
+	"nfs-file-share-create": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"nfs-file-share-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"nfs-file-share-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"nfs-file-share-delete": {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"nfs-snapshot-list":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"nfs-snapshot-get":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"nfs-snapshot-delete":   {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// nfs_actions.go
+	"nfs-resize":                  {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"nfs-snapshot":                {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"nfs-attach":                  {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"nfs-detach":                  {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"nfs-reassign":                {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+	"nfs-switch-performance-tier": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewNfsTool(clientFn).Tools()...)
+	all = append(all, NewNfsActionsTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout.

## What this does

Applies the shared annotation profiles to **every `nfs` tool** (file shares + snapshots + share actions) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`nfs_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern (`WithHints` + `WithRisk` + inline-struct contract test). This PR is self-contained and independently mergeable onto `main`.

## Field definitions (please classify against these)

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for the deletes.
- **`idempotent`** — repeating converges to the same state. Resize/attach/detach/tier-switch and deletes are idempotent; a fresh create/snapshot and `reassign` are not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and cheap/reversible ops; **medium** = single-resource mutation that reconfigures/interrupts but is recoverable, or provisions a paid resource; **high** = irreversible/data-losing (deleting a live share). When in doubt, round **up**.

The six hint profiles: `Read`(r/o), `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR

### File shares + snapshots (`nfs.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `nfs-file-share-create` | Create | create | – | – | medium |
| `nfs-file-share-list` | Read | read | – | ✓ | low |
| `nfs-file-share-get` | Read | read | – | ✓ | low |
| `nfs-file-share-delete` | Delete | delete | ✓ | ✓ | high |
| `nfs-snapshot-list` | Read | read | – | ✓ | low |
| `nfs-snapshot-get` | Read | read | – | ✓ | low |
| `nfs-snapshot-delete` | Delete | delete | ✓ | ✓ | medium |

### Share actions (`nfs_actions.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `nfs-resize` | Toggle | update | – | ✓ | medium |
| `nfs-snapshot` | Create | create | – | – | low |
| `nfs-attach` | Toggle | update | – | ✓ | medium |
| `nfs-detach` | Toggle | update | – | ✓ | medium |
| `nfs-reassign` | Action | update | – | – | medium |
| `nfs-switch-performance-tier` | Toggle | update | – | ✓ | medium |

## Points of clarification (please confirm)

1. **Delete risk split** — `nfs-file-share-delete` is **high** (destroys a live file share's data); `nfs-snapshot-delete` is **medium** (removes one backup, live share intact). Confirm — happy to bump the snapshot delete to high if losing a backup is equally severe.
2. **`nfs-reassign`** — modeled as **Action** (non-idempotent `update`), not Toggle, because moving a share from `OldVpcID`→`NewVpcID` cannot be replayed (after the first call it's no longer on the old VPC). Confirm.
3. **`nfs-attach` / `nfs-detach` / `nfs-resize` / `nfs-switch-performance-tier`** — modeled as **Toggle** (idempotent `update`) at **medium** (reconfigure a live share, recoverable). Confirm.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/nfs/...`, `go test ./pkg/registry/nfs/...` — all pass.
- `gofmt` clean.
