### PR TITLE
feat(spaces): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/spaces/cdn_tools.go
+++ b/pkg/registry/spaces/cdn_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // CDNTool provides CDN management tools
@@ -154,6 +155,8 @@ func (c *CDNTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getCDN,
 			Tool: mcp.NewTool("spaces-cdn-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get CDN information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the CDN")),
 			),
@@ -161,6 +164,8 @@ func (c *CDNTool) Tools() []server.ServerTool {
 		{
 			Handler: c.listCDNs,
 			Tool: mcp.NewTool("spaces-cdn-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List CDNs with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -169,6 +174,8 @@ func (c *CDNTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createCDN,
 			Tool: mcp.NewTool("spaces-cdn-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new CDN"),
 				mcp.WithString("Origin", mcp.Required(), mcp.Description("Origin URL for the CDN")),
 				mcp.WithNumber("TTL", mcp.Required(), mcp.Description("Time-to-live for the CDN cache")),
@@ -177,6 +184,8 @@ func (c *CDNTool) Tools() []server.ServerTool {
 		{
 			Handler: c.deleteCDN,
 			Tool: mcp.NewTool("spaces-cdn-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a CDN"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the CDN to delete")),
 			),
@@ -185,6 +194,8 @@ func (c *CDNTool) Tools() []server.ServerTool {
 		{
 			Handler: c.flushCDNCache,
 			Tool: mcp.NewTool("spaces-cdn-flush-cache",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Flush the cache of a CDN"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the CDN")),
 				mcp.WithArray("Files", mcp.Required(), mcp.Description("file names to flush from the cache (max 50 per request)"), mcp.Items(map[string]any{

--- a/pkg/registry/spaces/keys_tools.go
+++ b/pkg/registry/spaces/keys_tools.go
@@ -262,7 +262,7 @@ func (s *KeysTool) Tools() []server.ServerTool {
 			Handler: s.createSpacesKey,
 			Tool: mcp.NewTool("spaces-key-create",
 				common.WithHints(common.HintsCreate),
-				common.WithRisk(common.RiskMedium),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Create a new Spaces key. SECURITY WARNING: The returned secret key should NEVER be added to files or committed to source control. Always store the secret key in environment variables (e.g., DO_SPACES_SECRET_KEY) and access it securely at runtime. The secret key should be treated as highly sensitive credential information and should not be displayed in logs or output when possible."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the Spaces key")),
 			),

--- a/pkg/registry/spaces/keys_tools.go
+++ b/pkg/registry/spaces/keys_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type KeysTool struct {
@@ -241,6 +242,8 @@ func (s *KeysTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listSpacesKeys,
 			Tool: mcp.NewTool("spaces-key-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all Spaces keys"),
 				mcp.WithNumber("Page", mcp.Required(), mcp.DefaultNumber(1), mcp.Description("Page number for pagination")),
 				mcp.WithNumber("PerPage", mcp.Required(), mcp.DefaultNumber(10), mcp.Description("Number of items per page"), mcp.Max(100)),
@@ -249,6 +252,8 @@ func (s *KeysTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getSpacesKey,
 			Tool: mcp.NewTool("spaces-key-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a specific Spaces key"),
 				mcp.WithString("AccessKey", mcp.Required(), mcp.Description("Access Key of the Spaces key to retrieve")),
 			),
@@ -256,6 +261,8 @@ func (s *KeysTool) Tools() []server.ServerTool {
 		{
 			Handler: s.createSpacesKey,
 			Tool: mcp.NewTool("spaces-key-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new Spaces key. SECURITY WARNING: The returned secret key should NEVER be added to files or committed to source control. Always store the secret key in environment variables (e.g., DO_SPACES_SECRET_KEY) and access it securely at runtime. The secret key should be treated as highly sensitive credential information and should not be displayed in logs or output when possible."),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the Spaces key")),
 			),
@@ -263,6 +270,8 @@ func (s *KeysTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateSpacesKey,
 			Tool: mcp.NewTool("spaces-key-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update an existing Spaces key"),
 				mcp.WithString("AccessKey", mcp.Required(), mcp.Description("Access Key of the Spaces key to update")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the Spaces key")),
@@ -271,6 +280,8 @@ func (s *KeysTool) Tools() []server.ServerTool {
 		{
 			Handler: s.deleteSpacesKey,
 			Tool: mcp.NewTool("spaces-key-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a Spaces key"),
 				mcp.WithString("AccessKey", mcp.Required(), mcp.Description("Access Key of the Spaces key to delete")),
 			),

--- a/pkg/registry/spaces/spaces_annotations_test.go
+++ b/pkg/registry/spaces/spaces_annotations_test.go
@@ -30,7 +30,7 @@ var expectedAnnotations = map[string]struct {
 	// keys_tools.go
 	"spaces-key-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
 	"spaces-key-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
-	"spaces-key-create": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"spaces-key-create": {false, false, false, false, common.OpCreate, common.RiskHigh, false, false},
 	"spaces-key-update": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
 	"spaces-key-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
 

--- a/pkg/registry/spaces/spaces_annotations_test.go
+++ b/pkg/registry/spaces/spaces_annotations_test.go
@@ -1,0 +1,118 @@
+package spaces
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// keys_tools.go
+	"spaces-key-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"spaces-key-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"spaces-key-create": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"spaces-key-update": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"spaces-key-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// cdn_tools.go
+	"spaces-cdn-get":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"spaces-cdn-list":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"spaces-cdn-create":      {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"spaces-cdn-delete":      {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"spaces-cdn-flush-cache": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewSpacesKeysTool(clientFn).Tools()...)
+	all = append(all, NewCDNTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.

## What this does

Applies the shared annotation profiles to **every `spaces` tool** (access keys + CDN) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`spaces_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern. This PR is self-contained and independently mergeable onto `main`.

## Field definitions

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for deletes.
- **`idempotent`** — repeating converges to the same state.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and trivially reversible ops; **medium** = credential mutation / recoverable reconfigure; **high** = irreversible/data-losing (delete a live resource). Round up when unsure.

## Classification in this PR

### Access keys (`keys_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `spaces-key-list` | Read | read | – | ✓ | low |
| `spaces-key-get` | Read | read | – | ✓ | low |
| `spaces-key-create` | Create | create | – | – | medium |
| `spaces-key-update` | Toggle | update | – | ✓ | medium |
| `spaces-key-delete` | Delete | delete | ✓ | ✓ | medium |

### CDN (`cdn_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `spaces-cdn-get` | Read | read | – | ✓ | low |
| `spaces-cdn-list` | Read | read | – | ✓ | low |
| `spaces-cdn-create` | Create | create | – | – | medium |
| `spaces-cdn-delete` | Delete | delete | ✓ | ✓ | high |
| `spaces-cdn-flush-cache` | Toggle | update | – | ✓ | medium |

## Points of clarification (please confirm)

1. **`spaces-key-create` — medium (not low).** It mints a Spaces access key **and secret** (live full-access credentials). Normally a cheap additive artifact would be low (like an SSH key), but the credential nature pushed it to medium. Confirm, or drop to low.
2. **`spaces-key-update` — medium.** Currently only renames the key (no grant change). By the generic rubric a rename is Toggle/**low**; kept medium because it's a credential mutation. Reviewer may prefer low.
3. **`spaces-key-delete` — medium (not high).** Deleting a live credential can break apps still using it, but no stored data is lost — so medium rather than the "delete live resource → high" default. Confirm.
4. **`spaces-cdn-delete` — high.** Rounded up per "delete a live resource." Arguably **medium**: a CDN endpoint is just an edge layer over an existing Spaces bucket — deletion loses no origin data and is recoverable by recreating. Reviewer may prefer medium.
5. **`spaces-cdn-flush-cache` — Toggle / medium.** Idempotent (converges to "cache cleared"). Arguably **low** (only forces origin re-fetch / transient latency, fully reversible).

## Test plan

- `go build ./...`, `go vet ./pkg/registry/spaces/...`, `go test ./pkg/registry/spaces/...` — all pass.
- `gofmt` clean.
