### PR TITLE
feat(insights): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/insights/alert_policy_tools.go
+++ b/pkg/registry/insights/alert_policy_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -296,6 +297,8 @@ func (c *AlertPolicyTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getAlertPolicy,
 			Tool: mcp.NewTool("alert-policy-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get Alert Policy information by UUID"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("UUID of the Alert Policy to retrieve (format: 00000000-0000-0000-0000-000000000000)")),
 			),
@@ -303,6 +306,8 @@ func (c *AlertPolicyTool) Tools() []server.ServerTool {
 		{
 			Handler: c.listAlertPolicies,
 			Tool: mcp.NewTool("alert-policy-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all Alert Policies in your account with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultAlertPoliciesPage), mcp.Description("Page number for pagination (starts from 1)")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultAlertPoliciesPageSize), mcp.Description("Number of items per page (1-200, default 20)")),
@@ -311,6 +316,8 @@ func (c *AlertPolicyTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createAlertPolicy,
 			Tool: mcp.NewTool("alert-policy-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a new Alert Policy"),
 				mcp.WithString("Type", mcp.Required(), mcp.Description(`Type of the Alert Policy. Available types:
 Droplet metrics:
@@ -372,6 +379,8 @@ Database metrics:
 		{
 			Handler: c.updateAlertPolicy,
 			Tool: mcp.NewTool("alert-policy-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update an Alert Policy"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("UUID of the Alert Policy to update")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description(`Type of the Alert Policy. Available types:
@@ -434,6 +443,8 @@ Database metrics:
 		{
 			Handler: c.deleteAlertPolicy,
 			Tool: mcp.NewTool("alert-policy-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete an Alert Policy permanently"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("UUID of the Alert Policy to delete (format: 00000000-0000-0000-0000-000000000000)")),
 			),

--- a/pkg/registry/insights/insights_annotations_test.go
+++ b/pkg/registry/insights/insights_annotations_test.go
@@ -1,0 +1,127 @@
+package insights
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// uptime_tools.go
+	"uptimecheck-get":       {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"uptimecheck-get-state": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"uptimecheck-list":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"uptimecheck-create":    {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"uptimecheck-update":    {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"uptimecheck-delete":    {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// uptime_alert_tools.go
+	"uptimecheck-alert-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"uptimecheck-alert-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"uptimecheck-alert-create": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"uptimecheck-alert-update": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"uptimecheck-alert-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+
+	// alert_policy_tools.go
+	"alert-policy-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"alert-policy-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"alert-policy-create": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"alert-policy-update": {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"alert-policy-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewUptimeTool(clientFn).Tools()...)
+	all = append(all, NewUptimeCheckAlertTool(clientFn).Tools()...)
+	all = append(all, NewAlertPolicyTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/insights/uptime_alert_tools.go
+++ b/pkg/registry/insights/uptime_alert_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -256,6 +257,8 @@ func (c *UptimeCheckAlertTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getUptimeCheckAlert,
 			Tool: mcp.NewTool("uptimecheck-alert-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get UptimeCheck Alert information by CheckID and AlertID"),
 				mcp.WithString("CheckID", mcp.Required(), mcp.Description("A unique identifier for a check")),
 				mcp.WithString("AlertID", mcp.Required(), mcp.Description("A unique identifier for a alert")),
@@ -264,6 +267,8 @@ func (c *UptimeCheckAlertTool) Tools() []server.ServerTool {
 		{
 			Handler: c.listUptimeCheckAlerts,
 			Tool: mcp.NewTool("uptimecheck-alert-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List UptimeChecks Alerts with pagination"),
 				mcp.WithString("CheckID", mcp.Required(), mcp.Description("A unique identifier for a check")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultAlertsPage), mcp.Description("Page number")),
@@ -273,6 +278,8 @@ func (c *UptimeCheckAlertTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createUptimeCheckAlert,
 			Tool: mcp.NewTool("uptimecheck-alert-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a new UptimeCheck"),
 				mcp.WithString("CheckID", mcp.Required(), mcp.Description("A unique identifier for a check")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the UptimeCheck Alert")),
@@ -301,6 +308,8 @@ func (c *UptimeCheckAlertTool) Tools() []server.ServerTool {
 		{
 			Handler: c.updateUptimeCheckAlert,
 			Tool: mcp.NewTool("uptimecheck-alert-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a UptimeCheck"),
 				mcp.WithString("CheckID", mcp.Required(), mcp.Description("A unique identifier for a check")),
 				mcp.WithString("AlertID", mcp.Required(), mcp.Description("A unique identifier for a check alert")),
@@ -330,6 +339,8 @@ func (c *UptimeCheckAlertTool) Tools() []server.ServerTool {
 		{
 			Handler: c.deleteUptimeCheckAlert,
 			Tool: mcp.NewTool("uptimecheck-alert-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a uptimeCheck"),
 				mcp.WithString("CheckID", mcp.Required(), mcp.Description("A unique identifier for a check")),
 				mcp.WithString("AlertID", mcp.Required(), mcp.Description("A unique identifier for a alert")),

--- a/pkg/registry/insights/uptime_tools.go
+++ b/pkg/registry/insights/uptime_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 const (
@@ -223,6 +224,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getUptimeCheck,
 			Tool: mcp.NewTool("uptimecheck-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get UptimeCheck information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the UptimeCheck")),
 			),
@@ -230,6 +233,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getUptimeCheckState,
 			Tool: mcp.NewTool("uptimecheck-get-state",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get UptimeCheck information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the UptimeCheck")),
 			),
@@ -237,6 +242,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.listUptimeChecks,
 			Tool: mcp.NewTool("uptimecheck-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List UptimeChecks with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(defaultChecksPage), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(defaultChecksPageSize), mcp.Description("Items per page")),
@@ -245,6 +252,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createUptimeCheck,
 			Tool: mcp.NewTool("uptimecheck-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a new UptimeCheck"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the UptimeCheck")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Type of the UptimeCheck. value : HTTPS, HTTP or PING")),
@@ -257,6 +266,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.updateUptimeCheck,
 			Tool: mcp.NewTool("uptimecheck-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a UptimeCheck"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the UptimeCheck")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the UptimeCheck")),
@@ -270,6 +281,8 @@ func (c *UptimeTool) Tools() []server.ServerTool {
 		{
 			Handler: c.deleteUptimeCheck,
 			Tool: mcp.NewTool("uptimecheck-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a uptimeCheck"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the uptimeCheck to delete")),
 			),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.
>

## What this does

Applies the shared annotation profiles to **every `insights` tool** (uptime checks, uptime-check alerts, alert policies) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`insights_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern. This PR is self-contained and independently mergeable onto `main`.

## Field definitions

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo.
- **`idempotent`** — repeating converges to the same state.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and cheap/reversible config; **medium** = recoverable but more impactful; **high** = irreversible/data-losing. Round up when unsure.

## Classification in this PR

### Uptime checks (`uptime_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `uptimecheck-get` | Read | read | – | ✓ | low |
| `uptimecheck-get-state` | Read | read | – | ✓ | low |
| `uptimecheck-list` | Read | read | – | ✓ | low |
| `uptimecheck-create` | Create | create | – | – | low |
| `uptimecheck-update` | Toggle | update | – | ✓ | low |
| `uptimecheck-delete` | Delete | delete | ✓ | ✓ | medium |

### Uptime alerts (`uptime_alert_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `uptimecheck-alert-get` | Read | read | – | ✓ | low |
| `uptimecheck-alert-list` | Read | read | – | ✓ | low |
| `uptimecheck-alert-create` | Create | create | – | – | low |
| `uptimecheck-alert-update` | Toggle | update | – | ✓ | low |
| `uptimecheck-alert-delete` | Delete | delete | ✓ | ✓ | medium |

### Alert policies (`alert_policy_tools.go`)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `alert-policy-get` | Read | read | – | ✓ | low |
| `alert-policy-list` | Read | read | – | ✓ | low |
| `alert-policy-create` | Create | create | – | – | low |
| `alert-policy-update` | Toggle | update | – | ✓ | low |
| `alert-policy-delete` | Delete | delete | ✓ | ✓ | medium |

## Points of clarification (please confirm)

1. **All `*-create` = low** (not medium). Uptime checks/alerts and alert policies are free, easily-reversible monitoring config objects — not paid/provisioned infra — so creates use the "cheap additive artifact" branch of the rubric. Bump to medium if you'd rather treat any provisioning as medium.
2. **All `*-delete` = medium** (not high). These delete monitoring *config*, not customer data — rounded up to medium per the "config, round up if unsure" guidance rather than high.
3. **`*-update` = Toggle / low** — full-object convergent updates, trivially reversible. Flag if reconfiguring an active alert policy should be medium.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/insights/...`, `go test ./pkg/registry/insights/...` — all pass.
- `gofmt` clean.
