### PR TITLE
feat(doks): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/doks/doks.go
+++ b/pkg/registry/doks/doks.go
@@ -10,8 +10,22 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"mcp-digitalocean/pkg/registry/common"
+
 	_ "embed"
 )
+
+// rawSchemaTool builds a Tool from a raw JSON input schema and applies the
+// given options. NewToolWithRawSchema does not accept ToolOptions directly, so
+// the hint profile and risk options are applied to the constructed tool here.
+// The applied options only touch Annotations and _meta, not the input schema.
+func rawSchemaTool(name, description string, schema json.RawMessage, opts ...mcp.ToolOption) mcp.Tool {
+	t := mcp.NewToolWithRawSchema(name, description, schema)
+	for _, opt := range opts {
+		opt(&t)
+	}
+	return t
+}
 
 //go:embed spec/cluster-create-schema.json
 var clusterCreateSchemaJSON []byte
@@ -796,6 +810,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDoksCluster,
 			Tool: mcp.NewTool("doks-get-cluster",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
@@ -803,6 +819,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.listDOKSClusters,
 			Tool: mcp.NewTool("doks-list-clusters",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all DigitalOcean Kubernetes clusters"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number of the results to fetch")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Number of items returned per page")),
@@ -810,13 +828,17 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		},
 		{
 			Handler: d.createDOKSCluster,
-			Tool: mcp.NewToolWithRawSchema("doks-create-cluster",
+			Tool: rawSchemaTool("doks-create-cluster",
 				"Create a new DigitalOcean Kubernetes cluster", clusterCreateSchemaJSON,
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskHigh),
 			),
 		},
 		{
 			Handler: d.updateDOKSCluster,
 			Tool: mcp.NewTool("doks-update-cluster",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Update a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("Name", mcp.Description("The name of the Kubernetes cluster")),
@@ -829,6 +851,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDOKSCluster,
 			Tool: mcp.NewTool("doks-delete-cluster",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
@@ -836,6 +860,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.upgradeDOKSCluster,
 			Tool: mcp.NewTool("doks-upgrade-cluster",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Upgrade a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("VersionSlug", mcp.Required(), mcp.Description("The Kubernetes version to upgrade to")),
@@ -844,6 +870,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDOKSClusterUpgrades,
 			Tool: mcp.NewTool("doks-get-cluster-upgrades",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get available upgrades for a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
@@ -851,6 +879,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDOKSClusterKubeConfig,
 			Tool: mcp.NewTool("doks-get-kubeconfig",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get kubeconfig for a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
@@ -858,19 +888,25 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDOKSClusterCredentials,
 			Tool: mcp.NewTool("doks-get-credentials",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get credentials for a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
 		},
 		{
 			Handler: d.createDOKSNodePool,
-			Tool: mcp.NewToolWithRawSchema("doks-create-nodepool",
+			Tool: rawSchemaTool("doks-create-nodepool",
 				"Create a new node pool in a DigitalOcean Kubernetes cluster", nodePoolCreateSchemaJSON,
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 			),
 		},
 		{
 			Handler: d.getDOKSNodePool,
 			Tool: mcp.NewTool("doks-get-nodepool",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a node pool in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
@@ -879,6 +915,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.listDOKSNodePools,
 			Tool: mcp.NewTool("doks-list-nodepools",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List all node pools in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 			),
@@ -886,6 +924,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.updateDOKSNodePool,
 			Tool: mcp.NewTool("doks-update-nodepool",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a node pool in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
@@ -902,6 +942,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDOKSNodePool,
 			Tool: mcp.NewTool("doks-delete-nodepool",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a node pool in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
@@ -910,6 +952,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDOKSNode,
 			Tool: mcp.NewTool("doks-delete-node",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a node from a node pool in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
@@ -921,6 +965,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.recycleDOKSNodes,
 			Tool: mcp.NewTool("doks-recycle-nodes",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Recycle specific nodes in a node pool in a DigitalOcean Kubernetes cluster"),
 				mcp.WithString("ClusterID", mcp.Required(), mcp.Description("The ID of the Kubernetes cluster")),
 				mcp.WithString("NodePoolID", mcp.Required(), mcp.Description("The ID of the node pool")),
@@ -930,6 +976,8 @@ func (d *DoksTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getKubernetesOptions,
 			Tool: mcp.NewTool("doks-list-options",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List available Kubernetes options including versions, regions, and sizes"),
 			),
 		},

--- a/pkg/registry/doks/doks_annotations_test.go
+++ b/pkg/registry/doks/doks_annotations_test.go
@@ -1,0 +1,122 @@
+package doks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See common/annotations.go for the rationale
+// behind the six profile categories these rows map to. permission is not
+// listed per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// doks.go
+	"doks-get-cluster":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-list-clusters":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-create-cluster":       {false, false, false, false, common.OpCreate, common.RiskHigh, false, false},
+	"doks-update-cluster":       {false, false, true, false, common.OpUpdate, common.RiskLow, false, false},
+	"doks-delete-cluster":       {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"doks-upgrade-cluster":      {false, false, false, false, common.OpUpdate, common.RiskHigh, false, false},
+	"doks-get-cluster-upgrades": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-get-kubeconfig":       {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-get-credentials":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-create-nodepool":      {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"doks-get-nodepool":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-list-nodepools":       {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"doks-update-nodepool":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"doks-delete-nodepool":      {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"doks-delete-node":          {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"doks-recycle-nodes":        {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+	"doks-list-options":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewDoksTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.


## What this does

Applies the shared annotation profiles to **every `doks` (Kubernetes) tool** (clusters + node pools) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A per-tool contract test (`doks_annotations_test.go`) is added, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern. This PR is self-contained and independently mergeable onto `main`.

## Field definitions

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for deletes.
- **`idempotent`** — repeating converges to the same state; a fresh create/upgrade/recycle does not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and trivially reversible config; **medium** = recoverable single-resource provisioning/reconfigure; **high** = irreversible/data-losing or expensive provisioning. Round up when unsure.

The six hint profiles: `Read`, `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR (`doks.go`, 17 tools)

| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `doks-get-cluster` | Read | read | – | ✓ | low |
| `doks-list-clusters` | Read | read | – | ✓ | low |
| `doks-create-cluster` | Create | create | – | – | high |
| `doks-update-cluster` | Toggle | update | – | ✓ | low |
| `doks-delete-cluster` | Delete | delete | ✓ | ✓ | high |
| `doks-upgrade-cluster` | Action | update | – | – | high |
| `doks-get-cluster-upgrades` | Read | read | – | ✓ | low |
| `doks-get-kubeconfig` | Read | read | – | ✓ | low |
| `doks-get-credentials` | Read | read | – | ✓ | low |
| `doks-create-nodepool` | Create | create | – | – | medium |
| `doks-get-nodepool` | Read | read | – | ✓ | low |
| `doks-list-nodepools` | Read | read | – | ✓ | low |
| `doks-update-nodepool` | Toggle | update | – | ✓ | medium |
| `doks-delete-nodepool` | Delete | delete | ✓ | ✓ | high |
| `doks-delete-node` | Delete | delete | ✓ | ✓ | high |
| `doks-recycle-nodes` | Action | update | – | – | medium |
| `doks-list-options` | Read | read | – | ✓ | low |

## Points of clarification (please confirm)

1. **`doks-get-kubeconfig` / `doks-get-credentials` — Read / low, but sensitive.** Both are side-effect-free reads, yet they **return live cluster credentials** (kubeconfig, client cert/key, bearer token, CA data). Flagging in case these should carry a higher risk or a `sensitive`/redaction treatment despite being reads.
2. **`doks-create-cluster` — Create / high** (expensive provisioning of a whole cluster you wouldn't fan out); **`doks-create-nodepool` — Create / medium.** Confirm the split.
3. **`doks-upgrade-cluster` — Action / high** (fresh, effectively irreversible async upgrade; non-idempotent so Action not Toggle). **`doks-recycle-nodes` — Action / medium.** Confirm.
4. **`doks-delete-node` — Delete / high** (rounded up). Arguably **medium**: a single node is ephemeral/cattle, the pool self-heals, and the tool has a `Replace`/`SkipDrain` flag making it recycle-like. Reviewer may prefer medium.
5. **`doks-update-cluster` — Toggle / low** (name/tags/maintenance/auto-upgrade flags). Could be medium if enabling auto-upgrade is considered impactful. `doks-update-nodepool` kept at **medium** since it includes node count/autoscale (re-provisioning).
6. **Raw-schema create tools.** `doks-create-cluster` and `doks-create-nodepool` use `mcp.NewToolWithRawSchema`, which doesn't accept `ToolOption`s. A small package-local `rawSchemaTool(...)` helper builds the tool then applies `WithHints`/`WithRisk` (touches only `Annotations`/`_meta`, never the input schema). Flag if you'd prefer a different mechanism.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/doks/...`, `go test ./pkg/registry/doks/...` — all pass.
- `gofmt` clean.
