### PR TITLE
feat(dbaas): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/dbaas/cluster.go
+++ b/pkg/registry/dbaas/cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type ClusterTool struct {
@@ -382,6 +383,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listCluster,
 			Tool: mcp.NewTool("db-cluster-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get list of  Cluster"),
 				mcp.WithString("page", mcp.Description("Page number for pagination (optional, integer as string)")),
 				mcp.WithNumber("per_page", mcp.Description("Number of results per page (optional, integer)")),
@@ -390,6 +393,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getCluster,
 			Tool: mcp.NewTool("db-cluster-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the cluster to retrieve")),
 			),
@@ -397,6 +402,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getCA,
 			Tool: mcp.NewTool("db-cluster-get-ca",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the CA certificate for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the cluster to retrieve the CA for")),
 			),
@@ -404,6 +411,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.createCluster,
 			Tool: mcp.NewTool("db-cluster-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new database cluster"),
 				mcp.WithString("name", mcp.Required(), mcp.Description("The name of the cluster")),
 				mcp.WithString("engine", mcp.Required(), mcp.Description("The engine slug (e.g., valkey, pg, mysql, etc.)")),
@@ -417,6 +426,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.deleteCluster,
 			Tool: mcp.NewTool("db-cluster-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a database cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the cluster to delete")),
 			),
@@ -424,6 +435,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.resizeCluster,
 			Tool: mcp.NewTool("db-cluster-resize",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Resize a database cluster by its id. At least one of size, num_nodes, or storage_size_mib must be provided."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the cluster to resize")),
 				mcp.WithString("size", mcp.Description("The new size slug (e.g., db-s-2vcpu-4gb)")),
@@ -434,6 +447,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listBackups,
 			Tool: mcp.NewTool("db-cluster-list-backups",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List backups for a database cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The id of the cluster to list backups for")),
 				mcp.WithString("page", mcp.Description("Page number for pagination (optional, integer as string)")),
@@ -443,12 +458,16 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listOptions,
 			Tool: mcp.NewTool("db-cluster-list-options",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List available database options (engines, versions, sizes, regions, etc) for DigitalOcean managed databases."),
 			),
 		},
 		{
 			Handler: s.upgradeMajorVersion,
 			Tool: mcp.NewTool("db-cluster-upgrade-major-version",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Upgrade the major version of a database cluster by its id. Requires the target version."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithString("version", mcp.Required(), mcp.Description("The target major version to upgrade to (e.g., 15 for PostgreSQL)")),
@@ -457,6 +476,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.startOnlineMigration,
 			Tool: mcp.NewTool("db-cluster-start-online-migration",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Start an online migration for a database cluster by its id."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("source",
@@ -492,6 +513,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.stopOnlineMigration,
 			Tool: mcp.NewTool("db-cluster-stop-online-migration",
+				common.WithHints(common.HintsAction),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Stop an online migration for a database cluster by its id and migration_id."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithString("migration_id", mcp.Required(), mcp.Description("The migration id to stop")),
@@ -500,6 +523,8 @@ func (s *ClusterTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getOnlineMigrationStatus,
 			Tool: mcp.NewTool("db-cluster-get-migration",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the online migration status for a database cluster by its id."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),

--- a/pkg/registry/dbaas/dbaas_annotations_test.go
+++ b/pkg/registry/dbaas/dbaas_annotations_test.go
@@ -1,0 +1,167 @@
+package dbaas
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See common/annotations.go for the rationale
+// behind the six profile categories these rows map to. permission is not
+// listed per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// cluster.go
+	"db-cluster-list":                   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-get":                    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-get-ca":                 {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-create":                 {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"db-cluster-delete":                 {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"db-cluster-resize":                 {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-list-backups":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-list-options":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-upgrade-major-version":  {false, false, false, false, common.OpUpdate, common.RiskHigh, false, false},
+	"db-cluster-start-online-migration": {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-stop-online-migration":  {false, false, false, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-get-migration":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+
+	// firewall.go
+	"db-cluster-get-firewall-rules":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-firewall-rules": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// kafka.go
+	"db-cluster-list-topics":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-create-topic":        {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"db-cluster-get-topic":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-delete-topic":        {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"db-cluster-update-topic":        {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-get-kafka-config":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-kafka-config": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// mongo.go
+	"db-cluster-get-mongodb-config":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-mongodb-config": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// mysql.go
+	"db-cluster-get-mysql-config":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-mysql-config": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-get-sql-mode":        {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-set-sql-mode":        {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// opensearch.go
+	"db-cluster-get-opensearch-config": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-os-config":      {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// postgres.go
+	"db-cluster-get-postgresql-config": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-psql-config":    {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// redis.go
+	"db-cluster-get-redis-config":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-update-redis-config": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// user.go
+	"db-cluster-get-user":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-list-users":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"db-cluster-create-user": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"db-cluster-update-user": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"db-cluster-delete-user": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewClusterTool(clientFn).Tools()...)
+	all = append(all, NewFirewallTool(clientFn).Tools()...)
+	all = append(all, NewKafkaTool(clientFn).Tools()...)
+	all = append(all, NewMongoTool(clientFn).Tools()...)
+	all = append(all, NewMysqlTool(clientFn).Tools()...)
+	all = append(all, NewOpenSearchTool(clientFn).Tools()...)
+	all = append(all, NewPostgreSQLTool(clientFn).Tools()...)
+	all = append(all, NewRedisTool(clientFn).Tools()...)
+	all = append(all, NewUserTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/dbaas/firewall.go
+++ b/pkg/registry/dbaas/firewall.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type FirewallTool struct {
@@ -95,6 +96,8 @@ func (s *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getFirewallRules,
 			Tool: mcp.NewTool("db-cluster-get-firewall-rules",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get firewall rules for a database cluster."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -102,6 +105,8 @@ func (s *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateFirewallRules,
 			Tool: mcp.NewTool("db-cluster-update-firewall-rules",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update firewall rules for a cluster using a structured list of rules."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithArray("rules",

--- a/pkg/registry/dbaas/kafka.go
+++ b/pkg/registry/dbaas/kafka.go
@@ -10,6 +10,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type KafkaTool struct {
@@ -286,6 +287,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listTopics,
 			Tool: mcp.NewTool("db-cluster-list-topics",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List topics for a Kafka cluster by its ID. Supports pagination and filtering."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The Kafka cluster UUID")),
 				mcp.WithString("page", mcp.Description("Page number (string)")),
@@ -299,6 +302,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.createTopic,
 			Tool: mcp.NewTool("db-cluster-create-topic",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a topic for a Kafka cluster."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Topic name")),
@@ -336,6 +341,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getTopic,
 			Tool: mcp.NewTool("db-cluster-get-topic",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a Kafka topic by name."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Topic name")),
@@ -344,6 +351,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.deleteTopic,
 			Tool: mcp.NewTool("db-cluster-delete-topic",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a Kafka topic by name."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Topic name")),
@@ -352,6 +361,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateTopic,
 			Tool: mcp.NewTool("db-cluster-update-topic",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a Kafka topic's partition count, replication factor, or config."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("Topic name")),
@@ -389,6 +400,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getKafkaConfig,
 			Tool: mcp.NewTool("db-cluster-get-kafka-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the Kafka config for a cluster."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 			),
@@ -396,6 +409,8 @@ func (s *KafkaTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateKafkaConfig,
 			Tool: mcp.NewTool("db-cluster-update-kafka-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the Kafka cluster configuration."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("Kafka cluster UUID")),
 				mcp.WithObject("config",

--- a/pkg/registry/dbaas/mongo.go
+++ b/pkg/registry/dbaas/mongo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type MongoTool struct {
@@ -80,6 +81,8 @@ func (s *MongoTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getMongoDBConfig,
 			Tool: mcp.NewTool("db-cluster-get-mongodb-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the MongoDB config for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -87,6 +90,8 @@ func (s *MongoTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateMongoDBConfig,
 			Tool: mcp.NewTool("db-cluster-update-mongodb-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the MongoDB config for a cluster by its id. Accepts a structured config object."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("config",

--- a/pkg/registry/dbaas/mysql.go
+++ b/pkg/registry/dbaas/mysql.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type MysqlTool struct {
@@ -125,6 +126,8 @@ func (s *MysqlTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getMySQLConfig,
 			Tool: mcp.NewTool("db-cluster-get-mysql-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the MySQL config for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -132,6 +135,8 @@ func (s *MysqlTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateMySQLConfig,
 			Tool: mcp.NewTool("db-cluster-update-mysql-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the MySQL config for a cluster by its id. Accepts a structured 'config' object."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("config",
@@ -179,6 +184,8 @@ func (s *MysqlTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getSQLMode,
 			Tool: mcp.NewTool("db-cluster-get-sql-mode",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the SQL mode for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -186,6 +193,8 @@ func (s *MysqlTool) Tools() []server.ServerTool {
 		{
 			Handler: s.setSQLMode,
 			Tool: mcp.NewTool("db-cluster-set-sql-mode",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Set the SQL mode for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithString("modes", mcp.Required(), mcp.Description("Comma-separated SQL modes to set")),

--- a/pkg/registry/dbaas/opensearch.go
+++ b/pkg/registry/dbaas/opensearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type OpenSearchTool struct {
@@ -75,6 +76,8 @@ func (s *OpenSearchTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getOpensearchConfig,
 			Tool: mcp.NewTool("db-cluster-get-opensearch-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the Opensearch config for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -82,6 +85,8 @@ func (s *OpenSearchTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateOpensearchConfig,
 			Tool: mcp.NewTool("db-cluster-update-os-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the Opensearch config for a cluster by its id. Accepts a structured config object."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("config",

--- a/pkg/registry/dbaas/postgres.go
+++ b/pkg/registry/dbaas/postgres.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type PostgreSQLTool struct {
@@ -83,6 +84,8 @@ func (s *PostgreSQLTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getPostgreSQLConfig,
 			Tool: mcp.NewTool("db-cluster-get-postgresql-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the PostgreSQL config for a cluster by its id"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -90,6 +93,8 @@ func (s *PostgreSQLTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updatePostgreSQLConfig,
 			Tool: mcp.NewTool("db-cluster-update-psql-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the PostgreSQL config for a cluster by its id. Accepts a structured config object."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("config",

--- a/pkg/registry/dbaas/redis.go
+++ b/pkg/registry/dbaas/redis.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type RedisTool struct {
@@ -84,6 +85,8 @@ func (s *RedisTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getRedisConfig,
 			Tool: mcp.NewTool("db-cluster-get-redis-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the Redis config for a cluster by its id."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 			),
@@ -91,6 +94,8 @@ func (s *RedisTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateRedisConfig,
 			Tool: mcp.NewTool("db-cluster-update-redis-config",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update the Redis config for a cluster by its id. Accepts a structured config object."),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster UUID")),
 				mcp.WithObject("config",

--- a/pkg/registry/dbaas/user.go
+++ b/pkg/registry/dbaas/user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type UserTool struct {
@@ -258,6 +259,8 @@ func (s *UserTool) Tools() []server.ServerTool {
 		{
 			Handler: s.getUser,
 			Tool: mcp.NewTool("db-cluster-get-user",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a database user by cluster id and user name"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster ID")),
 				mcp.WithString("user", mcp.Required(), mcp.Description("The user name")),
@@ -266,6 +269,8 @@ func (s *UserTool) Tools() []server.ServerTool {
 		{
 			Handler: s.listUsers,
 			Tool: mcp.NewTool("db-cluster-list-users",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List database users for a cluster"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster ID")),
 				mcp.WithString("page", mcp.Description("Page number for pagination (optional)")),
@@ -275,6 +280,8 @@ func (s *UserTool) Tools() []server.ServerTool {
 		{
 			Handler: s.createUser,
 			Tool: mcp.NewTool("db-cluster-create-user",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new database user for a cluster"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster ID")),
 				mcp.WithString("name", mcp.Required(), mcp.Description("The user name")),
@@ -285,6 +292,8 @@ func (s *UserTool) Tools() []server.ServerTool {
 		{
 			Handler: s.updateUser,
 			Tool: mcp.NewTool("db-cluster-update-user",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a database user's settings"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster ID")),
 				mcp.WithString("user", mcp.Required(), mcp.Description("The user name")),
@@ -294,6 +303,8 @@ func (s *UserTool) Tools() []server.ServerTool {
 		{
 			Handler: s.deleteUser,
 			Tool: mcp.NewTool("db-cluster-delete-user",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a database user from a cluster"),
 				mcp.WithString("id", mcp.Required(), mcp.Description("The cluster ID")),
 				mcp.WithString("user", mcp.Required(), mcp.Description("The user name to delete")),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.

## What this does

Applies the shared annotation profiles to **every `dbaas` tool** (cluster lifecycle, firewall, per-engine config for Kafka/Mongo/MySQL/OpenSearch/Postgres/Redis, and users) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A single per-package contract test (`dbaas_annotations_test.go`) is added covering all 38 tools across all 9 source files, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern. This PR is self-contained and independently mergeable onto `main`.

## Field definitions

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for deletes.
- **`idempotent`** — repeating converges to the same state; migrations/upgrades/creates do not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads; **medium** = recoverable provisioning/reconfigure or sub-resource delete; **high** = irreversible/data-losing (delete a live cluster, major-version upgrade). Round up when unsure.

The six hint profiles: `Read`, `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR (38 tools)

### `cluster.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `db-cluster-list` | Read | read | – | ✓ | low |
| `db-cluster-get` | Read | read | – | ✓ | low |
| `db-cluster-get-ca` | Read | read | – | ✓ | low |
| `db-cluster-create` | Create | create | – | – | medium |
| `db-cluster-delete` | Delete | delete | ✓ | ✓ | high |
| `db-cluster-resize` | Toggle | update | – | ✓ | medium |
| `db-cluster-list-backups` | Read | read | – | ✓ | low |
| `db-cluster-list-options` | Read | read | – | ✓ | low |
| `db-cluster-upgrade-major-version` | Action | update | – | – | high |
| `db-cluster-start-online-migration` | Action | update | – | – | medium |
| `db-cluster-stop-online-migration` | Action | update | – | – | medium |
| `db-cluster-get-migration` | Read | read | – | ✓ | low |

### `firewall.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `db-cluster-get-firewall-rules` | Read | read | – | ✓ | low |
| `db-cluster-update-firewall-rules` | Toggle | update | – | ✓ | medium |

### `kafka.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `db-cluster-list-topics` | Read | read | – | ✓ | low |
| `db-cluster-create-topic` | Create | create | – | – | medium |
| `db-cluster-get-topic` | Read | read | – | ✓ | low |
| `db-cluster-delete-topic` | Delete | delete | ✓ | ✓ | medium |
| `db-cluster-update-topic` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-kafka-config` | Read | read | – | ✓ | low |
| `db-cluster-update-kafka-config` | Toggle | update | – | ✓ | medium |

### `mongo.go` / `mysql.go` / `opensearch.go` / `postgres.go` / `redis.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `db-cluster-get-mongodb-config` | Read | read | – | ✓ | low |
| `db-cluster-update-mongodb-config` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-mysql-config` | Read | read | – | ✓ | low |
| `db-cluster-update-mysql-config` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-sql-mode` | Read | read | – | ✓ | low |
| `db-cluster-set-sql-mode` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-opensearch-config` | Read | read | – | ✓ | low |
| `db-cluster-update-os-config` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-postgresql-config` | Read | read | – | ✓ | low |
| `db-cluster-update-psql-config` | Toggle | update | – | ✓ | medium |
| `db-cluster-get-redis-config` | Read | read | – | ✓ | low |
| `db-cluster-update-redis-config` | Toggle | update | – | ✓ | medium |

### `user.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `db-cluster-get-user` | Read | read | – | ✓ | low |
| `db-cluster-list-users` | Read | read | – | ✓ | low |
| `db-cluster-create-user` | Create | create | – | – | medium |
| `db-cluster-update-user` | Toggle | update | – | ✓ | medium |
| `db-cluster-delete-user` | Delete | delete | ✓ | ✓ | medium |

## Points of clarification (please confirm)

1. **`db-cluster-upgrade-major-version` — Action / high.** Modeled as a non-idempotent action (each call kicks off a fresh, effectively irreversible major-version upgrade) rather than Replace, since it doesn't destroy/recreate in place. Flag if you'd prefer Replace.
2. **`db-cluster-delete-topic` / `db-cluster-delete-user` — Delete / medium (not high).** These delete a *sub-resource* of a cluster, not a live cluster. Bump to high if topic/user deletion is considered live-data-losing in your model.
3. **Config updates (`update-*-config`, `set-sql-mode`, `update-firewall-rules`, `update-topic`, `update-user`) — Toggle / medium.** Convergent reconfigurations. `db-cluster-update-user` (ACL/settings only) is arguably low; rounded up to medium.
4. **Online migration start/stop — Action / medium.** Neither converges idempotently (start pulls from a source; stop halts an in-flight job), hence Action not Toggle.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/dbaas/...`, `go test ./pkg/registry/dbaas/...` — all pass.
- `gofmt` clean.
