### PR TITLE
feat(networking): annotate tools with hint profiles and risk classification

### DIFF
--- a/pkg/registry/networking/byoip_prefix_tools.go
+++ b/pkg/registry/networking/byoip_prefix_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type BYOIPPrefixTool struct {
@@ -173,6 +174,8 @@ func (t *BYOIPPrefixTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getBYOIPPrefix,
 			Tool: mcp.NewTool("byoip-prefix-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get BYOIP prefix information by UUID"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("The UUID of the BYOIP prefix")),
 			),
@@ -180,6 +183,8 @@ func (t *BYOIPPrefixTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listBYOIPPrefix,
 			Tool: mcp.NewTool("byoip-prefix-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List BYOIP prefixes"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Number of items per page")),
@@ -188,6 +193,8 @@ func (t *BYOIPPrefixTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getByOIPPrefixResources,
 			Tool: mcp.NewTool("byoip-prefix-resources-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get all resources for a BYOIP prefix"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("The UUID of the BYOIP prefix")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
@@ -197,6 +204,8 @@ func (t *BYOIPPrefixTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createBYOIPPrefix,
 			Tool: mcp.NewTool("byoip-prefix-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new BYOIP prefix"),
 				mcp.WithString("Prefix", mcp.Required(), mcp.Description("The CIDR of the BYOIP prefix")),
 				mcp.WithString("Signature", mcp.Required(), mcp.Description("The signature for the prefix")),
@@ -206,6 +215,8 @@ func (t *BYOIPPrefixTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deleteBYOIPPrefix,
 			Tool: mcp.NewTool("byoip-prefix-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a BYOIP prefix"),
 				mcp.WithString("UUID", mcp.Required(), mcp.Description("The UUID of the BYOIP prefix")),
 			),

--- a/pkg/registry/networking/certificate_tools.go
+++ b/pkg/registry/networking/certificate_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // CertificateTool provides tools for managing certificates
@@ -163,6 +164,8 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 		{
 			Handler: c.getCertificate,
 			Tool: mcp.NewTool("certificate-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get certificate information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the certificate")),
 			),
@@ -170,6 +173,8 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 		{
 			Handler: c.listCertificates,
 			Tool: mcp.NewTool("certificate-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List certificates with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -178,6 +183,8 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createCustomCertificate,
 			Tool: mcp.NewTool("custom-certificate-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new custom certificate"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
 				mcp.WithString("PrivateKey", mcp.Required(), mcp.Description("Private key for the certificate")),
@@ -188,6 +195,8 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 		{
 			Handler: c.createLetsEncryptCertificate,
 			Tool: mcp.NewTool("lets-encrypt-certificate-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new let's encrypt certificate"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the certificate")),
 				mcp.WithArray("DnsNames", mcp.Required(), mcp.Description("DNS names of the certificate"), mcp.Items(map[string]any{
@@ -199,6 +208,8 @@ func (c *CertificateTool) Tools() []server.ServerTool {
 		{
 			Handler: c.deleteCertificate,
 			Tool: mcp.NewTool("certificate-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a certificate"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the certificate to delete")),
 			),

--- a/pkg/registry/networking/domains_tools.go
+++ b/pkg/registry/networking/domains_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type DomainsTool struct {
@@ -255,6 +256,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDomain,
 			Tool: mcp.NewTool("domain-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get domain information by name"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the domain")),
 			),
@@ -262,6 +265,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.listDomains,
 			Tool: mcp.NewTool("domain-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List domains with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -270,6 +275,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.getDomainRecord,
 			Tool: mcp.NewTool("domain-record-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a domain record by domain name and record ID"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
 				mcp.WithNumber("RecordID", mcp.Required(), mcp.Description("ID of the domain record")),
@@ -278,6 +285,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.listDomainRecords,
 			Tool: mcp.NewTool("domain-record-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List domain records for a domain with pagination"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
@@ -287,6 +296,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.createDomain,
 			Tool: mcp.NewTool("domain-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new domain"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the domain")),
 				mcp.WithString("IPAddress", mcp.Required(), mcp.Description("IP address for the domain")),
@@ -295,6 +306,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteDomain,
 			Tool: mcp.NewTool("domain-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a domain"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the domain to delete")),
 			),
@@ -302,6 +315,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.createRecord,
 			Tool: mcp.NewTool("domain-record-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Create a new domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Record type (e.g., A, CNAME, TXT)")),
@@ -312,6 +327,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.deleteRecord,
 			Tool: mcp.NewTool("domain-record-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete a domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
 				mcp.WithNumber("RecordID", mcp.Required(), mcp.Description("ID of the record to delete")),
@@ -320,6 +337,8 @@ func (d *DomainsTool) Tools() []server.ServerTool {
 		{
 			Handler: d.editRecord,
 			Tool: mcp.NewTool("domain-record-edit",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Edit a domain record"),
 				mcp.WithString("Domain", mcp.Required(), mcp.Description("Domain name")),
 				mcp.WithNumber("RecordID", mcp.Required(), mcp.Description("ID of the record to edit")),

--- a/pkg/registry/networking/firewall_tools.go
+++ b/pkg/registry/networking/firewall_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // FirewallTool provides firewall management tools
@@ -410,6 +411,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.getFirewall,
 			Tool: mcp.NewTool("firewall-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get firewall information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall")),
 			),
@@ -417,6 +420,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.listFirewalls,
 			Tool: mcp.NewTool("firewall-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List firewalls with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -425,6 +430,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.createFirewall,
 			Tool: mcp.NewTool("firewall-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new firewall"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the firewall")),
 				mcp.WithString("InboundProtocol", mcp.Required(), mcp.Description("Protocol for inbound rule")),
@@ -446,6 +453,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.deleteFirewall,
 			Tool: mcp.NewTool("firewall-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to delete")),
 			),
@@ -453,6 +462,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.addDroplets,
 			Tool: mcp.NewTool("firewall-add-droplets",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Adds one or more droplets to a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to apply to droplets")),
 				mcp.WithArray("DropletIDs", mcp.Required(), mcp.Description("Droplet IDs to apply the firewall to"), mcp.Items(map[string]any{
@@ -464,6 +475,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.addTags,
 			Tool: mcp.NewTool("firewall-add-tags",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Adds one or more tags to a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to update tags")),
 				mcp.WithArray("Tags", mcp.Required(), mcp.Description("Tags to apply the firewall to"), mcp.Items(map[string]any{
@@ -476,6 +489,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.removeDroplets,
 			Tool: mcp.NewTool("firewall-remove-droplets",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Removes one or more droplets from a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to remove droplets from")),
 				mcp.WithArray("DropletIDs", mcp.Required(), mcp.Description("Droplet IDs to remove from the firewall"), mcp.Items(map[string]any{
@@ -487,6 +502,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.removeTags,
 			Tool: mcp.NewTool("firewall-remove-tags",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Removes one or more tags from a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to update tags")),
 				mcp.WithArray("Tags", mcp.Required(), mcp.Description("Tags to remove from the firewall"), mcp.Items(map[string]any{
@@ -498,6 +515,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.addRules,
 			Tool: mcp.NewTool("firewall-add-rules",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Add one or more rules to a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to add rules to")),
 				mcp.WithArray("InboundRules", mcp.Description("Inbound rules to add"), mcp.Items(map[string]any{
@@ -551,6 +570,8 @@ func (f *FirewallTool) Tools() []server.ServerTool {
 		{
 			Handler: f.removeRules,
 			Tool: mcp.NewTool("firewall-remove-rules",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Remove one or more rules from a firewall"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the firewall to remove rules from")),
 				mcp.WithArray("InboundRules", mcp.Description("Inbound rules to remove"), mcp.Items(map[string]any{

--- a/pkg/registry/networking/load_balancers_tools.go
+++ b/pkg/registry/networking/load_balancers_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // LoadBalancersTool provides load balancer management tools
@@ -537,6 +538,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.createLoadBalancer,
 			Tool: mcp.NewTool("lb-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new Load Balancer"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the load balancer")),
 				mcp.WithString("Region", mcp.Description("Region slug (e.g., nyc3)")),
@@ -555,7 +558,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.deleteLoadBalancer,
 			Tool: mcp.NewTool("lb-delete",
-				mcp.WithDestructiveHintAnnotation(true),
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a Load Balancer by ID"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 			),
@@ -563,7 +567,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.deleteLoadBalancerCache,
 			Tool: mcp.NewTool("lb-delete-cache",
-				mcp.WithDestructiveHintAnnotation(true),
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Delete the CDN cache of a global load balancer by ID"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 			),
@@ -571,6 +576,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.getLoadBalancer,
 			Tool: mcp.NewTool("lb-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get a Load Balancer by ID"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 			),
@@ -578,6 +585,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.listLoadBalancers,
 			Tool: mcp.NewTool("lb-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List Load Balancers with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -586,6 +595,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.addDroplets,
 			Tool: mcp.NewTool("lb-add-droplets",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Add Droplets to a Load Balancer"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 				mcp.WithArray("DropletIDs", mcp.Required(), mcp.Description("IDs of the droplets to add"), mcp.Items(map[string]any{"type": "string"})),
@@ -594,6 +605,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.removeDroplets,
 			Tool: mcp.NewTool("lb-remove-droplets",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Remove Droplets from a Load Balancer"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 				mcp.WithArray("DropletIDs", mcp.Required(), mcp.Description("IDs of the droplets to remove"), mcp.Items(map[string]any{"type": "string"})),
@@ -602,6 +615,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.updateLoadBalancer,
 			Tool: mcp.NewTool("lb-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a Load Balancer"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the load balancer")),
@@ -621,6 +636,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.addForwardingRules,
 			Tool: mcp.NewTool("lb-add-fwd-rules",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Add Forwarding Rules to a Load Balancer"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 				mcp.WithArray("ForwardingRules", mcp.Required(), mcp.Description("Forwarding rules to add"), mcp.Items(map[string]any{"type": "string"})),
@@ -629,6 +646,8 @@ func (l *LoadBalancersTool) Tools() []server.ServerTool {
 		{
 			Handler: l.removeForwardingRules,
 			Tool: mcp.NewTool("lb-remove-fwd-rules",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Remove Forwarding Rules from a Load Balancer"),
 				mcp.WithString("LoadBalancerID", mcp.Required(), mcp.Description("ID of the load balancer")),
 				mcp.WithArray("ForwardingRules", mcp.Required(), mcp.Description("Forwarding rules to remove"), mcp.Items(map[string]any{"type": "string"})),

--- a/pkg/registry/networking/networking_annotations_test.go
+++ b/pkg/registry/networking/networking_annotations_test.go
@@ -1,0 +1,190 @@
+package networking
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// expectedAnnotations is the per-tool annotation contract enforced by
+// TestToolAnnotations. Adding a tool to this package WITHOUT a row here, or
+// changing an annotation in code without updating the row, fails the test.
+//
+// Order: readOnly, destructive, idempotent, openWorld, operation, risk,
+// parallelizable, streamingSafe. See annotations.go for the rationale behind
+// the six profile categories these rows map to. permission is not listed
+// per row because it is derived 1:1 from the tool name and asserted
+// generically. risk is set per tool (via common.WithRisk) because it varies
+// within a single hint profile.
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	// vpc_tools.go
+	"vpc-get":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"vpc-list":         {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"vpc-list-members": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"vpc-create":       {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"vpc-delete":       {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+
+	// vpc_peering_tools.go
+	"vpc-peering-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"vpc-peering-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"vpc-peering-create": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"vpc-peering-delete": {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+
+	// reserved_ips_tools.go
+	"reserved-ip-get":      {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"reserved-ip-list":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"reserved-ip-reserve":  {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"reserved-ip-release":  {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"reserved-ip-assign":   {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"reserved-ip-unassign": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// partner_attachment_tools.go
+	"partner-attachment-get":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"partner-attachment-list":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"partner-attachment-create":          {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"partner-attachment-delete":          {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"partner-attachment-get-service-key": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"partner-attachment-get-bgp-config":  {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"partner-attachment-update":          {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// load_balancers_tools.go
+	"lb-create":           {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"lb-delete":           {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"lb-delete-cache":     {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"lb-get":              {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"lb-list":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"lb-add-droplets":     {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"lb-remove-droplets":  {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"lb-update":           {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"lb-add-fwd-rules":    {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"lb-remove-fwd-rules": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// firewall_tools.go
+	"firewall-get":             {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"firewall-list":            {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"firewall-create":          {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"firewall-delete":          {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"firewall-add-droplets":    {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"firewall-add-tags":        {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"firewall-remove-droplets": {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"firewall-remove-tags":     {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"firewall-add-rules":       {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"firewall-remove-rules":    {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// domains_tools.go
+	"domain-get":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"domain-list":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"domain-record-get":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"domain-record-list":   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"domain-create":        {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"domain-delete":        {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"domain-record-create": {false, false, false, false, common.OpCreate, common.RiskLow, false, false},
+	"domain-record-delete": {false, true, true, false, common.OpDelete, common.RiskMedium, false, false},
+	"domain-record-edit":   {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+
+	// certificate_tools.go
+	"certificate-get":                 {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"certificate-list":                {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"custom-certificate-create":       {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"lets-encrypt-certificate-create": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"certificate-delete":              {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+
+	// byoip_prefix_tools.go
+	"byoip-prefix-get":           {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"byoip-prefix-list":          {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"byoip-prefix-resources-get": {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"byoip-prefix-create":        {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"byoip-prefix-delete":        {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	clientFn := func(context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	var all []server.ServerTool
+	all = append(all, NewVPCTool(clientFn).Tools()...)
+	all = append(all, NewVPCPeeringTool(clientFn).Tools()...)
+	all = append(all, NewReservedIPTool(clientFn).Tools()...)
+	all = append(all, NewPartnerAttachmentTool(clientFn).Tools()...)
+	all = append(all, NewLoadBalancersTool(clientFn).Tools()...)
+	all = append(all, NewFirewallTool(clientFn).Tools()...)
+	all = append(all, NewDomainsTool(clientFn).Tools()...)
+	all = append(all, NewCertificateTool(clientFn).Tools()...)
+	all = append(all, NewBYOIPPrefixTool(clientFn).Tools()...)
+
+	if len(all) != len(expectedAnnotations) {
+		t.Fatalf("tool count mismatch: registered=%d, expected=%d (add new tools to expectedAnnotations)", len(all), len(expectedAnnotations))
+	}
+
+	seen := make(map[string]bool, len(all))
+	for _, st := range all {
+		name := st.Tool.Name
+		if seen[name] {
+			t.Errorf("duplicate tool registration: %q", name)
+			continue
+		}
+		seen[name] = true
+
+		want, ok := expectedAnnotations[name]
+		if !ok {
+			t.Errorf("tool %q has no expected annotation row — add one to expectedAnnotations", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing one or more annotation hints (got %+v)", name, a)
+			continue
+		}
+		if got := *a.ReadOnlyHint; got != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, got, want.readOnly)
+		}
+		if got := *a.DestructiveHint; got != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, got, want.destructive)
+		}
+		if got := *a.IdempotentHint; got != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, got, want.idempotent)
+		}
+		if got := *a.OpenWorldHint; got != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, got, want.openWorld)
+		}
+
+		// Registry metadata (_meta), set by the hint profile.
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if got, _ := reg["operation"].(string); got != string(want.operation) {
+			t.Errorf("tool %q operation = %q, want %q", name, got, want.operation)
+		}
+		if got, _ := reg["risk"].(string); got != string(want.risk) {
+			t.Errorf("tool %q risk = %q, want %q", name, got, want.risk)
+		}
+		if got, _ := reg["parallelizable"].(bool); got != want.parallelizable {
+			t.Errorf("tool %q parallelizable = %v, want %v", name, got, want.parallelizable)
+		}
+		if got, _ := reg["streamingSafe"].(bool); got != want.streamingSafe {
+			t.Errorf("tool %q streamingSafe = %v, want %v", name, got, want.streamingSafe)
+		}
+	}
+}

--- a/pkg/registry/networking/partner_attachment_tools.go
+++ b/pkg/registry/networking/partner_attachment_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 type PartnerAttachmentTool struct {
@@ -195,6 +196,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.getPartnerAttachment,
 			Tool: mcp.NewTool("partner-attachment-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get partner attachment information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment")),
 			),
@@ -202,6 +205,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.listPartnerAttachments,
 			Tool: mcp.NewTool("partner-attachment-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List partner attachments with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -210,6 +215,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.createPartnerAttachment,
 			Tool: mcp.NewTool("partner-attachment-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new partner attachment"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the partner attachment")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region for the partner attachment")),
@@ -219,6 +226,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.deletePartnerAttachment,
 			Tool: mcp.NewTool("partner-attachment-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment to delete")),
 			),
@@ -226,6 +235,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.getServiceKey,
 			Tool: mcp.NewTool("partner-attachment-get-service-key",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the service key of a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment")),
 			),
@@ -233,6 +244,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.getBGPConfig,
 			Tool: mcp.NewTool("partner-attachment-get-bgp-config",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get the BGP configuration of a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment")),
 			),
@@ -240,6 +253,8 @@ func (p *PartnerAttachmentTool) Tools() []server.ServerTool {
 		{
 			Handler: p.updatePartnerAttachment,
 			Tool: mcp.NewTool("partner-attachment-update",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Update a partner attachment"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the partner attachment to update")),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("New name for the partner attachment")),

--- a/pkg/registry/networking/reserved_ips_tools.go
+++ b/pkg/registry/networking/reserved_ips_tools.go
@@ -10,6 +10,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // ReservedIPTool provides tools for managing reserved IPs
@@ -235,6 +236,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getReservedIP,
 			Tool: mcp.NewTool("reserved-ip-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get reserved IPv4 or IPv6 information by IP"),
 				mcp.WithString("IP", mcp.Required(), mcp.Description("The reserved IPv4 or IPv6 address")),
 			),
@@ -242,6 +245,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listReservedIPs,
 			Tool: mcp.NewTool("reserved-ip-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List reserved IPv4 or IPv6 addresses with pagination"),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Type of IP to list ('ipv4' or 'ipv6')")),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number (default: 1)")),
@@ -251,6 +256,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.reserveIP,
 			Tool: mcp.NewTool("reserved-ip-reserve",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Reserve a new IPv4 or IPv6"),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region to reserve the IP in")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Type of IP to reserve ('ipv4' or 'ipv6')")),
@@ -259,6 +266,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.releaseIP,
 			Tool: mcp.NewTool("reserved-ip-release",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Release a reserved IPv4 or IPv6"),
 				mcp.WithString("IP", mcp.Required(), mcp.Description("The reserved IP to release")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Type of IP to release ('ipv4' or 'ipv6')")),
@@ -267,6 +276,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.assignIP,
 			Tool: mcp.NewTool("reserved-ip-assign",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Assign a reserved IP to a droplet"),
 				mcp.WithString("IP", mcp.Required(), mcp.Description("The reserved IP to assign")),
 				mcp.WithNumber("DropletID", mcp.Required(), mcp.Description("The ID of the droplet to assign the IP to")),
@@ -276,6 +287,8 @@ func (t *ReservedIPTool) Tools() []server.ServerTool {
 		{
 			Handler: t.unassignIP,
 			Tool: mcp.NewTool("reserved-ip-unassign",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Unassign a reserved IP from a droplet"),
 				mcp.WithString("IP", mcp.Required(), mcp.Description("The reserved IP to unassign")),
 				mcp.WithString("Type", mcp.Required(), mcp.Description("Type of IP to unassign ('ipv4' or 'ipv6')")),

--- a/pkg/registry/networking/vpc_peering_tools.go
+++ b/pkg/registry/networking/vpc_peering_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // VPCPeeringTool represents a tool for managing VPC peering connections.
@@ -123,6 +124,8 @@ func (t *VPCPeeringTool) Tools() []server.ServerTool {
 		{
 			Handler: t.getVPCPeering,
 			Tool: mcp.NewTool("vpc-peering-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get VPC Peering information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC Peering connection")),
 			),
@@ -130,6 +133,8 @@ func (t *VPCPeeringTool) Tools() []server.ServerTool {
 		{
 			Handler: t.listVPCPeerings,
 			Tool: mcp.NewTool("vpc-peering-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List VPC Peering connections with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -138,6 +143,8 @@ func (t *VPCPeeringTool) Tools() []server.ServerTool {
 		{
 			Handler: t.createPeering,
 			Tool: mcp.NewTool("vpc-peering-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new VPC Peering connection between two VPCs"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name for the Peering connection")),
 				mcp.WithString("Vpc1", mcp.Required(), mcp.Description("ID of the first VPC")),
@@ -147,6 +154,8 @@ func (t *VPCPeeringTool) Tools() []server.ServerTool {
 		{
 			Handler: t.deletePeering,
 			Tool: mcp.NewTool("vpc-peering-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a VPC Peering connection"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC Peering connection to delete")),
 			),

--- a/pkg/registry/networking/vpc_tools.go
+++ b/pkg/registry/networking/vpc_tools.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"mcp-digitalocean/pkg/registry/common"
 )
 
 // VPCTool provides VPC management tools
@@ -155,6 +156,8 @@ func (v *VPCTool) Tools() []server.ServerTool {
 		{
 			Handler: v.getVPC,
 			Tool: mcp.NewTool("vpc-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("Get VPC information by ID"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC")),
 			),
@@ -162,6 +165,8 @@ func (v *VPCTool) Tools() []server.ServerTool {
 		{
 			Handler: v.listVPCs,
 			Tool: mcp.NewTool("vpc-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List VPCs with pagination"),
 				mcp.WithNumber("Page", mcp.DefaultNumber(1), mcp.Description("Page number")),
 				mcp.WithNumber("PerPage", mcp.DefaultNumber(20), mcp.Description("Items per page")),
@@ -170,6 +175,8 @@ func (v *VPCTool) Tools() []server.ServerTool {
 		{
 			Handler: v.createVPC,
 			Tool: mcp.NewTool("vpc-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Create a new VPC"),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the VPC")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Region slug (e.g., nyc3)")),
@@ -180,6 +187,8 @@ func (v *VPCTool) Tools() []server.ServerTool {
 		{
 			Handler: v.listVPCMembers,
 			Tool: mcp.NewTool("vpc-list-members",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List members of a VPC"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC")),
 			),
@@ -187,6 +196,8 @@ func (v *VPCTool) Tools() []server.ServerTool {
 		{
 			Handler: v.deleteVPC,
 			Tool: mcp.NewTool("vpc-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
 				mcp.WithDescription("Delete a VPC"),
 				mcp.WithString("ID", mcp.Required(), mcp.Description("ID of the VPC to delete")),
 			),


### PR DESCRIPTION
> **This PR was raised by Cursor** (agent), as part of the MCP tool-annotation rollout. Please review the per-tool classification below.

## What this does

Applies the shared annotation profiles to **every `networking` tool** (load balancers, firewalls, VPCs, VPC peering, domains + records, reserved IPs, certificates, BYOIP prefixes, partner attachments) so that each tool carries:

- the four **MCP hints** — `readOnly`, `destructive`, `idempotent`, `openWorld` (via `common.WithHints`), and
- the tool-registry **`_meta`** — `operation`, `risk`, `permission`, `parallelizable`, `streamingSafe` (`operation`/etc. via `WithHints`, `risk` via `common.WithRisk`).

Without this, these tools inherit the mcp-go library's worst-case defaults (`destructive`, not `readOnly`), which causes unnecessary confirmation prompts and a missing/incorrect `risk` for approval gating.

A single per-package contract test (`networking_annotations_test.go`) is added covering all 61 tools across all 9 source files, mirroring the droplet package's `TestToolAnnotations`.

**Reference example:** the droplet annotation PR — https://github.com/digitalocean-labs/mcp-digitalocean/pull/397 — established this exact pattern. This PR is self-contained and independently mergeable onto `main`.

## Field definitions

- **`readOnly`** — side-effect free (get/list) → `true`.
- **`destructive`** — deletes/overwrites data hard-to-undo. `true` for deletes.
- **`idempotent`** — repeating converges to the same state; a fresh create does not.
- **`openWorld`** — touches external/unbounded systems. `false` here.
- **`operation`** — `read` / `create` / `update` / `delete`.
- **`risk`** — blast radius: **low** = reads and cheap/reversible ops; **medium** = recoverable single-resource provisioning/reconfigure or sub-resource delete; **high** = irreversible/data-losing (delete a live LB/firewall/VPC/domain/certificate). Round up when unsure.

The six hint profiles: `Read`, `Create`, `Action`(non-idempotent update), `Toggle`(idempotent update), `Delete`(destructive+idempotent), `Replace`(destructive+non-idempotent).

## Classification in this PR (61 tools)

### `vpc_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `vpc-get` | Read | read | – | ✓ | low |
| `vpc-list` | Read | read | – | ✓ | low |
| `vpc-list-members` | Read | read | – | ✓ | low |
| `vpc-create` | Create | create | – | – | medium |
| `vpc-delete` | Delete | delete | ✓ | ✓ | high |

### `vpc_peering_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `vpc-peering-get` | Read | read | – | ✓ | low |
| `vpc-peering-list` | Read | read | – | ✓ | low |
| `vpc-peering-create` | Create | create | – | – | medium |
| `vpc-peering-delete` | Delete | delete | ✓ | ✓ | high |

### `reserved_ips_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `reserved-ip-get` | Read | read | – | ✓ | low |
| `reserved-ip-list` | Read | read | – | ✓ | low |
| `reserved-ip-reserve` | Create | create | – | – | medium |
| `reserved-ip-release` | Delete | delete | ✓ | ✓ | medium |
| `reserved-ip-assign` | Toggle | update | – | ✓ | medium |
| `reserved-ip-unassign` | Toggle | update | – | ✓ | medium |

### `partner_attachment_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `partner-attachment-get` | Read | read | – | ✓ | low |
| `partner-attachment-list` | Read | read | – | ✓ | low |
| `partner-attachment-create` | Create | create | – | – | medium |
| `partner-attachment-delete` | Delete | delete | ✓ | ✓ | high |
| `partner-attachment-get-service-key` | Read | read | – | ✓ | low |
| `partner-attachment-get-bgp-config` | Read | read | – | ✓ | low |
| `partner-attachment-update` | Toggle | update | – | ✓ | medium |

### `load_balancers_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `lb-get` | Read | read | – | ✓ | low |
| `lb-list` | Read | read | – | ✓ | low |
| `lb-create` | Create | create | – | – | medium |
| `lb-delete` | Delete | delete | ✓ | ✓ | high |
| `lb-delete-cache` | Delete | delete | ✓ | ✓ | medium |
| `lb-update` | Toggle | update | – | ✓ | medium |
| `lb-add-droplets` | Toggle | update | – | ✓ | medium |
| `lb-remove-droplets` | Toggle | update | – | ✓ | medium |
| `lb-add-fwd-rules` | Toggle | update | – | ✓ | medium |
| `lb-remove-fwd-rules` | Toggle | update | – | ✓ | medium |

### `firewall_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `firewall-get` | Read | read | – | ✓ | low |
| `firewall-list` | Read | read | – | ✓ | low |
| `firewall-create` | Create | create | – | – | medium |
| `firewall-delete` | Delete | delete | ✓ | ✓ | high |
| `firewall-add-droplets` | Toggle | update | – | ✓ | medium |
| `firewall-add-tags` | Toggle | update | – | ✓ | medium |
| `firewall-remove-droplets` | Toggle | update | – | ✓ | medium |
| `firewall-remove-tags` | Toggle | update | – | ✓ | medium |
| `firewall-add-rules` | Toggle | update | – | ✓ | medium |
| `firewall-remove-rules` | Toggle | update | – | ✓ | medium |

### `domains_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `domain-get` | Read | read | – | ✓ | low |
| `domain-list` | Read | read | – | ✓ | low |
| `domain-record-get` | Read | read | – | ✓ | low |
| `domain-record-list` | Read | read | – | ✓ | low |
| `domain-create` | Create | create | – | – | medium |
| `domain-delete` | Delete | delete | ✓ | ✓ | high |
| `domain-record-create` | Create | create | – | – | low |
| `domain-record-delete` | Delete | delete | ✓ | ✓ | medium |
| `domain-record-edit` | Toggle | update | – | ✓ | medium |

### `certificate_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `certificate-get` | Read | read | – | ✓ | low |
| `certificate-list` | Read | read | – | ✓ | low |
| `custom-certificate-create` | Create | create | – | – | medium |
| `lets-encrypt-certificate-create` | Create | create | – | – | medium |
| `certificate-delete` | Delete | delete | ✓ | ✓ | high |

### `byoip_prefix_tools.go`
| Tool | Profile | operation | destructive | idempotent | risk |
|---|---|---|---|---|---|
| `byoip-prefix-get` | Read | read | – | ✓ | low |
| `byoip-prefix-list` | Read | read | – | ✓ | low |
| `byoip-prefix-resources-get` | Read | read | – | ✓ | low |
| `byoip-prefix-create` | Create | create | – | – | medium |
| `byoip-prefix-delete` | Delete | delete | ✓ | ✓ | high |

## Points of clarification (please confirm)

1. **Live-resource deletes are `high`** (`vpc-delete`, `vpc-peering-delete`, `partner-attachment-delete`, `lb-delete`, `firewall-delete`, `domain-delete`, `certificate-delete`, `byoip-prefix-delete`); **sub-resource / recoverable deletes are `medium`** (`reserved-ip-release`, `lb-delete-cache`, `domain-record-delete`). Confirm the split.
2. **`domain-record-create` = Create / low** (a cheap DNS record) vs `domain-create` = Create / medium (a zone). Confirm.
3. **add/remove members, rules, tags, forwarding-rules, and reserved-ip assign/unassign = Toggle / medium** — modeled as idempotent convergence. If any of these truly can't be replayed, they should be `Action`. Flag any you want changed.
4. **`partner-attachment-get-service-key` = Read / low, but returns a service key** (sensitive). Flag if it should carry higher risk / redaction despite being a read.

## Test plan

- `go build ./...`, `go vet ./pkg/registry/networking/...`, `go test ./pkg/registry/networking/...` — all pass.
- `gofmt` clean.

---

*Process note:* the original worker for this package crashed mid-run after applying all the code edits; the annotations, the self-contained contract test, and validation were completed and pushed afterward. All 61 tools build/vet/test/gofmt clean.
