### PR TITLE
fix(docs): restrict page fetches to docs.digitalocean.com

### DIFF
--- a/pkg/registry/docs/docs_client.go
+++ b/pkg/registry/docs/docs_client.go
@@ -233,6 +233,10 @@ func (d *DocsClient) FetchDocPage(url string) (string, error) {
 			pageURL = "/" + pageURL
 		}
 		pageURL = docsBase + pageURL
+	} else if pageURL != docsBase && !strings.HasPrefix(pageURL, docsBase+"/") {
+		// Keep the docs tools closed-world: absolute URLs outside the docs
+		// site are rejected rather than proxied.
+		return "", fmt.Errorf("refusing to fetch %s: only %s pages are supported", url, docsBase)
 	}
 
 	// Try index.html.md for raw markdown

--- a/pkg/registry/docs/docs_client_test.go
+++ b/pkg/registry/docs/docs_client_test.go
@@ -161,6 +161,24 @@ func TestResolveServiceSlug(t *testing.T) {
 	}
 }
 
+func TestFetchDocPage_RejectsExternalHosts(t *testing.T) {
+	client := NewDocsClient()
+
+	tests := []string{
+		"https://example.com/products/droplets/",
+		"https://docs.digitalocean.com.evil.example/products/droplets/",
+		"http://attacker.example/",
+	}
+
+	for _, url := range tests {
+		t.Run(url, func(t *testing.T) {
+			_, err := client.FetchDocPage(url)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "refusing to fetch")
+		})
+	}
+}
+
 func TestCleanMarkdown(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- `FetchDocPage` now rejects absolute URLs outside `https://docs.digitalocean.com/` instead of fetching them. Relative paths and docs URLs behave exactly as before.
- This enforces the closed-domain assumption behind the `openWorld = false` classification in #407 (see discussion there): previously `docs-get-page` would fetch an arbitrary external URL if passed one, making the MCP server usable as a generic fetch proxy.
- The prefix check is suffix-spoof safe (`docs.digitalocean.com.evil.example` is rejected); test cases included.

4 lines of code plus a test. Non-blocking companion to #407; also covers `docs-get-related` in #405, which fetches through the same path.

## Test plan

- New `TestFetchDocPage_RejectsExternalHosts` covering external host, spoofed subdomain suffix, and http scheme
- Full `go test ./...` passes; `gofmt`, `go vet`, and revive clean
- Manually verified over stdio against live docs: docs URLs (absolute and relative) still fetch, `https://example.com/whatever` returns an isError response