### PR TITLE
refactor(docs): extract shared entry scoring helper

### DIFF
--- a/pkg/registry/docs/docs_client.go
+++ b/pkg/registry/docs/docs_client.go
@@ -285,66 +285,107 @@ func SearchIndex(index *DocsIndex, query string) []DocsEntry {
 		return nil
 	}
 
-	type scored struct {
-		entry DocsEntry
-		score int
-	}
-
 	wordRegexes := make([]*regexp.Regexp, len(terms))
 	for i, term := range terms {
 		wordRegexes[i] = regexp.MustCompile(`\b` + regexp.QuoteMeta(term) + `\b`)
 	}
 
-	var results []scored
+	var results []scoredEntry
 
 	for _, entry := range index.Entries {
+		score, allTermsMatched := scoreEntryTerms(entry, terms, searchWeights)
+
+		// Exact word boundary matches in title
 		titleLower := strings.ToLower(entry.Title)
-		descLower := strings.ToLower(entry.Description)
-		sectionLower := strings.ToLower(entry.Section)
-		urlLower := strings.ToLower(entry.URL)
-		score := 0
-		matchedTerms := 0
-
-		for i, term := range terms {
-			termMatched := false
-
-			if strings.Contains(titleLower, term) {
-				score += 10
-				termMatched = true
-			}
-			// Exact word boundary match in title
+		for i := range terms {
 			if wordRegexes[i].MatchString(titleLower) {
 				score += 5
-			}
-			if strings.Contains(descLower, term) {
-				score += 3
-				termMatched = true
-			}
-			if strings.Contains(sectionLower, term) {
-				score += 2
-				termMatched = true
-			}
-			// Match against URL path segments (e.g., "manage-domains" matches "domain")
-			if strings.Contains(urlLower, term) {
-				score += 4
-				termMatched = true
-			}
-
-			if termMatched {
-				matchedTerms++
 			}
 		}
 
 		// Boost entries that match all query terms
-		if len(terms) > 1 && matchedTerms == len(terms) {
-			score += 15
+		if len(terms) > 1 && allTermsMatched {
+			score += allTermsMatchBoost
 		}
 
 		if score > 0 {
-			results = append(results, scored{entry: entry, score: score})
+			results = append(results, scoredEntry{entry: entry, score: score})
 		}
 	}
 
+	return rankEntries(results)
+}
+
+// fieldWeights defines the per-term score contribution of each DocsEntry
+// field during scoring. A zero weight excludes the field from matching.
+type fieldWeights struct {
+	title, description, section, url int
+}
+
+// allTermsMatchBoost is added to an entry's score when every query term
+// matched at least one field, ranking complete matches above partial ones
+// for multi-term queries.
+const allTermsMatchBoost = 15
+
+var (
+	// searchWeights is the profile used by SearchIndex.
+	searchWeights = fieldWeights{title: 10, description: 3, section: 2, url: 4}
+
+	// troubleshootWeights is the profile used by FindTroubleshootPage. It
+	// ignores the section field; support sections are handled by a separate
+	// boost instead.
+	troubleshootWeights = fieldWeights{title: 10, description: 3, url: 2}
+)
+
+// scoreEntryTerms scores entry against the query terms using the given field
+// weights. It returns the accumulated score and whether every term matched at
+// least one weighted field. Callers layer their own boosts on top.
+func scoreEntryTerms(entry DocsEntry, terms []string, weights fieldWeights) (int, bool) {
+	titleLower := strings.ToLower(entry.Title)
+	descLower := strings.ToLower(entry.Description)
+	sectionLower := strings.ToLower(entry.Section)
+	urlLower := strings.ToLower(entry.URL)
+
+	score := 0
+	matchedTerms := 0
+
+	for _, term := range terms {
+		termMatched := false
+
+		if weights.title > 0 && strings.Contains(titleLower, term) {
+			score += weights.title
+			termMatched = true
+		}
+		if weights.description > 0 && strings.Contains(descLower, term) {
+			score += weights.description
+			termMatched = true
+		}
+		if weights.section > 0 && strings.Contains(sectionLower, term) {
+			score += weights.section
+			termMatched = true
+		}
+		// Match against URL path segments (e.g., "manage-domains" matches "domain")
+		if weights.url > 0 && strings.Contains(urlLower, term) {
+			score += weights.url
+			termMatched = true
+		}
+
+		if termMatched {
+			matchedTerms++
+		}
+	}
+
+	return score, matchedTerms == len(terms)
+}
+
+// scoredEntry pairs a DocsEntry with its relevance score for ranking.
+type scoredEntry struct {
+	entry DocsEntry
+	score int
+}
+
+// rankEntries sorts results by descending score and returns the bare entries.
+func rankEntries(results []scoredEntry) []DocsEntry {
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].score > results[j].score
 	})
@@ -404,43 +445,17 @@ func (d *DocsClient) FindTroubleshootPage(symptom string) ([]DocsEntry, error) {
 		return nil, fmt.Errorf("symptom query must not be empty")
 	}
 
-	type scored struct {
-		entry DocsEntry
-		score int
-	}
-
-	var results []scored
+	var results []scoredEntry
 
 	for _, entry := range index.Entries {
-		titleLower := strings.ToLower(entry.Title)
-		descLower := strings.ToLower(entry.Description)
-		urlLower := strings.ToLower(entry.URL)
-		sectionLower := strings.ToLower(entry.Section)
-		score := 0
-		matchedTerms := 0
-
-		for _, term := range terms {
-			termMatched := false
-			if strings.Contains(titleLower, term) {
-				score += 10
-				termMatched = true
-			}
-			if strings.Contains(descLower, term) {
-				score += 3
-				termMatched = true
-			}
-			if strings.Contains(urlLower, term) {
-				score += 2
-				termMatched = true
-			}
-			if termMatched {
-				matchedTerms++
-			}
-		}
-
+		score, allTermsMatched := scoreEntryTerms(entry, terms, troubleshootWeights)
 		if score == 0 {
 			continue
 		}
+
+		titleLower := strings.ToLower(entry.Title)
+		sectionLower := strings.ToLower(entry.Section)
+		urlLower := strings.ToLower(entry.URL)
 
 		// Boost support/troubleshooting pages
 		if strings.Contains(sectionLower, "support") || strings.Contains(urlLower, "/support/") {
@@ -456,22 +471,14 @@ func (d *DocsClient) FindTroubleshootPage(symptom string) ([]DocsEntry, error) {
 		}
 
 		// Boost entries matching all terms
-		if len(terms) > 1 && matchedTerms == len(terms) {
-			score += 15
+		if len(terms) > 1 && allTermsMatched {
+			score += allTermsMatchBoost
 		}
 
-		results = append(results, scored{entry: entry, score: score})
+		results = append(results, scoredEntry{entry: entry, score: score})
 	}
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].score > results[j].score
-	})
-
-	entries := make([]DocsEntry, len(results))
-	for i, r := range results {
-		entries[i] = r.entry
-	}
-	return entries, nil
+	return rankEntries(results), nil
 }
 
 var troubleshootPrefixes = []string{

--- a/pkg/registry/docs/docs_client_test.go
+++ b/pkg/registry/docs/docs_client_test.go
@@ -172,6 +172,60 @@ func TestResolveServiceSlug(t *testing.T) {
 	}
 }
 
+func TestScoreEntryTerms(t *testing.T) {
+	entry := DocsEntry{
+		Title:       "How to Create a Droplet",
+		Description: "Create Droplets from the control panel or API.",
+		Section:     "Droplet How-Tos",
+		URL:         "https://docs.digitalocean.com/products/droplets/how-to/create/",
+	}
+
+	tests := []struct {
+		name           string
+		terms          []string
+		weights        fieldWeights
+		expectScore    int
+		expectAllMatch bool
+	}{
+		{
+			name:           "single term matches all weighted fields",
+			terms:          []string{"droplet"},
+			weights:        fieldWeights{title: 10, description: 3, section: 2, url: 4},
+			expectScore:    19,
+			expectAllMatch: true,
+		},
+		{
+			name:           "zero weight excludes field",
+			terms:          []string{"droplet"},
+			weights:        fieldWeights{title: 10, description: 3, url: 2},
+			expectScore:    15,
+			expectAllMatch: true,
+		},
+		{
+			name:           "unmatched term clears all-match flag",
+			terms:          []string{"droplet", "kubernetes"},
+			weights:        fieldWeights{title: 10, description: 3, section: 2, url: 4},
+			expectScore:    19,
+			expectAllMatch: false,
+		},
+		{
+			name:           "no matches",
+			terms:          []string{"kubernetes"},
+			weights:        fieldWeights{title: 10, description: 3, section: 2, url: 4},
+			expectScore:    0,
+			expectAllMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			score, allMatched := scoreEntryTerms(entry, tc.terms, tc.weights)
+			require.Equal(t, tc.expectScore, score)
+			require.Equal(t, tc.expectAllMatch, allMatched)
+		})
+	}
+}
+
 func TestFetchDocPage_RejectsExternalHosts(t *testing.T) {
 	client := NewDocsClient()
 


### PR DESCRIPTION
## Summary

- Extracts the duplicated per-term scoring skeleton from `SearchIndex` and `FindTroubleshootPage` into a shared `scoreEntryTerms(entry, terms, weights)` helper, as suggested in the review discussion on #404. Each caller keeps its own `fieldWeights` profile (`searchWeights`, `troubleshootWeights`) and layers its specific boosts on top (word-boundary title bonus for search; support-section and troubleshooting-title boosts for troubleshoot).
- The shared all-terms-match bonus is now a named constant (`allTermsMatchBoost`) applied by both callers.
- The scored-slice sort and flatten is extracted into `rankEntries`.
- Pure refactor: no behavior change intended, no new dependencies, net -84/+145 lines mostly from documentation on the new helper.

## Test plan

- All existing docs tests pass unchanged (they pin the ranking behavior); new `TestScoreEntryTerms` covers weight application, zero-weight field exclusion, and the all-terms-matched flag
- Full `go test ./...` passes; `go test -race ./pkg/registry/docs/` passes
- `gofmt`, `go vet ./...`, revive (`make lint`), and `go vet -tags=integration ./testing/` all clean
- Behavior verified identical end to end: built the server from main and from this branch, ran 3 `docs-search` and 2 `docs-troubleshoot` queries against live docs over stdio, and diffed the full outputs - byte-identical