### PR TITLE
fix(marketplace): rename 1-click tools to start with a letter

### DIFF
--- a/pkg/registry/marketplace/1-click_tools.go
+++ b/pkg/registry/marketplace/1-click_tools.go
@@ -122,7 +122,7 @@ func (o *OneClickTool) Tools() []server.ServerTool {
 	return []server.ServerTool{
 		{
 			Handler: o.listOneClickApps,
-			Tool: mcp.NewTool("1-click-list",
+			Tool: mcp.NewTool("marketplace-1-click-list",
 				common.WithHints(common.HintsRead),
 				common.WithRisk(common.RiskLow),
 				mcp.WithDescription("List available 1-click applications from the DigitalOcean marketplace"),
@@ -131,7 +131,7 @@ func (o *OneClickTool) Tools() []server.ServerTool {
 		},
 		{
 			Handler: o.installKubernetesApps,
-			Tool: mcp.NewTool("1-click-kubernetes-app-install",
+			Tool: mcp.NewTool("marketplace-1-click-kubernetes-app-install",
 				common.WithHints(common.HintsCreate),
 				common.WithRisk(common.RiskMedium),
 				mcp.WithDescription("Install 1-click applications on a Kubernetes cluster"),

--- a/pkg/registry/marketplace/1-click_tools_test.go
+++ b/pkg/registry/marketplace/1-click_tools_test.go
@@ -28,8 +28,8 @@ func TestOneClickTool_Tools(t *testing.T) {
 		toolNames[i] = tool.Tool.Name
 	}
 
-	assert.Contains(t, toolNames, "1-click-list")
-	assert.Contains(t, toolNames, "1-click-kubernetes-app-install")
+	assert.Contains(t, toolNames, "marketplace-1-click-list")
+	assert.Contains(t, toolNames, "marketplace-1-click-kubernetes-app-install")
 }
 
 func setupOneClickToolWithMock(mockOneClick *MockOneClickService) *OneClickTool {

--- a/pkg/registry/marketplace/README.md
+++ b/pkg/registry/marketplace/README.md
@@ -8,12 +8,12 @@ This directory contains tools for managing DigitalOcean Marketplace services via
 
 ### 1-Click Application Tools
 
-- **1-click-list**  
+- **marketplace-1-click-list**  
   List available 1-click applications from the DigitalOcean marketplace.  
   **Arguments:**  
   - `type` (string, optional, default: "droplet"): Type of 1-click apps to list (e.g., "droplet", "kubernetes")
 
-- **1-click-kubernetes-app-install**  
+- **marketplace-1-click-kubernetes-app-install**  
   Install 1-click applications on a Kubernetes cluster.  
   **Arguments:**  
   - `ClusterUUID` (string, required): UUID of the Kubernetes cluster to install apps on  
@@ -24,22 +24,22 @@ This directory contains tools for managing DigitalOcean Marketplace services via
 ## Example Usage
 
 - **List all droplet 1-click apps:**  
-  Tool: `1-click-list`  
+  Tool: `marketplace-1-click-list`  
   Arguments: `{}`
 
 - **List Kubernetes 1-click apps:**  
-  Tool: `1-click-list`  
+  Tool: `marketplace-1-click-list`  
   Arguments:  
   - `type`: `"kubernetes"`
 
 - **Install single app on Kubernetes cluster:**  
-  Tool: `1-click-kubernetes-app-install`  
+  Tool: `marketplace-1-click-kubernetes-app-install`  
   Arguments:  
   - `ClusterUUID`: `"k8s-1234567890abcdef"`  
   - `AppSlugs`: `["wordpress"]`
 
 - **Install multiple apps on Kubernetes cluster:**  
-  Tool: `1-click-kubernetes-app-install`  
+  Tool: `marketplace-1-click-kubernetes-app-install`  
   Arguments:  
   - `ClusterUUID`: `"k8s-1234567890abcdef"`  
   - `AppSlugs`: `["wordpress", "mysql", "redis"]`
@@ -51,19 +51,19 @@ This directory contains tools for managing DigitalOcean Marketplace services via
 - **List droplet 1-click apps:**
 
   ```json
-  {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"1-click-list","arguments":{}}}
+  {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"marketplace-1-click-list","arguments":{}}}
   ```
 
 - **List Kubernetes 1-click apps:**
 
   ```json
-  {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"1-click-list","arguments":{"type":"kubernetes"}}}
+  {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"marketplace-1-click-list","arguments":{"type":"kubernetes"}}}
   ```
 
 - **Install apps on Kubernetes cluster:**
 
   ```json
-  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"1-click-kubernetes-app-install","arguments":{"ClusterUUID":"k8s-1234567890abcdef","AppSlugs":["wordpress","nginx"]}}}
+  {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"marketplace-1-click-kubernetes-app-install","arguments":{"ClusterUUID":"k8s-1234567890abcdef","AppSlugs":["wordpress","nginx"]}}}
   ```
 
 ---
@@ -71,5 +71,5 @@ This directory contains tools for managing DigitalOcean Marketplace services via
 ## Notes
 
 - For Kubernetes app installation, you need the UUID of an existing Kubernetes cluster.
-- Use the `1-click-list` tool with `type: "kubernetes"` to see available Kubernetes 1-click apps.
+- Use the `marketplace-1-click-list` tool with `type: "kubernetes"` to see available Kubernetes 1-click apps.
 - A valid DigitalOcean API token is required for all operations.

--- a/pkg/registry/marketplace/marketplace_annotations_test.go
+++ b/pkg/registry/marketplace/marketplace_annotations_test.go
@@ -28,8 +28,8 @@ var expectedAnnotations = map[string]struct {
 	parallelizable, streamingSafe                bool
 }{
 	// 1-click_tools.go
-	"1-click-list":                   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
-	"1-click-kubernetes-app-install": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"marketplace-1-click-list":                   {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"marketplace-1-click-kubernetes-app-install": {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
 }
 
 func TestToolAnnotations(t *testing.T) {

--- a/testing/e2e_marketplace_test.go
+++ b/testing/e2e_marketplace_test.go
@@ -23,7 +23,7 @@ func TestListOneClickApps(t *testing.T) {
 	t.Run("list droplet 1-click apps", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name:      "1-click-list",
+				Name:      "marketplace-1-click-list",
 				Arguments: map[string]interface{}{},
 			},
 		})
@@ -51,7 +51,7 @@ func TestListOneClickApps(t *testing.T) {
 	t.Run("list kubernetes 1-click apps", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-list",
+				Name: "marketplace-1-click-list",
 				Arguments: map[string]interface{}{
 					"Type": "kubernetes",
 				},
@@ -145,7 +145,7 @@ func TestInstallKubernetesApps(t *testing.T) {
 
 	listResp, err := c.CallTool(ctx, mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
-			Name: "1-click-list",
+			Name: "marketplace-1-click-list",
 			Arguments: map[string]interface{}{
 				"Type": "kubernetes",
 			},
@@ -173,7 +173,7 @@ func TestInstallKubernetesApps(t *testing.T) {
 
 		installResp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": cluster.ID,
 					"AppSlugs":    []string{appSlug},
@@ -209,7 +209,7 @@ func TestInstallKubernetesApps(t *testing.T) {
 
 		installResp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": cluster.ID,
 					"AppSlugs":    appSlugs,
@@ -239,7 +239,7 @@ func TestInstallKubernetesApps_InvalidInputs(t *testing.T) {
 	t.Run("missing cluster UUID", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"AppSlugs": []string{"monitoring"},
 				},
@@ -258,7 +258,7 @@ func TestInstallKubernetesApps_InvalidInputs(t *testing.T) {
 	t.Run("missing app slugs", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": "test-cluster-uuid",
 				},
@@ -277,7 +277,7 @@ func TestInstallKubernetesApps_InvalidInputs(t *testing.T) {
 	t.Run("empty cluster UUID", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": "",
 					"AppSlugs":    []string{"monitoring"},
@@ -297,7 +297,7 @@ func TestInstallKubernetesApps_InvalidInputs(t *testing.T) {
 	t.Run("empty app slugs array", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": "test-cluster-uuid",
 					"AppSlugs":    []string{},
@@ -317,7 +317,7 @@ func TestInstallKubernetesApps_InvalidInputs(t *testing.T) {
 	t.Run("invalid cluster UUID", func(t *testing.T) {
 		resp, err := c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Name: "1-click-kubernetes-app-install",
+				Name: "marketplace-1-click-kubernetes-app-install",
 				Arguments: map[string]interface{}{
 					"ClusterUUID": "invalid-cluster-uuid-that-does-not-exist",
 					"AppSlugs":    []string{"monitoring"},


### PR DESCRIPTION
## Summary
The tool-registry action registry rejects tool names that start with a digit (slug validator `^[a-z][a-z0-9_-]*$`), so the two marketplace tools failed to register.

- `1-click-list` → `marketplace-1-click-list`
- `1-click-kubernetes-app-install` → `marketplace-1-click-kubernetes-app-install`

Updated the annotation/unit/e2e tests and the marketplace README accordingly. (The droplet tool references to `1-click-list` are updated in a separate droplet PR to keep this change server-scoped.)

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/registry/marketplace/...`

Made with [Cursor](https://cursor.com)