### PR TITLE
docs(droplet): reference renamed marketplace-1-click-list tool

### DIFF
--- a/pkg/registry/droplet/README.md
+++ b/pkg/registry/droplet/README.md
@@ -14,7 +14,7 @@ This directory contains tools for managing DigitalOcean Droplets, Images, and Si
   - `Name` (string, required): Name of the Droplet  
   - `Size` (string, required): Slug of the Droplet size (e.g., `s-1vcpu-1gb`)  
   - `ImageID` (number, optional): Numeric ID of the image to use. Mutually exclusive with `ImageSlug`.  
-  - `ImageSlug` (string, optional): Slug of the image to use (e.g., `ubuntu-22-04-x64`, `wordpress-20-04`). Use this for 1-click marketplace app images; slugs can be discovered via the `1-click-list` tool. Mutually exclusive with `ImageID`.  
+  - `ImageSlug` (string, optional): Slug of the image to use (e.g., `ubuntu-22-04-x64`, `wordpress-20-04`). Use this for 1-click marketplace app images; slugs can be discovered via the `marketplace-1-click-list` tool. Mutually exclusive with `ImageID`.  
   - `Region` (string, required): Slug of the region (e.g., `nyc3`)  
   - `Backup` (boolean, optional, default: false): Enable backups  
   - `Monitoring` (boolean, optional, default: false): Enable monitoring  

--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -336,7 +336,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Name of the droplet")),
 				mcp.WithString("Size", mcp.Required(), mcp.Description("Slug of the droplet size (e.g., s-1vcpu-1gb)")),
 				mcp.WithNumber("ImageID", mcp.Description("Numeric ID of the image to use. Mutually exclusive with ImageSlug.")),
-				mcp.WithString("ImageSlug", mcp.Description("Slug of the image to use (e.g., ubuntu-22-04-x64, wordpress-20-04). Use this for 1-click marketplace app images; slugs can be discovered via the 1-click-list tool. Mutually exclusive with ImageID.")),
+				mcp.WithString("ImageSlug", mcp.Description("Slug of the image to use (e.g., ubuntu-22-04-x64, wordpress-20-04). Use this for 1-click marketplace app images; slugs can be discovered via the marketplace-1-click-list tool. Mutually exclusive with ImageID.")),
 				mcp.WithString("Region", mcp.Required(), mcp.Description("Slug of the region (e.g., nyc3)")),
 				mcp.WithBoolean("Backup", mcp.DefaultBool(false), mcp.Description("Whether to enable backups")),
 				mcp.WithBoolean("Monitoring", mcp.DefaultBool(false), mcp.Description("Whether to enable monitoring")),


### PR DESCRIPTION
## Summary
Follow-up to the marketplace 1-click tool rename. The droplet `droplet-create` `ImageSlug` description and the droplet README pointed users at the old `1-click-list` tool name; update them to `marketplace-1-click-list`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/registry/droplet/...`

Made with [Cursor](https://cursor.com)