### PR TITLE
fix(genai-custom-models): trim delete description under registry 512-char limit

### DIFF
--- a/pkg/registry/genai-custom-models/delete_resolve.go
+++ b/pkg/registry/genai-custom-models/delete_resolve.go
@@ -25,12 +25,11 @@ const (
 		"Omitted or false is rejected. Not required when the tool only returns a name-match list (partial name with no exact match)."
 
 	genaiCustomModelsDeleteToolDescription = "Delete a custom model by exact UUID or exact name.\n\n" +
-		"EXACT IDENTIFIER REQUIRED: Provide uuid OR name (at least one). Only a full UUID (8-4-4-4-12 hex) or an exact model name deletes. " +
-		"Partial uuid or partial name returns candidates only — never deletes, even if only one match. " +
-		"Never substitute a name or uuid from a prior partial-match list.\n\n" +
-		"CONSENT REQUIRED (every delete): Do not call with confirm_deletion: true until the user has explicitly agreed to delete that model. " +
-		"Present name, uuid, and that deletion is permanent; ask for yes/no.\n\n" +
-		"If both uuid and name are set, they must refer to the same model."
+		"EXACT IDENTIFIER: provide uuid OR name. Only a full UUID (8-4-4-4-12 hex) or an exact name deletes; " +
+		"a partial value returns candidates only, never deletes. Never reuse a partial-match value.\n\n" +
+		"CONSENT (every delete): do not pass confirm_deletion: true until the user has explicitly agreed; " +
+		"show name, uuid, and that deletion is permanent, then ask yes/no. " +
+		"If uuid and name are both set, they must match the same model."
 )
 
 // DeleteModelMatchCandidate is a custom model returned when delete-by-name needs disambiguation.


### PR DESCRIPTION
## Summary
The tool-registry action-gateway stores tool descriptions bounded by 512 characters limit. `genai-custom-models-delete` had a ~608-char description and failed to register. Condensed to ~469 chars, keeping the exact-identifier requirement and the per-delete consent flow.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/registry/genai-custom-models/...`
- [x] `gofmt` clean

Made with [Cursor](https://cursor.com)