### PR TITLE
fix(genai-inferencerouter): trim create description under registry 512-char limit

### DIFF
--- a/pkg/registry/genai-inferencerouter/router_tools.go
+++ b/pkg/registry/genai-inferencerouter/router_tools.go
@@ -334,7 +334,7 @@ func (t *RouterTool) Tools() []server.ServerTool {
 				"genai-inference-router-create",
 				common.WithHints(common.HintsCreate),
 				common.WithRisk(common.RiskLow),
-				mcp.WithDescription(`Create a GenAI model router via godo.GradientAI.CreateInferenceRouter. JSON body fields: "name", optional "policies" array, and required "fallback_models" (at least one model). Each policy needs a task: either "task_slug" (built-in) plus "models" and "selection_policy":{"prefer":"fastest"|"cheapest"}, or "custom_task":{"name","description"} with "models" and selection_policy. Flat {"model","usecase_class"} policies fail with "task is required". List/get return the same policy shape under model_router.config.`),
+				mcp.WithDescription(`Create a GenAI model router (godo.GradientAI.CreateInferenceRouter). JSON body: "name", optional "policies" array, and required "fallback_models" (at least one). Each policy needs a task: either "task_slug" plus "models" and "selection_policy":{"prefer":"fastest"|"cheapest"}, or "custom_task":{"name","description"} with "models" and selection_policy. Flat {"model","usecase_class"} policies fail with "task is required". List/get return the same policy shape under model_router.config.`),
 				mcp.WithString("Name", mcp.Required(), mcp.Description("Router name")),
 				mcp.WithString("PoliciesJson", mcp.Description(`JSON array for "policies". Example: [{"task_slug":"code-generation","models":["openai-gpt-5"],"selection_policy":{"prefer":"fastest"}}]. Custom task: use custom_task with name+description instead of task_slug. Omit or "[]" if allowed.`)),
 				mcp.WithArray("FallbackModels", mcp.Required(), mcp.MinItems(1), mcp.Description("At least one fallback model id, in order, sent as fallback_models (required by the API).")),


### PR DESCRIPTION
## Summary
The tool-registry action-gateway stores tool descriptions bounded by 512 chars. `genai-inference-router-create` was 513 chars (1 over) and failed to register. Trimmed minor wording to ~487 chars without dropping any of the policy-shape guidance.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/registry/genai-inferencerouter/...`
- [x] `gofmt` clean

Made with [Cursor](https://cursor.com)