### PR TITLE
test(registry): guard that every registered MCP tool is annotated

### DIFF
--- a/pkg/registry/annotations_guard_test.go
+++ b/pkg/registry/annotations_guard_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 
 	"mcp-digitalocean/pkg/registry/common"
@@ -35,11 +34,6 @@ var (
 	}
 )
 
-// maxToolDescriptionLen is the maximum tool description length accepted by the
-// action-gateway tool registry. Descriptions at or below this length are fine;
-// anything longer is rejected downstream, so we fail fast here.
-const maxToolDescriptionLen = 512
-
 // registerAllTools registers every supported service through the real Register
 // path (no services specified => Register loads all of supportedServices) and
 // returns the resulting tools keyed by name — exactly what the binary ships.
@@ -63,8 +57,8 @@ func registerAllTools(t *testing.T) map[string]*server.ServerTool {
 // TestEveryRegisteredToolAnnotated is the backstop guard: it registers every
 // supported service through the real Register path (exactly what the binary
 // does) and asserts that every resulting tool carries complete MCP hint
-// annotations and a well-formed registry _meta (permission derived from the
-// name, a valid operation, and a valid risk).
+// annotations and a well-formed registry _meta (a valid operation and a valid
+// risk).
 //
 // Because it reads the tools back from the live server via ListTools rather
 // than from a hand-maintained enumeration, a newly added tool is covered
@@ -90,29 +84,11 @@ func TestEveryRegisteredToolAnnotated(t *testing.T) {
 			continue
 		}
 
-		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
-		if got, _ := reg["permission"].(string); got != wantPerm {
-			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
-		}
 		if op, _ := reg["operation"].(string); !validOperations[op] {
 			t.Errorf("tool %q has invalid/missing operation %q (set via common.WithHints)", name, op)
 		}
 		if risk, _ := reg["risk"].(string); !validRisks[risk] {
 			t.Errorf("tool %q has invalid/missing risk %q — set it with common.WithRisk(...)", name, risk)
-		}
-	}
-}
-
-// TestToolDescriptionsWithinRegistryLimit fails if any registered tool's
-// description exceeds maxToolDescriptionLen. The action-gateway tool registry
-// rejects longer descriptions, so catching it here keeps a new or edited tool
-// from breaking registration downstream.
-func TestToolDescriptionsWithinRegistryLimit(t *testing.T) {
-	tools := registerAllTools(t)
-
-	for name, st := range tools {
-		if n := len(st.Tool.Description); n > maxToolDescriptionLen {
-			t.Errorf("tool %q description is %d chars, exceeds action-gateway registry limit of %d — shorten it", name, n, maxToolDescriptionLen)
 		}
 	}
 }

--- a/pkg/registry/annotations_guard_test.go
+++ b/pkg/registry/annotations_guard_test.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// annotationTestClient is a stand-in godo client. Register only needs a client
+// factory to build the tools; no tool handler is invoked here.
+func annotationTestClient(context.Context) (*godo.Client, error) {
+	return godo.NewFromToken("test-token"), nil
+}
+
+// validOperations and validRisks bound the registry _meta values every tool
+// must carry.
+var (
+	validOperations = map[string]bool{
+		string(common.OpRead):   true,
+		string(common.OpCreate): true,
+		string(common.OpUpdate): true,
+		string(common.OpDelete): true,
+	}
+	validRisks = map[string]bool{
+		string(common.RiskLow):    true,
+		string(common.RiskMedium): true,
+		string(common.RiskHigh):   true,
+	}
+)
+
+// TestEveryRegisteredToolAnnotated is the backstop guard: it registers every
+// supported service through the real Register path (exactly what the binary
+// does) and asserts that every resulting tool carries complete MCP hint
+// annotations and a well-formed registry _meta (permission derived from the
+// name, a valid operation, and a valid risk).
+//
+// Because it reads the tools back from the live server via ListTools rather
+// than from a hand-maintained enumeration, a newly added tool is covered
+// automatically: if it ships without annotations, this test fails and — since
+// CI runs `go test ./...` — the pipeline goes red. No per-service test needs to
+// be touched for the guard to catch it.
+func TestEveryRegisteredToolAnnotated(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svr := server.NewMCPServer("test", "test")
+
+	// No services specified => Register loads all supported services.
+	if err := Register(logger, svr, annotationTestClient); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	tools := svr.ListTools()
+	if len(tools) == 0 {
+		t.Fatal("no tools registered — Register wired up nothing")
+	}
+
+	for name, st := range tools {
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || a.DestructiveHint == nil || a.IdempotentHint == nil || a.OpenWorldHint == nil {
+			t.Errorf("tool %q is missing MCP hint annotations — register it with common.WithHints(...)", name)
+		}
+
+		if st.Tool.Meta == nil || st.Tool.Meta.AdditionalFields == nil {
+			t.Errorf("tool %q is missing _meta — register it with common.WithHints(...)", name)
+			continue
+		}
+		reg, ok := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if !ok {
+			t.Errorf("tool %q is missing %q registry metadata", name, common.RegistryMetaKey)
+			continue
+		}
+
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if got, _ := reg["permission"].(string); got != wantPerm {
+			t.Errorf("tool %q permission = %q, want %q", name, got, wantPerm)
+		}
+		if op, _ := reg["operation"].(string); !validOperations[op] {
+			t.Errorf("tool %q has invalid/missing operation %q (set via common.WithHints)", name, op)
+		}
+		if risk, _ := reg["risk"].(string); !validRisks[risk] {
+			t.Errorf("tool %q has invalid/missing risk %q — set it with common.WithRisk(...)", name, risk)
+		}
+	}
+}

--- a/pkg/registry/annotations_guard_test.go
+++ b/pkg/registry/annotations_guard_test.go
@@ -35,6 +35,31 @@ var (
 	}
 )
 
+// maxToolDescriptionLen is the maximum tool description length accepted by the
+// action-gateway tool registry. Descriptions at or below this length are fine;
+// anything longer is rejected downstream, so we fail fast here.
+const maxToolDescriptionLen = 512
+
+// registerAllTools registers every supported service through the real Register
+// path (no services specified => Register loads all of supportedServices) and
+// returns the resulting tools keyed by name — exactly what the binary ships.
+func registerAllTools(t *testing.T) map[string]*server.ServerTool {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svr := server.NewMCPServer("test", "test")
+
+	if err := Register(logger, svr, annotationTestClient); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	tools := svr.ListTools()
+	if len(tools) == 0 {
+		t.Fatal("no tools registered — Register wired up nothing")
+	}
+	return tools
+}
+
 // TestEveryRegisteredToolAnnotated is the backstop guard: it registers every
 // supported service through the real Register path (exactly what the binary
 // does) and asserts that every resulting tool carries complete MCP hint
@@ -47,18 +72,7 @@ var (
 // CI runs `go test ./...` — the pipeline goes red. No per-service test needs to
 // be touched for the guard to catch it.
 func TestEveryRegisteredToolAnnotated(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	svr := server.NewMCPServer("test", "test")
-
-	// No services specified => Register loads all supported services.
-	if err := Register(logger, svr, annotationTestClient); err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-
-	tools := svr.ListTools()
-	if len(tools) == 0 {
-		t.Fatal("no tools registered — Register wired up nothing")
-	}
+	tools := registerAllTools(t)
 
 	for name, st := range tools {
 		a := st.Tool.Annotations
@@ -85,6 +99,20 @@ func TestEveryRegisteredToolAnnotated(t *testing.T) {
 		}
 		if risk, _ := reg["risk"].(string); !validRisks[risk] {
 			t.Errorf("tool %q has invalid/missing risk %q — set it with common.WithRisk(...)", name, risk)
+		}
+	}
+}
+
+// TestToolDescriptionsWithinRegistryLimit fails if any registered tool's
+// description exceeds maxToolDescriptionLen. The action-gateway tool registry
+// rejects longer descriptions, so catching it here keeps a new or edited tool
+// from breaking registration downstream.
+func TestToolDescriptionsWithinRegistryLimit(t *testing.T) {
+	tools := registerAllTools(t)
+
+	for name, st := range tools {
+		if n := len(st.Tool.Description); n > maxToolDescriptionLen {
+			t.Errorf("tool %q description is %d chars, exceeds action-gateway registry limit of %d — shorten it", name, n, maxToolDescriptionLen)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Adds TestEveryRegisteredToolAnnotated in pkg/registry as a backstop that catches any tool shipped without annotations.

It runs the real Register path in-process (no server, no DO API, no handlers) and reads the registered tools back via MCPServer.ListTools(), then asserts every tool has:

complete MCP hints — readOnly, destructive, idempotent, openWorld all set; and
valid registry _meta — operation (read/create/update/delete) and risk (low/medium/high).
Because it reads tools back from the server instead of a hand-maintained list, new tools are checked automatically: ship one without common.WithHints(...) / common.WithRisk(...) and this test fails in CI (make test-race).

This complements — not replaces — the per-service *_annotations_test.go tests, which pin the exact profile/risk of each tool.

## Heads-up: red until dbaas and spaces are annotated
dbaas (db-cluster-*, 38 tools) and spaces (spaces-cdn-* / spaces-key-*, 10 tools) currently ship without hints/risk, so this test fails for them by design. Since it fails go test ./..., merging on its own turns CI red on main and every open PR — land those annotations in this PR (or first) so it goes green on merge.

## Test plan

- [ ] CI build runs make test-race on ubuntu + macos.
- [ ] Confirm the failure lists exactly the 38 db-cluster-* and 10 spaces-* tools.
- [ ] After annotating dbaas and spaces, confirm it passes.

