### PR TITLE
Add UserData support to droplet-create

### DIFF
--- a/pkg/registry/droplet/droplet_tools.go
+++ b/pkg/registry/droplet/droplet_tools.go
@@ -31,6 +31,7 @@ func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest
 	region := args["Region"].(string)
 	backup, _ := args["Backup"].(bool)         // Defaults to false
 	monitoring, _ := args["Monitoring"].(bool) // Defaults to false
+	userData, _ := args["UserData"].(string)
 
 	imageID, hasID := args["ImageID"].(float64)
 	imageSlug, hasSlug := args["ImageSlug"].(string)
@@ -85,6 +86,7 @@ func (d *DropletTool) createDroplet(ctx context.Context, req mcp.CallToolRequest
 		Monitoring: monitoring,
 		SSHKeys:    sshKeys,
 		Tags:       tags,
+		UserData:   userData,
 	}
 
 	client, err := d.client(ctx)
@@ -342,6 +344,7 @@ func (d *DropletTool) Tools() []server.ServerTool {
 				mcp.WithBoolean("Monitoring", mcp.DefaultBool(false), mcp.Description("Whether to enable monitoring")),
 				mcp.WithArray("SSHKeys", mcp.Description("Array of SSH key IDs (numbers) or fingerprints (strings) to add to the droplet"), mcp.Items(map[string]any{"type": "string"})),
 				mcp.WithArray("Tags", mcp.Description("Array of tag names to apply to the droplet"), mcp.Items(map[string]any{"type": "string"})),
+				mcp.WithString("UserData", mcp.Description("Cloud-init user data to provide to the droplet")),
 			),
 		},
 		{

--- a/pkg/registry/droplet/droplet_user_data_test.go
+++ b/pkg/registry/droplet/droplet_user_data_test.go
@@ -1,0 +1,50 @@
+package droplet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDropletTool_createDropletWithUserData(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDroplets := NewMockDropletsService(ctrl)
+	mockActions := NewMockDropletActionsService(ctrl)
+	tool := setupDropletToolWithMocks(mockDroplets, mockActions)
+
+	userData := "#cloud-config\nruncmd:\n  - echo ready\n"
+
+	mockDroplets.EXPECT().
+		Create(gomock.Any(), &godo.DropletCreateRequest{
+			Name:       "cloud-init-droplet",
+			Region:     "nyc3",
+			Size:       "s-1vcpu-1gb",
+			Image:      godo.DropletCreateImage{ID: 456},
+			Backups:    false,
+			Monitoring: false,
+			UserData:   userData,
+		}).
+		Return(&godo.Droplet{ID: 123, Name: "cloud-init-droplet"}, nil, nil).
+		Times(1)
+
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"Name":       "cloud-init-droplet",
+		"Size":       "s-1vcpu-1gb",
+		"ImageID":    float64(456),
+		"Region":     "nyc3",
+		"Backup":     false,
+		"Monitoring": false,
+		"UserData":   userData,
+	}}}
+
+	resp, err := tool.createDroplet(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError)
+}


### PR DESCRIPTION
## Summary

Add optional `UserData` support to the `droplet-create` MCP tool.

DigitalOcean's Droplet API already supports user data through `godo.DropletCreateRequest.UserData`, but the MCP `droplet-create` tool currently does not expose or forward this field.

## Changes

- Add optional `UserData` argument to the `droplet-create` tool schema
- Forward `UserData` to `godo.DropletCreateRequest`
- Add a regression test verifying that user data is passed through unchanged

## Use case

This enables cloud-init and other first-boot configuration when provisioning Droplets through MCP, without requiring additional post-provisioning steps.

## Scope

The change is intentionally minimal and preserves the existing behavior when `UserData` is not provided.