### PR TITLE
Add MicroDroplet lifecycle MCP tools

### DIFF
--- a/pkg/registry/microdroplet/README.md
+++ b/pkg/registry/microdroplet/README.md
@@ -1,0 +1,24 @@
+# MicroDroplet MCP tools
+
+Lifecycle tools for [MicroDroplet](https://docs.digitalocean.com/products/microdroplets/) over `POST/GET/DELETE /v2/microdroplets/*`. REST JSON is passed through; argument names mirror the public API (**snake_case**).
+
+Activate with `--services microdroplets` (or include `microdroplets` in `SERVICES`). Requires a valid `DIGITALOCEAN_API_TOKEN`.
+
+## Tools
+
+| Tool | REST | Notes |
+| --- | --- | --- |
+| `microdroplet-create` | `POST /instances` | Exactly one of `image`, `checkpoint`, `container` |
+| `microdroplet-list` | `GET /instances` | Paginated |
+| `microdroplet-get` | `GET /instances/{id}` | |
+| `microdroplet-delete` | `DELETE /instances/{id}` | Destructive |
+| `microdroplet-pause` | `POST /instances/{id}/pause` | Sync, idempotent |
+| `microdroplet-resume` | `POST /instances/{id}/resume` | Sync, idempotent |
+| `microdroplet-checkpoint-create` | `POST /instances/{id}/checkpoints` | Async; poll get/list |
+| `microdroplet-checkpoint-list` | `GET /checkpoints` | Optional `micro_droplet_id` filter |
+| `microdroplet-checkpoint-get` | `GET /checkpoints/{id}` | |
+| `microdroplet-checkpoint-delete` | `DELETE /checkpoints/{id}` | Destructive |
+
+Out of scope: exec/PTY, Images API.
+
+Schema source (cthulhu): `docode/src/do/services/microdroplet/docs/specs/mcp-tools/tools.json` (MDROP-237).

--- a/pkg/registry/microdroplet/client.go
+++ b/pkg/registry/microdroplet/client.go
@@ -1,0 +1,56 @@
+package microdroplet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/digitalocean/godo"
+)
+
+const apiBasePath = "v2/microdroplets"
+
+type apiClient struct {
+	client *godo.Client
+}
+
+func newAPIClient(client *godo.Client) *apiClient {
+	return &apiClient{client: client}
+}
+
+func (a *apiClient) do(ctx context.Context, method, subPath string, query url.Values, body any) (json.RawMessage, error) {
+	path := apiBasePath + subPath
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	req, err := a.client.NewRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	var out json.RawMessage
+	_, err = a.client.Do(ctx, req, &out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (a *apiClient) doNoContent(ctx context.Context, method, subPath string) error {
+	req, err := a.client.NewRequest(ctx, method, apiBasePath+subPath, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := a.client.Do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+	if resp != nil && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/registry/microdroplet/microdroplet_annotations_test.go
+++ b/pkg/registry/microdroplet/microdroplet_annotations_test.go
@@ -1,0 +1,81 @@
+package microdroplet
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"mcp-digitalocean/pkg/registry/common"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+var expectedAnnotations = map[string]struct {
+	readOnly, destructive, idempotent, openWorld bool
+	operation                                    common.Operation
+	risk                                         common.Risk
+	parallelizable, streamingSafe                bool
+}{
+	"microdroplet-create":             {false, false, false, false, common.OpCreate, common.RiskHigh, false, false},
+	"microdroplet-list":               {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"microdroplet-get":                {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"microdroplet-delete":             {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+	"microdroplet-pause":              {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"microdroplet-resume":             {false, false, true, false, common.OpUpdate, common.RiskMedium, false, false},
+	"microdroplet-checkpoint-create":  {false, false, false, false, common.OpCreate, common.RiskMedium, false, false},
+	"microdroplet-checkpoint-list":    {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"microdroplet-checkpoint-get":     {true, false, true, false, common.OpRead, common.RiskLow, false, false},
+	"microdroplet-checkpoint-delete":  {false, true, true, false, common.OpDelete, common.RiskHigh, false, false},
+}
+
+func TestToolAnnotations(t *testing.T) {
+	client := func(ctx context.Context) (*godo.Client, error) {
+		return godo.NewFromToken("test-token"), nil
+	}
+
+	tools := NewMicroDropletTool(client).Tools()
+	byName := make(map[string]server.ServerTool, len(tools))
+	for _, st := range tools {
+		byName[st.Tool.Name] = st
+	}
+
+	for name, want := range expectedAnnotations {
+		st, ok := byName[name]
+		if !ok {
+			t.Errorf("tool %q missing from Tools()", name)
+			continue
+		}
+
+		a := st.Tool.Annotations
+		if a.ReadOnlyHint == nil || *a.ReadOnlyHint != want.readOnly {
+			t.Errorf("tool %q readOnlyHint = %v, want %v", name, a.ReadOnlyHint, want.readOnly)
+		}
+		if a.DestructiveHint == nil || *a.DestructiveHint != want.destructive {
+			t.Errorf("tool %q destructiveHint = %v, want %v", name, a.DestructiveHint, want.destructive)
+		}
+		if a.IdempotentHint == nil || *a.IdempotentHint != want.idempotent {
+			t.Errorf("tool %q idempotentHint = %v, want %v", name, a.IdempotentHint, want.idempotent)
+		}
+		if a.OpenWorldHint == nil || *a.OpenWorldHint != want.openWorld {
+			t.Errorf("tool %q openWorldHint = %v, want %v", name, a.OpenWorldHint, want.openWorld)
+		}
+
+		reg := st.Tool.Meta.AdditionalFields[common.RegistryMetaKey].(map[string]any)
+		if reg["operation"] != string(want.operation) {
+			t.Errorf("tool %q operation = %v, want %v", name, reg["operation"], want.operation)
+		}
+		if reg["risk"] != string(want.risk) {
+			t.Errorf("tool %q risk = %v, want %v", name, reg["risk"], want.risk)
+		}
+
+		wantPerm := "tools.digitalocean." + strings.ReplaceAll(name, "-", "_")
+		if reg["permission"] != wantPerm {
+			t.Errorf("tool %q permission = %v, want %v", name, reg["permission"], wantPerm)
+		}
+	}
+
+	if len(byName) != len(expectedAnnotations) {
+		t.Errorf("registered %d tools, expected %d — update expectedAnnotations when adding tools", len(byName), len(expectedAnnotations))
+	}
+}

--- a/pkg/registry/microdroplet/microdroplet_tools.go
+++ b/pkg/registry/microdroplet/microdroplet_tools.go
@@ -1,0 +1,517 @@
+package microdroplet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"mcp-digitalocean/pkg/registry/common"
+)
+
+// MicroDropletTool exposes MicroDroplet lifecycle tools over the public REST API.
+type MicroDropletTool struct {
+	client func(ctx context.Context) (*godo.Client, error)
+}
+
+// NewMicroDropletTool creates a MicroDropletTool backed by the shared godo client.
+func NewMicroDropletTool(client func(ctx context.Context) (*godo.Client, error)) *MicroDropletTool {
+	return &MicroDropletTool{client: client}
+}
+
+func (t *MicroDropletTool) api(ctx context.Context) (*apiClient, error) {
+	c, err := t.client(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get DigitalOcean client: %w", err)
+	}
+	return newAPIClient(c), nil
+}
+
+func (t *MicroDropletTool) create(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+
+	name, _ := args["name"].(string)
+	region, _ := args["region"].(string)
+	size, _ := args["size"].(string)
+	if strings.TrimSpace(name) == "" {
+		return mcp.NewToolResultError("name is required"), nil
+	}
+	if strings.TrimSpace(region) == "" {
+		return mcp.NewToolResultError("region is required"), nil
+	}
+	if strings.TrimSpace(size) == "" {
+		return mcp.NewToolResultError("size is required"), nil
+	}
+
+	body, err := buildCreateBody(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodPost, "/instances", nil, body)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet create", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) list(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	query := url.Values{}
+	query.Set("page", fmt.Sprintf("%d", intFromArg(args["page"], 1)))
+	query.Set("per_page", fmt.Sprintf("%d", intFromArg(args["per_page"], 25)))
+	if v, _ := args["region"].(string); v != "" {
+		query.Set("region", v)
+	}
+	if v, _ := args["name"].(string); v != "" {
+		query.Set("name", v)
+	}
+	if v, _ := args["tag_name"].(string); v != "" {
+		query.Set("tag_name", v)
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodGet, "/instances", query, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet list", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) get(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodGet, "/instances/"+id, nil, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet get", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) delete(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := api.doNoContent(ctx, http.MethodDelete, "/instances/"+id); err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet delete", err), nil
+	}
+	return mcp.NewToolResultText("MicroDroplet deleted successfully"), nil
+}
+
+func (t *MicroDropletTool) pause(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodPost, "/instances/"+id+"/pause", nil, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet pause", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) resume(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodPost, "/instances/"+id+"/resume", nil, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("microdroplet resume", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) checkpointCreate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	id, errMsg := requiredUUID(args, "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	var body any
+	if name, ok := args["name"].(string); ok && strings.TrimSpace(name) != "" {
+		body = map[string]string{"name": name}
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodPost, "/instances/"+id+"/checkpoints", nil, body)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("checkpoint create", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) checkpointList(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	query := url.Values{}
+	query.Set("page", fmt.Sprintf("%d", intFromArg(args["page"], 1)))
+	query.Set("per_page", fmt.Sprintf("%d", intFromArg(args["per_page"], 25)))
+	if v, _ := args["micro_droplet_id"].(string); v != "" {
+		query.Set("micro_droplet_id", v)
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodGet, "/checkpoints", query, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("checkpoint list", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) checkpointGet(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := api.do(ctx, http.MethodGet, "/checkpoints/"+id, nil, nil)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("checkpoint get", err), nil
+	}
+	return toolResultJSON(out)
+}
+
+func (t *MicroDropletTool) checkpointDelete(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	id, errMsg := requiredUUID(req.GetArguments(), "id")
+	if errMsg != "" {
+		return mcp.NewToolResultError(errMsg), nil
+	}
+
+	api, err := t.api(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := api.doNoContent(ctx, http.MethodDelete, "/checkpoints/"+id); err != nil {
+		return mcp.NewToolResultErrorFromErr("checkpoint delete", err), nil
+	}
+	return mcp.NewToolResultText("Checkpoint deleted successfully"), nil
+}
+
+func buildCreateBody(args map[string]any) (map[string]any, error) {
+	image, hasImage := args["image"].(string)
+	checkpoint, hasCheckpoint := args["checkpoint"].(string)
+	container, hasContainer, err := parseContainer(args["container"])
+	if err != nil {
+		return nil, err
+	}
+
+	hasImage = hasImage && strings.TrimSpace(image) != ""
+	hasCheckpoint = hasCheckpoint && strings.TrimSpace(checkpoint) != ""
+
+	switch {
+	case !hasImage && !hasCheckpoint && !hasContainer:
+		return nil, fmt.Errorf("exactly one of image, checkpoint, or container must be provided")
+	case hasImage && hasCheckpoint, hasImage && hasContainer, hasCheckpoint && hasContainer:
+		return nil, fmt.Errorf("exactly one of image, checkpoint, or container must be provided, not more than one")
+	}
+
+	body := map[string]any{
+		"name":   args["name"],
+		"region": args["region"],
+		"size":   args["size"],
+	}
+
+	if hasImage {
+		body["image"] = image
+	}
+	if hasCheckpoint {
+		body["checkpoint"] = checkpoint
+	}
+	if hasContainer {
+		body["container"] = container
+	}
+
+	copyOptionalString(body, args, "networking")
+	copyOptionalString(body, args, "vpc_uuid")
+	copyOptionalBool(body, args, "auto_resume")
+	copyOptionalNumber(body, args, "http_port")
+	copyOptionalString(body, args, "http_protocol")
+
+	if v, ok := args["auto_pause"]; ok && v != nil {
+		body["auto_pause"] = v
+	}
+	if v, ok := args["environment"]; ok && v != nil {
+		body["environment"] = v
+	}
+	if tags := stringSliceArg(args["tags"]); len(tags) > 0 {
+		body["tags"] = tags
+	}
+
+	return body, nil
+}
+
+func copyOptionalString(body, args map[string]any, key string) {
+	if v, ok := args[key].(string); ok && v != "" {
+		body[key] = v
+	}
+}
+
+func copyOptionalBool(body, args map[string]any, key string) {
+	if v, ok := args[key].(bool); ok {
+		body[key] = v
+	}
+}
+
+func copyOptionalNumber(body, args map[string]any, key string) {
+	if v, ok := args[key].(float64); ok {
+		body[key] = int(v)
+	}
+}
+
+// parseContainer treats nil, {}, and missing/blank image as omitted so create
+// fails with the same "exactly one of ..." message as a missing boot source.
+func parseContainer(raw any) (map[string]any, bool, error) {
+	if raw == nil {
+		return nil, false, nil
+	}
+	container, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false, fmt.Errorf("container must be an object with an image field")
+	}
+	image, _ := container["image"].(string)
+	if strings.TrimSpace(image) == "" {
+		return nil, false, nil
+	}
+	return container, true, nil
+}
+
+func requiredUUID(args map[string]any, key string) (string, string) {
+	id, _ := args[key].(string)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", key + " is required"
+	}
+	return id, ""
+}
+
+func toolResultJSON(raw json.RawMessage) (*mcp.CallToolResult, error) {
+	if len(raw) == 0 {
+		return mcp.NewToolResultText("{}"), nil
+	}
+	var pretty json.RawMessage
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return mcp.NewToolResultText(string(raw)), nil
+	}
+	b, err := json.MarshalIndent(pretty, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal response: %w", err)
+	}
+	return mcp.NewToolResultText(string(b)), nil
+}
+
+func intFromArg(v any, def int) int {
+	switch x := v.(type) {
+	case nil:
+		return def
+	case float64:
+		if x >= 1 {
+			return int(x)
+		}
+		return def
+	case int:
+		if x >= 1 {
+			return x
+		}
+		return def
+	default:
+		return def
+	}
+}
+
+func stringSliceArg(v any) []string {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		return x
+	case []any:
+		var out []string
+		for _, el := range x {
+			if s, ok := el.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// Tools registers MCP tools for MicroDroplet lifecycle management.
+func (t *MicroDropletTool) Tools() []server.ServerTool {
+	return []server.ServerTool{
+		{
+			Handler: t.create,
+			Tool: mcp.NewTool("microdroplet-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskHigh),
+				mcp.WithDescription("Create a MicroDroplet. Provide exactly one of image, checkpoint, or container as the boot source."),
+				mcp.WithString("name", mcp.Required(), mcp.Description("Human-readable name.")),
+				mcp.WithString("region", mcp.Required(), mcp.Description("Region slug (e.g. nyc1).")),
+				mcp.WithString("size", mcp.Required(), mcp.Description("Size slug (e.g. mv-2vcpu-4gb).")),
+				mcp.WithString("image", mcp.Description("Imported image UUID or do:microdroplet_image URN. Mutually exclusive with checkpoint and container.")),
+				mcp.WithString("checkpoint", mcp.Description("Checkpoint UUID to restore from. Mutually exclusive with image and container.")),
+				mcp.WithObject("container", mcp.Description("Golden-mode OCI workload ref."),
+					mcp.Properties(map[string]any{
+						"image": map[string]any{
+							"type":        "string",
+							"description": "OCI reference (public Hub or team DOCR).",
+						},
+					})),
+				mcp.WithString("networking", mcp.Enum("public", "vpc"), mcp.Description("Network posture: public or vpc.")),
+				mcp.WithString("vpc_uuid", mcp.Description("Required when networking is vpc.")),
+				mcp.WithObject("auto_pause", mcp.Description("Auto-pause config: enabled (bool), idle_timeout (duration string).")),
+				mcp.WithBoolean("auto_resume", mcp.Description("Whether to auto-resume on HTTP traffic (default true).")),
+				mcp.WithNumber("http_port", mcp.Description("HTTP listen port for ingress and auto-resume probing.")),
+				mcp.WithString("http_protocol", mcp.Enum("http", "http2"), mcp.Description("Application protocol on http_port: http or http2.")),
+				mcp.WithObject("environment", mcp.Description("Key-value environment variables injected at boot.")),
+				mcp.WithArray("tags", mcp.Description("Resource tags."), mcp.Items(map[string]any{"type": "string"})),
+			),
+		},
+		{
+			Handler: t.list,
+			Tool: mcp.NewTool("microdroplet-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
+				mcp.WithDescription("List MicroDroplets for the authenticated team."),
+				mcp.WithNumber("page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1).")),
+				mcp.WithNumber("per_page", mcp.DefaultNumber(25), mcp.Description("Items per page (default 25, max 200).")),
+				mcp.WithString("region", mcp.Description("Filter by region slug.")),
+				mcp.WithString("name", mcp.Description("Filter by name.")),
+				mcp.WithString("tag_name", mcp.Description("Filter by resource tag name.")),
+			),
+		},
+		{
+			Handler: t.get,
+			Tool: mcp.NewTool("microdroplet-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
+				mcp.WithDescription("Get a MicroDroplet by ID."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("MicroDroplet UUID.")),
+			),
+		},
+		{
+			Handler: t.delete,
+			Tool: mcp.NewTool("microdroplet-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
+				mcp.WithDescription("Delete a MicroDroplet. Irreversible; checkpoints are retained until deleted separately."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("MicroDroplet UUID.")),
+			),
+		},
+		{
+			Handler: t.pause,
+			Tool: mcp.NewTool("microdroplet-pause",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
+				mcp.WithDescription("Pause a running MicroDroplet (synchronous, idempotent)."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("MicroDroplet UUID.")),
+			),
+		},
+		{
+			Handler: t.resume,
+			Tool: mcp.NewTool("microdroplet-resume",
+				common.WithHints(common.HintsToggle),
+				common.WithRisk(common.RiskMedium),
+				mcp.WithDescription("Resume a paused MicroDroplet (synchronous, idempotent)."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("MicroDroplet UUID.")),
+			),
+		},
+		{
+			Handler: t.checkpointCreate,
+			Tool: mcp.NewTool("microdroplet-checkpoint-create",
+				common.WithHints(common.HintsCreate),
+				common.WithRisk(common.RiskMedium),
+				mcp.WithDescription("Start async checkpoint of a running MicroDroplet without pausing. Poll checkpoint-get until available or failed."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("MicroDroplet UUID.")),
+				mcp.WithString("name", mcp.Description("Optional checkpoint name.")),
+			),
+		},
+		{
+			Handler: t.checkpointList,
+			Tool: mcp.NewTool("microdroplet-checkpoint-list",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
+				mcp.WithDescription("List team checkpoints, newest first."),
+				mcp.WithNumber("page", mcp.DefaultNumber(1), mcp.Description("Page number (default 1).")),
+				mcp.WithNumber("per_page", mcp.DefaultNumber(25), mcp.Description("Items per page (default 25, max 200).")),
+				mcp.WithString("micro_droplet_id", mcp.Description("Filter by source MicroDroplet UUID.")),
+			),
+		},
+		{
+			Handler: t.checkpointGet,
+			Tool: mcp.NewTool("microdroplet-checkpoint-get",
+				common.WithHints(common.HintsRead),
+				common.WithRisk(common.RiskLow),
+				mcp.WithDescription("Get a checkpoint by ID."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("Checkpoint UUID.")),
+			),
+		},
+		{
+			Handler: t.checkpointDelete,
+			Tool: mcp.NewTool("microdroplet-checkpoint-delete",
+				common.WithHints(common.HintsDelete),
+				common.WithRisk(common.RiskHigh),
+				mcp.WithDescription("Delete a checkpoint. Irreversible."),
+				mcp.WithString("id", mcp.Required(), mcp.Description("Checkpoint UUID.")),
+			),
+		},
+	}
+}

--- a/pkg/registry/microdroplet/microdroplet_tools_test.go
+++ b/pkg/registry/microdroplet/microdroplet_tools_test.go
@@ -1,0 +1,274 @@
+package microdroplet
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func testGodoClient(t *testing.T, h http.Handler) *godo.Client {
+	t.Helper()
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	c, err := godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL+"/"))
+	require.NoError(t, err)
+	return c
+}
+
+func testTool(t *testing.T, c *godo.Client) *MicroDropletTool {
+	t.Helper()
+	return NewMicroDropletTool(func(ctx context.Context) (*godo.Client, error) { return c, nil })
+}
+
+func TestMicroDropletTool_create(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"micro_droplet":{"id":"9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f","name":"agent-sandbox-1","state":"creating"}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name":   "agent-sandbox-1",
+		"region": "nyc1",
+		"size":   "mv-2vcpu-4gb",
+		"image":  "do:microdroplet_image:9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+		"tags":   []any{"prod"},
+	}}}
+
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.IsError)
+
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "/v2/microdroplets/instances", gotPath)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &decoded))
+	require.Equal(t, "agent-sandbox-1", decoded["name"])
+	require.Equal(t, "nyc1", decoded["region"])
+	require.Equal(t, "mv-2vcpu-4gb", decoded["size"])
+	require.Equal(t, "do:microdroplet_image:9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f", decoded["image"])
+
+	text := resp.Content[0].(mcp.TextContent).Text
+	require.Contains(t, text, "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f")
+}
+
+func TestMicroDropletTool_create_validation(t *testing.T) {
+	tool := testTool(t, testGodoClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called")
+	})))
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "missing boot source",
+			args: map[string]any{"name": "n", "region": "nyc1", "size": "mv-2vcpu-4gb"},
+			want: "exactly one of image, checkpoint, or container",
+		},
+		{
+			name: "multiple boot sources",
+			args: map[string]any{
+				"name": "n", "region": "nyc1", "size": "mv-2vcpu-4gb",
+				"image": "img", "checkpoint": "chk",
+			},
+			want: "not more than one",
+		},
+		{
+			name: "empty container",
+			args: map[string]any{
+				"name": "n", "region": "nyc1", "size": "mv-2vcpu-4gb",
+				"container": map[string]any{},
+			},
+			want: "exactly one of image, checkpoint, or container",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: tc.args}}
+			resp, err := tool.create(context.Background(), req)
+			require.NoError(t, err)
+			require.True(t, resp.IsError)
+			require.Contains(t, resp.Content[0].(mcp.TextContent).Text, tc.want)
+		})
+	}
+}
+
+func TestMicroDropletTool_create_container(t *testing.T) {
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v2/microdroplets/instances", r.URL.Path)
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"micro_droplet":{"id":"9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f","state":"creating"}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"name":      "agent-sandbox-1",
+		"region":    "nyc1",
+		"size":      "mv-2vcpu-4gb",
+		"container": map[string]any{"image": "docker.io/library/nginx:1.27"},
+	}}}
+
+	resp, err := tool.create(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &decoded))
+	container, ok := decoded["container"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "docker.io/library/nginx:1.27", container["image"])
+	_, hasImage := decoded["image"]
+	require.False(t, hasImage)
+}
+
+func TestMicroDropletTool_get_notFound(t *testing.T) {
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"id":"not_found","message":"The resource you requested could not be found."}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"id": "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+	}}}
+
+	resp, err := tool.get(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+}
+
+func TestMicroDropletTool_list(t *testing.T) {
+	var gotQuery string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v2/microdroplets/instances", r.URL.Path)
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"micro_droplets":[],"links":{},"meta":{"total":0}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"page":     float64(2),
+		"per_page": float64(50),
+		"region":   "nyc1",
+	}}}
+
+	resp, err := tool.list(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Contains(t, gotQuery, "page=2")
+	require.Contains(t, gotQuery, "per_page=50")
+	require.Contains(t, gotQuery, "region=nyc1")
+}
+
+func TestMicroDropletTool_delete(t *testing.T) {
+	var gotPath string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	id := "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{"id": id}}}
+
+	resp, err := tool.delete(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, "/v2/microdroplets/instances/"+id, gotPath)
+	require.Contains(t, resp.Content[0].(mcp.TextContent).Text, "deleted successfully")
+}
+
+func TestMicroDropletTool_checkpointCreate(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		gotPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		_, _ = w.Write([]byte(`{"checkpoint":{"id":"0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d","status":"CHECKPOINT_CREATING"}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	mdID := "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"id":   mdID,
+		"name": "chk-1",
+	}}}
+
+	resp, err := tool.checkpointCreate(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, "/v2/microdroplets/instances/"+mdID+"/checkpoints", gotPath)
+	require.Equal(t, "chk-1", gotBody["name"])
+}
+
+func TestMicroDropletTool_checkpointCreate_omittedName(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		gotPath = r.URL.Path
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"checkpoint":{"id":"0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d","status":"CHECKPOINT_CREATING"}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	mdID := "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"id": mdID,
+	}}}
+
+	resp, err := tool.checkpointCreate(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Equal(t, "/v2/microdroplets/instances/"+mdID+"/checkpoints", gotPath)
+	require.Empty(t, gotBody)
+}
+
+func TestMicroDropletTool_checkpointList_filter(t *testing.T) {
+	var gotQuery string
+	srv := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"checkpoints":[],"links":{},"meta":{"total":0}}`))
+	})
+
+	tool := testTool(t, testGodoClient(t, srv))
+	mdID := "9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"micro_droplet_id": mdID,
+	}}}
+
+	resp, err := tool.checkpointList(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.Contains(t, gotQuery, "micro_droplet_id="+mdID)
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -23,6 +23,7 @@ import (
 	inferencemodelcatalog "mcp-digitalocean/pkg/registry/inference-modelcatalog"
 	"mcp-digitalocean/pkg/registry/insights"
 	"mcp-digitalocean/pkg/registry/marketplace"
+	"mcp-digitalocean/pkg/registry/microdroplet"
 	"mcp-digitalocean/pkg/registry/networking"
 	"mcp-digitalocean/pkg/registry/nfs"
 	"mcp-digitalocean/pkg/registry/spaces"
@@ -58,6 +59,7 @@ var supportedServices = map[string]struct{}{
 	"functions":              {},
 	"nfs":                    {},
 	"vector-databases":       {},
+	"microdroplets":          {},
 }
 
 // registerAppTools registers the app platform tools with the MCP server.
@@ -242,6 +244,11 @@ func registerVectorDBTools(s *server.MCPServer, getClient getClientFn) error {
 	return nil
 }
 
+func registerMicroDropletTools(s *server.MCPServer, getClient getClientFn) error {
+	s.AddTools(microdroplet.NewMicroDropletTool(getClient).Tools()...)
+	return nil
+}
+
 // Register registers the set of tools for the specified services with the MCP server.
 // We either register a subset of tools of the services are specified, or we register all tools if no services are specified.
 func Register(logger *slog.Logger, s *server.MCPServer, getClient getClientFn, servicesToActivate ...string) error {
@@ -338,6 +345,10 @@ func Register(logger *slog.Logger, s *server.MCPServer, getClient getClientFn, s
 		case "vector-databases":
 			if err := registerVectorDBTools(s, getClient); err != nil {
 				return fmt.Errorf("failed to register vector-databases tools: %w", err)
+			}
+		case "microdroplets":
+			if err := registerMicroDropletTools(s, getClient); err != nil {
+				return fmt.Errorf("failed to register microdroplets tools: %w", err)
 			}
 		default:
 			return fmt.Errorf("unsupported service: %s, supported service are: %v", svc, setToString(supportedServices))


### PR DESCRIPTION
Jira: https://do-internal.atlassian.net/browse/MDROP-238

## Summary
- Add `microdroplets` service with 10 lifecycle tools over `/v2/microdroplets/*`
- Thin REST JSON pass-through via the shared godo client (kebab-case tool names, snake_case args matching the public API)
- Unit + annotation tests; registers under `--services microdroplets`

Covers MDROP-238 (tools), MDROP-239 (Bearer via existing godo client), and MDROP-240 (REST wire-up).

## Test plan
- [x] `go test ./pkg/registry/microdroplet/...`
- [x] Registry annotation guard (`TestEveryRegisteredToolAnnotated`)
- [ ] Manual: `--services microdroplets` with a DO API token against stage2/prod when available


Made with [Cursor](https://cursor.com)