### PR TITLE
bumped to 1.0.69

### DIFF
--- a/cmd/mcp-digitalocean/main.go
+++ b/cmd/mcp-digitalocean/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	mcpName                 = "mcp-digitalocean"
-	mcpVersion              = "1.0.68"
+	mcpVersion              = "1.0.69"
 	wsLoggingContextTimeout = 15 * time.Second
 	// mcpEndpointPath is the path the streamable HTTP server serves the MCP
 	// protocol on. It matches mcp-go's default so existing clients are unaffected.

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalocean/mcp",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "DigitalOcean MCP Implementation,",
   "author": "DigitalOcean",
   "homepage": "https://github.com/digitalocean-labs/mcp-digitalocean?tab=readme-ov-file#mcp-digitalocean-integration",


### PR DESCRIPTION
Bump MCP version to 1.0.69 for the genai-evaluation simulation tools release.